### PR TITLE
Tix#1

### DIFF
--- a/client/src/components/AvatarCreator.tsx
+++ b/client/src/components/AvatarCreator.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/lib/avatarData";
 
 interface Props {
-  onSave: (config: AvatarConfig, displayName: string) => void;
+  onSave: (config: AvatarConfig, displayName: string, username?: string) => void;
   initialConfig?: AvatarConfig;
   initialDisplayName?: string;
   /** When provided, shows a back button (edit mode, not first setup) */
@@ -102,6 +102,8 @@ export default function AvatarCreator({
     initialConfig ?? DEFAULT_AVATAR,
   );
   const [displayName, setDisplayName] = useState(initialDisplayName ?? "");
+  const [username, setUsername] = useState("");
+  const [usernameError, setUsernameError] = useState("");
 
   const set = <K extends keyof AvatarConfig>(key: K, value: AvatarConfig[K]) =>
     setConfig((prev) => ({ ...prev, [key]: value }));
@@ -141,20 +143,50 @@ export default function AvatarCreator({
           </div>
         </div>
 
-        {/* ── Display Name ── */}
+        {/* ── Display Name & Username ── */}
         {!isEditing && (
-          <div className="mb-4">
-            <p className="text-gray-400 text-xs font-bold font-mono mb-2">
-              YOUR NAME
-            </p>
-            <input
-              className="w-full px-3 py-2 bg-gray-900/60 border border-gray-600 rounded-lg text-white text-sm font-mono placeholder-gray-600 focus:outline-none focus:border-emerald-500 transition-colors"
-              placeholder="e.g. Jorge"
-              value={displayName}
-              onChange={(e) => setDisplayName(e.target.value)}
-              maxLength={24}
-            />
-          </div>
+          <>
+            <div className="mb-4">
+              <p className="text-gray-400 text-xs font-bold font-mono mb-2">
+                YOUR NAME
+              </p>
+              <input
+                className="w-full px-3 py-2 bg-gray-900/60 border border-gray-600 rounded-lg text-white text-sm font-mono placeholder-gray-600 focus:outline-none focus:border-emerald-500 transition-colors"
+                placeholder="e.g. Jorge"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                maxLength={24}
+              />
+            </div>
+            <div className="mb-4">
+              <p className="text-gray-400 text-xs font-bold font-mono mb-2">
+                USERNAME
+              </p>
+              <input
+                className={`w-full px-3 py-2 bg-gray-900/60 border rounded-lg text-white text-sm font-mono placeholder-gray-600 focus:outline-none transition-colors ${
+                  usernameError ? "border-red-500 focus:border-red-400" : "border-gray-600 focus:border-emerald-500"
+                }`}
+                placeholder="e.g. jorji"
+                value={username}
+                onChange={(e) => {
+                  const val = e.target.value.toLowerCase().replace(/[^a-z0-9_]/g, "");
+                  setUsername(val);
+                  if (val && (val.length < 3 || val.length > 20)) {
+                    setUsernameError("Must be 3-20 characters");
+                  } else {
+                    setUsernameError("");
+                  }
+                }}
+                maxLength={20}
+              />
+              <p className="text-gray-600 text-[10px] font-mono mt-1">
+                Lowercase letters, numbers, underscores. A #tag will be added automatically.
+              </p>
+              {usernameError && (
+                <p className="text-red-400 text-xs font-mono mt-1">{usernameError}</p>
+              )}
+            </div>
+          </>
         )}
 
         {/* ── Controls ── */}
@@ -210,7 +242,7 @@ export default function AvatarCreator({
         </div>
 
         <button
-          onClick={() => onSave(config, displayName.trim())}
+          onClick={() => onSave(config, displayName.trim(), !isEditing && username ? username : undefined)}
           className="w-full bg-emerald-500 hover:bg-emerald-400 active:scale-95 text-white font-bold py-3 px-4 rounded-xl border-b-4 border-emerald-700 transition-all font-mono tracking-widest"
         >
           {isEditing ? "SAVE CHANGES →" : "READY TO FOCUS →"}

--- a/client/src/components/DuoTimer.tsx
+++ b/client/src/components/DuoTimer.tsx
@@ -13,6 +13,7 @@ import HomeDashboard from "./HomeDashboard";
 import InvitePopup from "./InvitePopup";
 import SessionTopBar from "./SessionTopBar";
 import SessionHUD from "./SessionHUD";
+import UsernameChangeModal from "./UsernameChangeModal";
 import { useAuth } from "@/hooks/useAuth";
 import { useGameSession } from "@/hooks/useGameSession";
 
@@ -27,6 +28,7 @@ export default function DuoTimer() {
   const [profileMenuOpen, setProfileMenuOpen] = useState(false);
   const [statsOpen, setStatsOpen] = useState(false);
   const [fullStatsOpen, setFullStatsOpen] = useState(false);
+  const [usernameModalOpen, setUsernameModalOpen] = useState(false);
 
   const { appStep, setAppStep, profile, myAvatar, isPremium, displayName, sb } =
     auth;
@@ -146,6 +148,7 @@ export default function DuoTimer() {
           onJoinSession={handleJoinSession}
           onInvite={handleSendInvite}
           onEditAvatar={() => setAppStep("avatar")}
+          onChangeUsername={() => setUsernameModalOpen(true)}
           onSignOut={async () => {
             const { signOut } = await import("@/lib/supabase");
             await signOut();
@@ -211,6 +214,24 @@ export default function DuoTimer() {
             />
           </>
         )}
+        <UsernameChangeModal
+          open={usernameModalOpen}
+          currentUsername={profile?.username ?? ""}
+          onClose={() => setUsernameModalOpen(false)}
+          onSubmit={async (newUsername) => {
+            const { data, error } = await sb.rpc("claim_username", {
+              desired_username: newUsername,
+            });
+            if (error) throw error;
+            const tag = data as { username: string; discriminator: string };
+            auth.updateProfile({
+              username: tag.username,
+              discriminator: tag.discriminator,
+              username_changed: true,
+            });
+            setUsernameModalOpen(false);
+          }}
+        />
       </>
     );
   }

--- a/client/src/components/DuoTimer.tsx
+++ b/client/src/components/DuoTimer.tsx
@@ -97,7 +97,24 @@ export default function DuoTimer() {
           initialConfig={myAvatar}
           initialDisplayName={profile?.display_name ?? ""}
           onBack={isEditing ? () => setAppStep("home") : undefined}
-          onSave={async (config, name) => {
+          onSave={async (config, name, username) => {
+            // Claim username (first setup only)
+            if (username && profile) {
+              try {
+                const { data, error } = await sb.rpc("claim_username", {
+                  desired_username: username,
+                });
+                if (error) throw error;
+                const tag = data as { username: string; discriminator: string };
+                auth.updateProfile({
+                  username: tag.username,
+                  discriminator: tag.discriminator,
+                });
+              } catch (err: any) {
+                alert(err?.message ?? "Failed to claim username");
+                return;
+              }
+            }
             await auth.saveAvatar(config);
             if (name && profile) {
               await sb
@@ -226,6 +243,7 @@ export default function DuoTimer() {
           phase={game.phase}
           displayName={displayName}
           username={profile?.username}
+          discriminator={profile?.discriminator}
           initial={initial}
           isPremium={isPremium}
           friendsOpen={friendsOpen}

--- a/client/src/components/FriendsPanel.tsx
+++ b/client/src/components/FriendsPanel.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { WORLDS } from "@/lib/avatarData";
 import type { Profile } from "@/lib/types";
+import { formatTag } from "@/lib/format";
 import { useFriendsList } from "@/hooks/useFriendsList";
 import { useFriendSearch } from "@/hooks/useFriendSearch";
 
@@ -56,7 +57,7 @@ function FriendRow({
           </p>
         ) : (
           <p className="text-xs text-gray-500 font-mono truncate">
-            @{friend.username}
+            @{friend.discriminator ? formatTag(friend.username, friend.discriminator) : friend.username}
           </p>
         )}
       </div>
@@ -235,7 +236,7 @@ export default function FriendsPanel({
                     <div className="flex gap-2 mb-3">
                       <input
                         className="flex-1 bg-gray-800 border border-gray-600 rounded-xl px-3 py-2 text-white text-sm font-mono placeholder-gray-600 focus:outline-none focus:border-emerald-500"
-                        placeholder="Search by username..."
+                        placeholder="Search name or tag#0000"
                         value={searchQuery}
                         onChange={(e) => setSearchQuery(e.target.value)}
                         onKeyDown={(e) => e.key === "Enter" && handleSearch()}
@@ -262,7 +263,7 @@ export default function FriendsPanel({
                                 {user.display_name ?? user.username}
                               </p>
                               <p className="text-xs text-gray-500 font-mono">
-                                @{user.username}
+                                @{user.discriminator ? formatTag(user.username, user.discriminator) : user.username}
                               </p>
                             </div>
                             {alreadyFriend ? (
@@ -300,9 +301,18 @@ export default function FriendsPanel({
                   <p className="text-sm font-bold text-white truncate">
                     {myProfile.display_name ?? myProfile.username}
                   </p>
-                  <p className="text-xs text-gray-500 font-mono">
-                    @{myProfile.username}
-                  </p>
+                  <button
+                    onClick={() => {
+                      const tag = myProfile.discriminator
+                        ? formatTag(myProfile.username, myProfile.discriminator)
+                        : myProfile.username;
+                      navigator.clipboard.writeText(tag);
+                    }}
+                    className="text-xs text-gray-500 font-mono hover:text-emerald-400 transition-colors"
+                    title="Copy tag to clipboard"
+                  >
+                    @{myProfile.discriminator ? formatTag(myProfile.username, myProfile.discriminator) : myProfile.username}
+                  </button>
                 </div>
                 {myProfile.is_premium && (
                   <span className="text-xs font-mono text-yellow-400 bg-yellow-400/10 px-2 py-0.5 rounded-full">

--- a/client/src/components/HomeDashboard.tsx
+++ b/client/src/components/HomeDashboard.tsx
@@ -19,6 +19,7 @@ interface Props {
   onJoinSession: (sessionId: string) => void;
   onInvite: (friendId: string) => void;
   onEditAvatar: () => void;
+  onChangeUsername: () => void;
   onSignOut: () => void;
   onOpenFriends: () => void;
   onOpenStats: () => void;
@@ -58,6 +59,7 @@ export default function HomeDashboard({
   onJoinSession,
   onInvite,
   onEditAvatar,
+  onChangeUsername,
   onSignOut,
   onOpenFriends,
   onOpenStats,
@@ -174,6 +176,17 @@ export default function HomeDashboard({
                 >
                   {"✏️"} Edit character
                 </button>
+                {!profile.username_changed && (
+                  <button
+                    onClick={() => {
+                      onChangeUsername();
+                      setProfileMenuOpen(false);
+                    }}
+                    className="w-full text-left text-xs font-mono text-emerald-400 hover:text-emerald-300 py-1.5 transition-colors"
+                  >
+                    {"✏️"} Change username (1x)
+                  </button>
+                )}
                 {!isPremium && (
                   <button
                     onClick={() => setProfileMenuOpen(false)}

--- a/client/src/components/HomeDashboard.tsx
+++ b/client/src/components/HomeDashboard.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { useStats } from "@/lib/useStats";
 import { WORLDS, type WorldId } from "@/lib/avatarData";
-import { formatDuration } from "@/lib/format";
+import { formatDuration, formatTag } from "@/lib/format";
 import { useTasks } from "@/hooks/useTasks";
 import { useOnlineFriends } from "@/hooks/useOnlineFriends";
 import TaskSection from "./TaskSection";
@@ -163,7 +163,7 @@ export default function HomeDashboard({
                   {displayName}
                 </p>
                 <p className="text-gray-500 text-xs font-mono mb-3">
-                  @{profile.username}
+                  @{profile.discriminator ? formatTag(profile.username, profile.discriminator) : profile.username}
                 </p>
                 <button
                   onClick={() => {

--- a/client/src/components/SessionTopBar.tsx
+++ b/client/src/components/SessionTopBar.tsx
@@ -25,6 +25,7 @@ interface SessionTopBarProps {
   phase: GamePhase;
   displayName: string;
   username?: string;
+  discriminator?: string;
   initial: string;
   isPremium: boolean;
   friendsOpen: boolean;
@@ -45,6 +46,7 @@ export default function SessionTopBar({
   phase,
   displayName,
   username,
+  discriminator,
   initial,
   isPremium,
   friendsOpen,
@@ -141,7 +143,7 @@ export default function SessionTopBar({
                 {displayName}
               </p>
               <p className="text-gray-500 text-xs font-mono mb-3">
-                @{username}
+                @{username}{discriminator ? `#${discriminator}` : ""}
               </p>
               <button
                 onClick={onEditAvatar}

--- a/client/src/components/UsernameChangeModal.tsx
+++ b/client/src/components/UsernameChangeModal.tsx
@@ -1,0 +1,101 @@
+"use client";
+import { useState } from "react";
+import { motion } from "framer-motion";
+
+interface Props {
+  open: boolean;
+  currentUsername: string;
+  onSubmit: (username: string) => Promise<void>;
+  onClose: () => void;
+}
+
+export default function UsernameChangeModal({
+  open,
+  currentUsername,
+  onSubmit,
+  onClose,
+}: Props) {
+  const [value, setValue] = useState("");
+  const [error, setError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  if (!open) return null;
+
+  const handleSubmit = async () => {
+    if (!value || value.length < 3 || value.length > 20) {
+      setError("Must be 3-20 characters");
+      return;
+    }
+    if (!/^[a-z0-9_]+$/.test(value)) {
+      setError("Only lowercase letters, numbers, underscores");
+      return;
+    }
+    setSubmitting(true);
+    setError("");
+    try {
+      await onSubmit(value);
+    } catch (err: any) {
+      setError(err?.message ?? "Failed to change username");
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-50 bg-black/50"
+        onClick={onClose}
+      />
+      <motion.div
+        initial={{ opacity: 0, scale: 0.95 }}
+        animate={{ opacity: 1, scale: 1 }}
+        className="fixed z-50 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-gray-800 border border-gray-700 rounded-2xl p-6 shadow-2xl w-80"
+      >
+        <h3 className="text-white font-bold font-mono tracking-widest text-sm mb-1">
+          CHANGE USERNAME
+        </h3>
+        <p className="text-gray-500 text-xs font-mono mb-4">
+          Current: @{currentUsername} — you can only do this once!
+        </p>
+        <input
+          className={`w-full px-3 py-2 bg-gray-900/60 border rounded-lg text-white text-sm font-mono placeholder-gray-600 focus:outline-none transition-colors mb-1 ${
+            error
+              ? "border-red-500 focus:border-red-400"
+              : "border-gray-600 focus:border-emerald-500"
+          }`}
+          placeholder="new_username"
+          value={value}
+          onChange={(e) => {
+            const val = e.target.value.toLowerCase().replace(/[^a-z0-9_]/g, "");
+            setValue(val);
+            setError("");
+          }}
+          maxLength={20}
+          onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
+          autoFocus
+        />
+        <p className="text-gray-600 text-[10px] font-mono mb-3">
+          A new #tag will be generated automatically.
+        </p>
+        {error && (
+          <p className="text-red-400 text-xs font-mono mb-3">{error}</p>
+        )}
+        <div className="flex gap-2">
+          <button
+            onClick={onClose}
+            className="flex-1 text-gray-400 hover:text-white text-sm font-mono py-2 rounded-xl transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={submitting || value.length < 3}
+            className="flex-1 bg-emerald-500 hover:bg-emerald-400 text-white font-bold text-sm font-mono py-2 rounded-xl transition-colors disabled:opacity-40"
+          >
+            {submitting ? "..." : "Confirm"}
+          </button>
+        </div>
+      </motion.div>
+    </>
+  );
+}

--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -67,6 +67,7 @@ export function useAuth() {
         id,
         username: raw,
         discriminator: "",
+        username_changed: false,
         display_name: user_metadata?.full_name ?? user_metadata?.name ?? raw,
         avatar_config: null,
         is_premium: false,

--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -66,6 +66,7 @@ export function useAuth() {
       return {
         id,
         username: raw,
+        discriminator: "",
         display_name: user_metadata?.full_name ?? user_metadata?.name ?? raw,
         avatar_config: null,
         is_premium: false,

--- a/client/src/hooks/useFriendSearch.ts
+++ b/client/src/hooks/useFriendSearch.ts
@@ -12,13 +12,31 @@ export function useFriendSearch(myProfileId: string) {
   const handleSearch = async () => {
     if (!searchQuery.trim()) return;
     setLoading(true);
-    const { data } = await sb
-      .from("profiles")
-      .select("id, username, display_name, is_premium, current_room")
-      .ilike("username", `%${searchQuery.trim()}%`)
-      .neq("id", myProfileId)
-      .limit(10);
-    setSearchResults((data as Profile[]) ?? []);
+    const query = searchQuery.trim();
+    const hashIdx = query.indexOf("#");
+
+    let result;
+    if (hashIdx !== -1 && query.length > hashIdx + 1) {
+      // Full tag search: name#XXXX → exact match
+      const name = query.slice(0, hashIdx).toLowerCase();
+      const disc = query.slice(hashIdx + 1);
+      result = await sb
+        .from("profiles")
+        .select("id, username, discriminator, display_name, is_premium, current_room")
+        .eq("username", name)
+        .eq("discriminator", disc)
+        .neq("id", myProfileId)
+        .limit(10);
+    } else {
+      // Partial search: ilike on username
+      result = await sb
+        .from("profiles")
+        .select("id, username, discriminator, display_name, is_premium, current_room")
+        .ilike("username", `%${query}%`)
+        .neq("id", myProfileId)
+        .limit(10);
+    }
+    setSearchResults((result.data as Profile[]) ?? []);
     setLoading(false);
   };
 

--- a/client/src/hooks/useFriendsList.ts
+++ b/client/src/hooks/useFriendsList.ts
@@ -15,8 +15,8 @@ export function useFriendsList(myProfileId: string, active: boolean) {
       .select(
         `
         id, status, requester_id, addressee_id,
-        requester:profiles!friendships_requester_id_fkey(id, username, display_name, current_room, current_session_id, current_world_id, is_premium),
-        addressee:profiles!friendships_addressee_id_fkey(id, username, display_name, current_room, current_session_id, current_world_id, is_premium)
+        requester:profiles!friendships_requester_id_fkey(id, username, discriminator, display_name, current_room, current_session_id, current_world_id, is_premium),
+        addressee:profiles!friendships_addressee_id_fkey(id, username, discriminator, display_name, current_room, current_session_id, current_world_id, is_premium)
       `,
       )
       .eq("status", "accepted");
@@ -34,7 +34,7 @@ export function useFriendsList(myProfileId: string, active: boolean) {
       .select(
         `
         id,
-        requester:profiles!friendships_requester_id_fkey(id, username, display_name, current_session_id, current_world_id)
+        requester:profiles!friendships_requester_id_fkey(id, username, discriminator, display_name, current_session_id, current_world_id)
       `,
       )
       .eq("addressee_id", myProfileId)

--- a/client/src/lib/format.ts
+++ b/client/src/lib/format.ts
@@ -5,6 +5,10 @@ export function formatDuration(seconds: number): string {
   return `${m}m`;
 }
 
+export function formatTag(username: string, discriminator: string): string {
+  return `${username}#${discriminator}`;
+}
+
 export function formatTime(seconds: number): string {
   const s = Math.max(0, Math.floor(seconds));
   return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, "0")}`;

--- a/client/src/lib/types.ts
+++ b/client/src/lib/types.ts
@@ -5,6 +5,7 @@ export type { AvatarConfig };
 export type Profile = {
   id: string;
   username: string;
+  discriminator: string;
   display_name: string | null;
   avatar_config: AvatarConfig | null;
   is_premium: boolean;

--- a/client/src/lib/types.ts
+++ b/client/src/lib/types.ts
@@ -6,6 +6,7 @@ export type Profile = {
   id: string;
   username: string;
   discriminator: string;
+  username_changed: boolean;
   display_name: string | null;
   avatar_config: AvatarConfig | null;
   is_premium: boolean;

--- a/supabase/migrations/005_username_tags.sql
+++ b/supabase/migrations/005_username_tags.sql
@@ -64,12 +64,14 @@ DECLARE
   disc TEXT;
 BEGIN
   -- Fix usernames that violate the new pattern
+  -- lowercase FIRST so uppercase chars become valid instead of being stripped
   FOR r IN SELECT id, username FROM profiles WHERE username !~ '^[a-z0-9_]{3,20}$' LOOP
-    clean := lower(regexp_replace(r.username, '[^a-z0-9_]', '', 'g'));
+    clean := regexp_replace(lower(r.username), '[^a-z0-9_]', '', 'g');
     clean := left(clean, 20);
     IF length(clean) < 3 THEN
       clean := clean || repeat('_', 3 - length(clean));
     END IF;
+    RAISE NOTICE 'Sanitizing user %: "%" -> "%"', r.id, r.username, clean;
     UPDATE profiles SET username = clean WHERE id = r.id;
   END LOOP;
 
@@ -80,9 +82,11 @@ BEGIN
   END LOOP;
 END $$;
 
--- 5. Now enforce NOT NULL + check constraints
+-- 5. Now enforce NOT NULL + check constraints (drop first for re-runnability)
 ALTER TABLE profiles ALTER COLUMN discriminator SET NOT NULL;
+ALTER TABLE profiles DROP CONSTRAINT IF EXISTS discriminator_format;
 ALTER TABLE profiles ADD CONSTRAINT discriminator_format CHECK (discriminator ~ '^\d{4}$');
+ALTER TABLE profiles DROP CONSTRAINT IF EXISTS username_format;
 ALTER TABLE profiles ADD CONSTRAINT username_format CHECK (username ~ '^[a-z0-9_]{3,20}$');
 
 -- 6. Drop old unique constraint on username alone, add composite unique

--- a/supabase/migrations/005_username_tags.sql
+++ b/supabase/migrations/005_username_tags.sql
@@ -3,8 +3,9 @@
 -- Run after 004_tighten_session_rls.sql
 -- ─────────────────────────────────────────────────────────────────────────────
 
--- 1. Add discriminator column (nullable first for backfill)
+-- 1. Add discriminator column (nullable first for backfill) + username_changed flag
 ALTER TABLE profiles ADD COLUMN IF NOT EXISTS discriminator TEXT;
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS username_changed BOOLEAN DEFAULT FALSE;
 
 -- 2. Helper: generate a random 4-digit discriminator that doesn't collide
 CREATE OR REPLACE FUNCTION generate_discriminator(base_username TEXT)
@@ -40,6 +41,11 @@ BEGIN
     RAISE EXCEPTION 'Not authenticated';
   END IF;
 
+  -- Enforce one-time change
+  IF EXISTS (SELECT 1 FROM profiles WHERE id = caller_id AND username_changed = TRUE) THEN
+    RAISE EXCEPTION 'Username can only be changed once';
+  END IF;
+
   clean_name := lower(trim(desired_username));
 
   IF clean_name !~ '^[a-z0-9_]{3,20}$' THEN
@@ -49,7 +55,7 @@ BEGIN
   new_disc := generate_discriminator(clean_name);
 
   UPDATE profiles
-  SET username = clean_name, discriminator = new_disc
+  SET username = clean_name, discriminator = new_disc, username_changed = TRUE
   WHERE id = caller_id;
 
   RETURN jsonb_build_object('username', clean_name, 'discriminator', new_disc);

--- a/supabase/migrations/005_username_tags.sql
+++ b/supabase/migrations/005_username_tags.sql
@@ -56,12 +56,24 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 
--- 4. Backfill existing users with random discriminators
+-- 4. Sanitize existing usernames that don't match the new format, then backfill discriminators
 DO $$
 DECLARE
   r RECORD;
+  clean TEXT;
   disc TEXT;
 BEGIN
+  -- Fix usernames that violate the new pattern
+  FOR r IN SELECT id, username FROM profiles WHERE username !~ '^[a-z0-9_]{3,20}$' LOOP
+    clean := lower(regexp_replace(r.username, '[^a-z0-9_]', '', 'g'));
+    clean := left(clean, 20);
+    IF length(clean) < 3 THEN
+      clean := clean || repeat('_', 3 - length(clean));
+    END IF;
+    UPDATE profiles SET username = clean WHERE id = r.id;
+  END LOOP;
+
+  -- Backfill discriminators
   FOR r IN SELECT id, username FROM profiles WHERE discriminator IS NULL LOOP
     disc := generate_discriminator(r.username);
     UPDATE profiles SET discriminator = disc WHERE id = r.id;

--- a/supabase/migrations/005_username_tags.sql
+++ b/supabase/migrations/005_username_tags.sql
@@ -1,0 +1,133 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- DuoFocus — Username Tag System (Discord-style #XXXX discriminators)
+-- Run after 004_tighten_session_rls.sql
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- 1. Add discriminator column (nullable first for backfill)
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS discriminator TEXT;
+
+-- 2. Helper: generate a random 4-digit discriminator that doesn't collide
+CREATE OR REPLACE FUNCTION generate_discriminator(base_username TEXT)
+RETURNS TEXT AS $$
+DECLARE
+  candidate TEXT;
+  attempts INT := 0;
+BEGIN
+  LOOP
+    candidate := lpad(floor(random() * 10000)::int::text, 4, '0');
+    EXIT WHEN NOT EXISTS (
+      SELECT 1 FROM profiles
+      WHERE username = base_username AND discriminator = candidate
+    );
+    attempts := attempts + 1;
+    IF attempts >= 20 THEN
+      RAISE EXCEPTION 'Could not generate unique discriminator for "%"', base_username;
+    END IF;
+  END LOOP;
+  RETURN candidate;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 3. RPC: claim_username — validates, generates discriminator, updates profile
+CREATE OR REPLACE FUNCTION claim_username(desired_username TEXT)
+RETURNS JSONB AS $$
+DECLARE
+  caller_id UUID := auth.uid();
+  clean_name TEXT;
+  new_disc TEXT;
+BEGIN
+  IF caller_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  clean_name := lower(trim(desired_username));
+
+  IF clean_name !~ '^[a-z0-9_]{3,20}$' THEN
+    RAISE EXCEPTION 'Username must be 3-20 characters: lowercase letters, numbers, underscores only';
+  END IF;
+
+  new_disc := generate_discriminator(clean_name);
+
+  UPDATE profiles
+  SET username = clean_name, discriminator = new_disc
+  WHERE id = caller_id;
+
+  RETURN jsonb_build_object('username', clean_name, 'discriminator', new_disc);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 4. Backfill existing users with random discriminators
+DO $$
+DECLARE
+  r RECORD;
+  disc TEXT;
+BEGIN
+  FOR r IN SELECT id, username FROM profiles WHERE discriminator IS NULL LOOP
+    disc := generate_discriminator(r.username);
+    UPDATE profiles SET discriminator = disc WHERE id = r.id;
+  END LOOP;
+END $$;
+
+-- 5. Now enforce NOT NULL + check constraints
+ALTER TABLE profiles ALTER COLUMN discriminator SET NOT NULL;
+ALTER TABLE profiles ADD CONSTRAINT discriminator_format CHECK (discriminator ~ '^\d{4}$');
+ALTER TABLE profiles ADD CONSTRAINT username_format CHECK (username ~ '^[a-z0-9_]{3,20}$');
+
+-- 6. Drop old unique constraint on username alone, add composite unique
+ALTER TABLE profiles DROP CONSTRAINT IF EXISTS profiles_username_key;
+CREATE UNIQUE INDEX IF NOT EXISTS profiles_username_discriminator_unique
+  ON profiles (username, discriminator);
+
+-- 7. Update handle_new_user() trigger to also generate a discriminator
+CREATE OR REPLACE FUNCTION handle_new_user()
+RETURNS TRIGGER AS $$
+DECLARE
+  base_username TEXT;
+  final_username TEXT;
+  new_disc TEXT;
+BEGIN
+  -- Build base username from OAuth metadata or email
+  base_username := COALESCE(
+    NEW.raw_user_meta_data->>'preferred_username',
+    NEW.raw_user_meta_data->>'user_name',
+    split_part(COALESCE(NEW.email, ''), '@', 1)
+  );
+
+  -- Sanitize: keep only alphanumeric + underscores, lowercase
+  base_username := lower(regexp_replace(base_username, '[^a-zA-Z0-9_]', '', 'g'));
+
+  -- Fallback if empty after sanitize
+  IF base_username = '' THEN
+    base_username := 'user';
+  END IF;
+
+  -- Truncate to 20 chars max
+  base_username := left(base_username, 20);
+
+  -- Ensure minimum 3 chars
+  IF length(base_username) < 3 THEN
+    base_username := base_username || repeat('_', 3 - length(base_username));
+  END IF;
+
+  final_username := base_username;
+  new_disc := generate_discriminator(final_username);
+
+  INSERT INTO public.profiles (id, username, display_name, discriminator)
+  VALUES (
+    NEW.id,
+    final_username,
+    COALESCE(
+      NEW.raw_user_meta_data->>'full_name',
+      NEW.raw_user_meta_data->>'name',
+      base_username
+    ),
+    new_disc
+  )
+  ON CONFLICT (id) DO NOTHING;
+
+  RETURN NEW;
+EXCEPTION WHEN OTHERS THEN
+  -- Never block auth signup due to profile creation errors
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
  **Database Migration (supabase/migrations/005_username_tags.sql)**

  - Added discriminator TEXT column to profiles
  - Created generate_discriminator(base_username) function with collision retry (up to 20 attempts)
  - Created claim_username(desired_username) RPC with format validation (^[a-z0-9_]{3,20}$)
  - Backfills existing users with random 4-digit discriminators
  - Added NOT NULL constraint, check constraints on both username and discriminator
  - Replaced old UNIQUE(username) with composite UNIQUE(username, discriminator)
  - Updated handle_new_user() trigger to auto-generate discriminators on signup
  - Added username_changed BOOLEAN DEFAULT FALSE column
  - claim_username RPC now checks username_changed — rejects if already TRUE, sets it to TRUE on success

  **Client Changes**

  - types.ts: Added discriminator: string to Profile
  - format.ts: Added formatTag(username, discriminator) helper
  - useAuth.ts: Added discriminator: "" to provisional profile
  - AvatarCreator.tsx: Added username input (first setup only) with live validation; updated onSave signature to include optional       username       
  - DuoTimer.tsx: Calls claim_username RPC before saving avatar on first setup; passes discriminator to SessionTopBar
  - SessionTopBar.tsx: Accepts and displays discriminator in profile menu
  - FriendsPanel.tsx: Shows full username#XXXX tags in friend rows, search results, and footer; copy-to-clipboard on own tag; 
  - HomeDashboard.tsx: Shows full tag in profile dropdown
  - useFriendSearch.ts: Parses # in query for exact tag match vs partial ilike search; includes discriminator in select
  - useFriendsList.ts: Added discriminator to both profile select strings  
  - Profile type now includes username_changed: boolean
  - New UsernameChangeModal component: input with validation, calls claim_username RPC
  - HomeDashboard profile dropdown shows "Change username (1x)" button when username_changed is false
  - DuoTimer wires up the modal and handles the RPC call + profile update

**Flow**: Existing users see the option in their profile menu, pick a new username, get a fresh #XXXX tag, and the option disappears after use. New users still pick their username during avatar creation.