### PR TITLE
UI redesign: light/dark mode with cozy stationery aesthetic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Duodoro is a collaborative pomodoro web app for long-distance couples/friends. Users sign in (Google/Discord OAuth via Supabase), create a pixel-art avatar, pick a themed "world", and run synchronized focus/break sessions together in real time. Friends, invites, presence, sticky-note tasks, and session stats are layered on top.
+
+## Repo layout
+
+Two independent npm packages (each with its own `package.json` and lockfile), plus infra:
+
+- `client/` — Next.js 16 (App Router, React 19, TypeScript, Tailwind 4, framer-motion). Single-page app: `app/page.tsx` just renders `DuoTimer`.
+- `server/` — Plain Node.js (CommonJS) Express + Socket.IO server. All real logic lives in `server/index.js`.
+- `supabase/migrations/` — Numbered SQL migrations (001–009). These are run manually in the Supabase SQL editor, not via a migration tool. Add new ones as the next number in sequence.
+- `docker-compose.yml`, `nginx/`, `scripts/`, `.github/workflows/deploy.yml` — production deploy (GHCR images → VPS over SSH on push to `main`).
+- The root `package.json` is vestigial — don't add dependencies there; install into `client/` or `server/`.
+
+## Commands
+
+Run commands inside `client/` or `server/`, not the repo root.
+
+Client (`cd client`):
+- `npm run dev` — dev server on http://localhost:3000
+- `npm run build` / `npm run lint`
+- `npm run test:run` — vitest once; `npm test` for watch mode
+- Single test: `npx vitest run src/lib/format.test.ts`
+
+Server (`cd server`):
+- `npm start` — runs on port 3001 (or `npx nodemon index.js` for reload)
+- `npm run test:run` — vitest once
+- Without `SUPABASE_URL`/`SUPABASE_SERVICE_KEY` set, the server runs in dev mode: JWT verification and all persistence are skipped. In production those vars are required (it exits otherwise).
+
+Local dev needs both processes running. Client env: `NEXT_PUBLIC_SOCKET_URL`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`. Server env: see `server/.env.example`.
+
+## Architecture
+
+### Split of responsibilities
+
+- **Socket.IO server** (`server/index.js`) is the source of truth for live session state: phases, timers, players, presence, invites. All session state is **in-memory** (`sessions`, `userSockets` maps) — it does not survive a server restart, and nothing live is read back from the DB.
+- **Supabase** handles auth (JWT), and persistence: profiles, friendships, tasks/sticky notes, and *completed* session history (`sessions` + `session_participants` rows written by the server with the service-role key, bypassing RLS). The client talks to Supabase directly (anon key + RLS) for friends, tasks, and stats.
+- **Client** never trusts its own clock for the timer: the server broadcasts `phase_change` with `phaseStartTime` and durations; the client renders countdowns from `Date.now() - phaseStartTime`.
+
+### Server session lifecycle
+
+Sessions are keyed by UUID. Phase state machine driven by `setTimeout` chains in `advancePhase()`:
+`waiting → focus → celebration (4s) → break → returning (3.5s) → focus → …`
+
+Two timer modes: `pomodoro` (fixed durations, server auto-advances) and `flow` (open-ended focus; client emits `finish_flow_focus`, break is computed as ~1/5 of elapsed focus). Focus is recorded to the DB when a focus phase completes or is stopped/abandoned early (`recordSession`, with `completed` flag).
+
+Security conventions in the socket layer (preserve these when adding events):
+- `io.use()` middleware verifies the Supabase JWT and sets `socket.userId` — **never trust a client-sent userId**.
+- Every inbound payload is validated/sanitized (`sanitizeAvatar`, `VALID_WORLDS`, name length caps, duration clamps `MAX_FOCUS`/`MAX_BREAK`).
+- Mutating events check the socket is actually a player in the session; create/join/invite are rate-limited per socket.
+
+Note: `server/session.js` is a pure-function extraction of session state logic used **only by tests** (`session.test.js`) — `index.js` does not import it and has its own inline copies. Keep them in sync or be aware they can drift.
+
+### Client structure
+
+`DuoTimer.tsx` is the top-level orchestrator: it composes two hooks and switches screens on `appStep` (`loading → landing → avatar → home → game`, defined in `lib/sessionTypes.ts`).
+
+- `hooks/useAuth.ts` — Supabase auth, profile load/save, drives `appStep`.
+- `hooks/useGameSession.ts` — owns the Socket.IO connection (auth token in handshake, retries on token expiry), all session/phase/player state, invites, and resume-after-tab-sleep resync (`request_sync`). This is the file to touch for any realtime behavior.
+- `lib/supabase.ts` — browser Supabase singleton (PKCE flow, localStorage sessions — deliberately not cookie/SSR-based; `app/auth/callback/route.ts` exists for the OAuth redirect).
+- Direct-to-Supabase data hooks: `useFriendsList`, `useFriendSearch`, `useTasks`, `useStickyNotes`, `lib/useStats.ts`.
+- Visuals: `GameWorld` renders the session scene; `PixelCharacter`/`PetCharacter`/`WorldDecorations` are hand-drawn SVG/CSS pixel art driven by `lib/avatarData.ts` (avatar options here must stay in sync with the server's `sanitizeAvatar` whitelist and `VALID_WORLDS`).
+
+### Database conventions
+
+- `profiles` extends `auth.users`; usernames use Discord-style `username#discriminator` tags via the `claim_username` RPC (one-time change enforced in SQL, migration 005).
+- Live presence is mirrored into `profiles.current_session_id` / `current_world_id` by the server so friends can see "in a session" from the client's Supabase queries.
+- RLS is on for all tables; the server's service-role key is what allows it to write session history and presence. Later migrations (004, 007, 009) tightened RLS and pinned function search paths — follow that pattern in new SQL.
+
+## Deployment
+
+Push to `main` → GitHub Actions builds client/server Docker images, pushes to GHCR, then SSHes into the VPS and runs `docker compose up -d` in `/opt/duodoro`. `NEXT_PUBLIC_*` vars are baked into the client image at build time (repo secrets). Nginx terminates TLS and proxies to client (3000) and server (3001, including websockets).

--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -1,6 +1,92 @@
 @import "tailwindcss";
 
 /* ─────────────────────────────────────────────────────────────────────────────
+   Theme Tokens — "warm paper" light / "warm charcoal" dark
+   Components use semantic Tailwind classes (bg-bg, bg-surface, text-ink,
+   border-line, bg-accent…) which resolve to these variables, so the whole
+   UI re-themes by swapping data-theme on <html>.
+───────────────────────────────────────────────────────────────────────────── */
+
+:root,
+[data-theme="light"] {
+  color-scheme: light;
+  --bg: #f3ede1;
+  --surface: #fbf7ee;
+  --raise: #eae2cf;
+  --ink: #332d24;
+  --muted: #847862;
+  --faint: #aca18a;
+  --line: #ddd3bd;
+  --accent: #d96c57;
+  --accent-deep: #b9543f;
+  --go: #4f9e6e;
+  --go-deep: #3c7f56;
+  --calm: #5b8fd9;
+  --calm-deep: #4674b8;
+  --gold: #e0a83f;
+  --gold-deep: #b9882c;
+  --danger: #c4554d;
+}
+
+[data-theme="dark"] {
+  color-scheme: dark;
+  --bg: #171411;
+  --surface: #211d18;
+  --raise: #2b261f;
+  --ink: #ede4d3;
+  --muted: #a2967e;
+  --faint: #6b614f;
+  --line: #363026;
+  --accent: #e6876f;
+  --accent-deep: #b95f49;
+  --go: #5fbe8a;
+  --go-deep: #3f9468;
+  --calm: #7da7e8;
+  --calm-deep: #5d86c8;
+  --gold: #e6b554;
+  --gold-deep: #bb8d33;
+  --danger: #e07b72;
+}
+
+@theme inline {
+  --color-bg: var(--bg);
+  --color-surface: var(--surface);
+  --color-raise: var(--raise);
+  --color-ink: var(--ink);
+  --color-muted: var(--muted);
+  --color-faint: var(--faint);
+  --color-line: var(--line);
+  --color-accent: var(--accent);
+  --color-accent-deep: var(--accent-deep);
+  --color-go: var(--go);
+  --color-go-deep: var(--go-deep);
+  --color-calm: var(--calm);
+  --color-calm-deep: var(--calm-deep);
+  --color-gold: var(--gold);
+  --color-gold-deep: var(--gold-deep);
+  --color-danger: var(--danger);
+  --font-sans: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
+  --font-mono: var(--font-geist-mono), ui-monospace, monospace;
+  --font-display: var(--font-pixel), var(--font-geist-mono), monospace;
+}
+
+body {
+  background-color: var(--bg);
+  color: var(--ink);
+  transition: background-color 0.25s ease, color 0.25s ease;
+}
+
+::selection {
+  background: color-mix(in oklab, var(--accent) 30%, transparent);
+}
+
+/* Subtle dot-grid texture for large empty backgrounds */
+.texture-dots {
+  background-image: radial-gradient(var(--line) 1px, transparent 1px);
+  background-size: 22px 22px;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
    Pixel Art Utilities
 ───────────────────────────────────────────────────────────────────────────── */
 
@@ -58,9 +144,9 @@
 }
 
 /* ─────────────────────────────────────────────────────────────────────────────
-   Scrollbar (dark theme)
+   Scrollbar (theme-aware)
 ───────────────────────────────────────────────────────────────────────────── */
 ::-webkit-scrollbar { width: 6px; }
-::-webkit-scrollbar-track { background: #111827; }
-::-webkit-scrollbar-thumb { background: #374151; border-radius: 3px; }
-::-webkit-scrollbar-thumb:hover { background: #4b5563; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--line); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: var(--faint); }

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, Pixelify_Sans } from "next/font/google";
 import "./globals.css";
 import ServiceWorkerRegister from "@/components/ServiceWorkerRegister";
 
@@ -12,6 +12,14 @@ const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
 });
+
+const pixelSans = Pixelify_Sans({
+  variable: "--font-pixel",
+  subsets: ["latin"],
+});
+
+// Runs before paint: picks saved theme or system preference so there's no flash
+const themeInitScript = `(function(){try{var t=localStorage.getItem("duodoro-theme");if(t!=="light"&&t!=="dark"){t=window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light"}document.documentElement.dataset.theme=t}catch(e){document.documentElement.dataset.theme="dark"}})();`;
 
 export const metadata: Metadata = {
   title: "Duodoro — Focus together, anywhere.",
@@ -37,7 +45,10 @@ export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   viewportFit: "cover",
-  themeColor: "#111827",
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#f3ede1" },
+    { media: "(prefers-color-scheme: dark)", color: "#171411" },
+  ],
 };
 
 export default function RootLayout({
@@ -46,9 +57,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} ${pixelSans.variable} font-sans antialiased`}
       >
         {children}
         <ServiceWorkerRegister />

--- a/client/src/components/AvatarCreator.tsx
+++ b/client/src/components/AvatarCreator.tsx
@@ -41,8 +41,8 @@ function ColorSwatch({
           className="w-11 h-11 sm:w-7 sm:h-7 rounded border-2 transition-all"
           style={{
             backgroundColor: hex,
-            borderColor: selected === hex ? "white" : "transparent",
-            boxShadow: selected === hex ? "0 0 0 2px #6ee7b7" : undefined,
+            borderColor: selected === hex ? "var(--surface)" : "transparent",
+            boxShadow: selected === hex ? "0 0 0 2px var(--accent)" : undefined,
           }}
         />
       ))}
@@ -69,21 +69,21 @@ function CycleRow<T extends string>({
   const next = () => onChange(options[(idx + 1) % options.length]);
 
   return (
-    <div className="flex items-center justify-between bg-gray-900/60 px-3 py-2 rounded-lg">
-      <span className="text-gray-400 text-xs font-bold w-14">{label}</span>
+    <div className="flex items-center justify-between bg-raise px-3 py-2 rounded-lg">
+      <span className="text-muted text-xs font-bold w-14">{label}</span>
       <div className="flex items-center gap-2">
         <button
           onClick={prev}
-          className="w-10 h-10 sm:w-6 sm:h-6 flex items-center justify-center bg-gray-700 hover:bg-gray-600 rounded text-white font-bold text-lg sm:text-sm"
+          className="w-10 h-10 sm:w-6 sm:h-6 flex items-center justify-center bg-line hover:bg-faint rounded text-ink font-bold text-lg sm:text-sm transition-colors"
         >
           ‹
         </button>
-        <span className="w-20 text-center text-xs text-white">
+        <span className="w-20 text-center text-xs text-ink">
           {labels[value]}
         </span>
         <button
           onClick={next}
-          className="w-10 h-10 sm:w-6 sm:h-6 flex items-center justify-center bg-gray-700 hover:bg-gray-600 rounded text-white font-bold text-lg sm:text-sm"
+          className="w-10 h-10 sm:w-6 sm:h-6 flex items-center justify-center bg-line hover:bg-faint rounded text-ink font-bold text-lg sm:text-sm transition-colors"
         >
           ›
         </button>
@@ -113,25 +113,25 @@ export default function AvatarCreator({
   return (
     <div className="flex flex-col items-center gap-8 w-full max-w-md mx-auto">
       <div>
-        <h1 className="text-3xl font-bold text-center text-white font-mono tracking-widest">
+        <h1 className="font-display text-3xl text-center text-ink tracking-wide">
           Duodoro
         </h1>
-        <p className="text-gray-400 text-center text-sm mt-1">
+        <p className="text-muted text-center text-sm mt-1">
           {isEditing
             ? "Update your character"
             : "Focus together, no matter the distance"}
         </p>
       </div>
 
-      <div className="bg-gray-800 p-6 rounded-2xl shadow-2xl border border-gray-700 w-full">
-        <h2 className="text-lg font-bold text-white font-mono tracking-widest text-center mb-6">
-          {isEditing ? "EDIT CHARACTER" : "DESIGN YOUR HERO"}
+      <div className="bg-surface p-6 rounded-2xl shadow-xl border border-line w-full">
+        <h2 className="font-display text-lg text-ink tracking-wide text-center mb-6">
+          {isEditing ? "Edit character" : "Design your hero"}
         </h2>
 
         {/* ── Live Preview ── */}
         <div className="flex justify-center mb-6">
           <div
-            className="rounded-2xl border-4 border-gray-600 flex items-end justify-center overflow-hidden"
+            className="rounded-2xl border-4 border-line flex items-end justify-center overflow-hidden"
             style={{
               width: 120,
               height: 140,
@@ -147,11 +147,11 @@ export default function AvatarCreator({
         {!isEditing && (
           <>
             <div className="mb-4">
-              <p className="text-gray-400 text-xs font-bold font-mono mb-2">
-                YOUR NAME
+              <p className="text-faint text-xs font-semibold uppercase tracking-wider mb-2">
+                Your name
               </p>
               <input
-                className="w-full px-3 py-2 bg-gray-900/60 border border-gray-600 rounded-lg text-white text-sm font-mono placeholder-gray-600 focus:outline-none focus:border-emerald-500 transition-colors"
+                className="w-full px-3 py-2 bg-raise border border-line rounded-lg text-ink text-sm placeholder-faint focus:outline-none focus:border-accent transition-colors"
                 placeholder="e.g. Jorge"
                 value={displayName}
                 onChange={(e) => setDisplayName(e.target.value)}
@@ -159,12 +159,12 @@ export default function AvatarCreator({
               />
             </div>
             <div className="mb-4">
-              <p className="text-gray-400 text-xs font-bold font-mono mb-2">
-                USERNAME
+              <p className="text-faint text-xs font-semibold uppercase tracking-wider mb-2">
+                Username
               </p>
               <input
-                className={`w-full px-3 py-2 bg-gray-900/60 border rounded-lg text-white text-sm font-mono placeholder-gray-600 focus:outline-none transition-colors ${
-                  usernameError ? "border-red-500 focus:border-red-400" : "border-gray-600 focus:border-emerald-500"
+                className={`w-full px-3 py-2 bg-raise border rounded-lg text-ink text-sm font-mono placeholder-faint focus:outline-none transition-colors ${
+                  usernameError ? "border-danger focus:border-danger" : "border-line focus:border-accent"
                 }`}
                 placeholder="e.g. jorji"
                 value={username}
@@ -179,18 +179,18 @@ export default function AvatarCreator({
                 }}
                 maxLength={20}
               />
-              <p className="text-gray-600 text-[10px] font-mono mt-1">
+              <p className="text-faint text-[10px] mt-1">
                 Lowercase letters, numbers, underscores. A #tag will be added automatically.
               </p>
               {usernameError && (
-                <p className="text-red-400 text-xs font-mono mt-1">{usernameError}</p>
+                <p className="text-danger text-xs mt-1">{usernameError}</p>
               )}
             </div>
           </>
         )}
 
         {/* ── Controls ── */}
-        <div className="space-y-3 font-mono text-sm mb-5">
+        <div className="space-y-3 text-sm mb-5">
           <CycleRow
             label="HAIR"
             options={HAIR_STYLES}
@@ -210,8 +210,8 @@ export default function AvatarCreator({
         {/* ── Color Pickers ── */}
         <div className="space-y-3 mb-6">
           <div>
-            <p className="text-gray-400 text-xs font-bold font-mono mb-2">
-              SKIN
+            <p className="text-faint text-xs font-semibold uppercase tracking-wider mb-2">
+              Skin
             </p>
             <ColorSwatch
               colors={SKIN_COLORS}
@@ -220,8 +220,8 @@ export default function AvatarCreator({
             />
           </div>
           <div>
-            <p className="text-gray-400 text-xs font-bold font-mono mb-2">
-              HAIR COLOR
+            <p className="text-faint text-xs font-semibold uppercase tracking-wider mb-2">
+              Hair color
             </p>
             <ColorSwatch
               colors={HAIR_COLORS}
@@ -230,8 +230,8 @@ export default function AvatarCreator({
             />
           </div>
           <div>
-            <p className="text-gray-400 text-xs font-bold font-mono mb-2">
-              OUTFIT
+            <p className="text-faint text-xs font-semibold uppercase tracking-wider mb-2">
+              Outfit
             </p>
             <ColorSwatch
               colors={OUTFIT_COLORS}
@@ -243,15 +243,15 @@ export default function AvatarCreator({
 
         <button
           onClick={() => onSave(config, displayName.trim(), !isEditing && username ? username : undefined)}
-          className="w-full bg-emerald-500 hover:bg-emerald-400 active:scale-95 text-white font-bold py-3 px-4 rounded-xl border-b-4 border-emerald-700 transition-all font-mono tracking-widest"
+          className="w-full bg-accent hover:brightness-105 active:scale-95 text-white font-display text-lg py-3 px-4 rounded-xl border-b-4 border-accent-deep transition-all tracking-wide"
         >
-          {isEditing ? "SAVE CHANGES →" : "READY TO FOCUS →"}
+          {isEditing ? "Save changes →" : "Ready to focus →"}
         </button>
 
         {onBack && (
           <button
             onClick={onBack}
-            className="w-full mt-3 text-gray-500 hover:text-gray-300 text-sm font-mono transition-colors"
+            className="w-full mt-3 text-muted hover:text-ink text-sm transition-colors"
           >
             ← Cancel
           </button>

--- a/client/src/components/DisplayNameChangeModal.tsx
+++ b/client/src/components/DisplayNameChangeModal.tsx
@@ -59,20 +59,20 @@ export default function DisplayNameChangeModal({
       <motion.div
         initial={{ opacity: 0, scale: 0.95 }}
         animate={{ opacity: 1, scale: 1 }}
-        className="fixed z-50 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-gray-800 border border-gray-700 rounded-2xl p-6 shadow-2xl w-[calc(100vw-1rem)] sm:w-80"
+        className="fixed z-50 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-surface border border-line rounded-2xl p-6 shadow-2xl w-[calc(100vw-1rem)] sm:w-80"
       >
-        <h3 className="text-white font-bold font-mono tracking-widest text-sm mb-1">
-          CHANGE DISPLAY NAME
+        <h3 className="font-display text-ink tracking-wide text-base mb-1">
+          Change display name
         </h3>
-        <p className="text-gray-500 text-xs font-mono mb-4">
+        <p className="text-faint text-xs mb-4">
           Current: {currentName}
         </p>
         {cooldown ? (
           <>
-            <p className="text-yellow-400 text-xs font-mono mb-4">{cooldown}</p>
+            <p className="text-gold text-xs mb-4">{cooldown}</p>
             <button
               onClick={onClose}
-              className="w-full text-gray-400 hover:text-white text-sm font-mono py-3 sm:py-2 rounded-xl transition-colors"
+              className="w-full text-muted hover:text-ink text-sm py-3 sm:py-2 rounded-xl transition-colors"
             >
               Close
             </button>
@@ -80,10 +80,10 @@ export default function DisplayNameChangeModal({
         ) : (
           <>
             <input
-              className={`w-full px-3 py-3 sm:py-2 bg-gray-900/60 border rounded-lg text-white text-sm font-mono placeholder-gray-600 focus:outline-none transition-colors mb-1 ${
+              className={`w-full px-3 py-3 sm:py-2 bg-raise border rounded-lg text-ink text-sm placeholder-faint focus:outline-none transition-colors mb-1 ${
                 error
-                  ? "border-red-500 focus:border-red-400"
-                  : "border-gray-600 focus:border-emerald-500"
+                  ? "border-danger focus:border-danger"
+                  : "border-line focus:border-accent"
               }`}
               placeholder="New display name"
               value={value}
@@ -95,23 +95,23 @@ export default function DisplayNameChangeModal({
               onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
               autoFocus
             />
-            <p className="text-gray-600 text-[10px] font-mono mb-3">
+            <p className="text-faint text-[10px] mb-3">
               1-week cooldown after changing.
             </p>
             {error && (
-              <p className="text-red-400 text-xs font-mono mb-3">{error}</p>
+              <p className="text-danger text-xs mb-3">{error}</p>
             )}
             <div className="flex gap-2">
               <button
                 onClick={onClose}
-                className="flex-1 text-gray-400 hover:text-white text-sm font-mono py-3 sm:py-2 rounded-xl transition-colors"
+                className="flex-1 text-muted hover:text-ink text-sm py-3 sm:py-2 rounded-xl transition-colors"
               >
                 Cancel
               </button>
               <button
                 onClick={handleSubmit}
                 disabled={submitting || value.trim().length < 1}
-                className="flex-1 bg-emerald-500 hover:bg-emerald-400 text-white font-bold text-sm font-mono py-3 sm:py-2 rounded-xl transition-colors disabled:opacity-40"
+                className="flex-1 bg-accent hover:brightness-105 text-white font-bold text-sm py-3 sm:py-2 rounded-xl transition-all disabled:opacity-40"
               >
                 {submitting ? "..." : "Confirm"}
               </button>

--- a/client/src/components/DuoTimer.tsx
+++ b/client/src/components/DuoTimer.tsx
@@ -60,28 +60,26 @@ export default function DuoTimer() {
   // ── Loading ─────────────────────────────────────────────────────────────
   if (appStep === "loading") {
     return (
-      <div className="min-h-screen bg-gray-900 flex items-center justify-center">
+      <div className="min-h-screen bg-bg flex items-center justify-center">
         <div className="flex flex-col items-center gap-5">
-          <div className="text-4xl font-black font-mono text-white tracking-widest">
+          <div className="font-display text-4xl text-ink tracking-wide">
             Duodoro
           </div>
           <div className="flex items-center gap-2">
             <div
-              className="w-2 h-2 rounded-full bg-emerald-500 animate-bounce"
+              className="w-2 h-2 rounded-full bg-accent animate-bounce"
               style={{ animationDelay: "0ms" }}
             />
             <div
-              className="w-2 h-2 rounded-full bg-emerald-500 animate-bounce"
+              className="w-2 h-2 rounded-full bg-accent animate-bounce"
               style={{ animationDelay: "150ms" }}
             />
             <div
-              className="w-2 h-2 rounded-full bg-emerald-500 animate-bounce"
+              className="w-2 h-2 rounded-full bg-accent animate-bounce"
               style={{ animationDelay: "300ms" }}
             />
           </div>
-          <span className="text-gray-600 text-xs font-mono">
-            signing you in...
-          </span>
+          <span className="text-faint text-xs">signing you in...</span>
         </div>
       </div>
     );
@@ -96,7 +94,7 @@ export default function DuoTimer() {
   if (appStep === "avatar") {
     const isEditing = !!profile?.avatar_config;
     return (
-      <div className="min-h-screen bg-gray-900 flex items-center justify-center p-6">
+      <div className="min-h-screen bg-bg texture-dots flex items-center justify-center p-6">
         <AvatarCreator
           initialConfig={myAvatar}
           initialDisplayName={profile?.display_name ?? ""}
@@ -182,7 +180,7 @@ export default function DuoTimer() {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: 20 }}
-              className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 bg-emerald-600 text-white text-sm font-mono font-bold px-4 py-2.5 rounded-xl shadow-lg"
+              className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 bg-go text-white text-sm font-bold px-4 py-2.5 rounded-xl shadow-lg"
             >
               Invite sent!
             </motion.div>
@@ -263,7 +261,7 @@ export default function DuoTimer() {
   // ── Game Screen ─────────────────────────────────────────────────────────
   return (
     <div
-      className="h-screen bg-gray-900 text-white relative overflow-hidden"
+      className="h-screen bg-bg text-white relative overflow-hidden"
       onClick={() => setProfileMenuOpen(false)}
     >
       {/* ── Game World (full-screen background) ── */}
@@ -368,7 +366,7 @@ export default function DuoTimer() {
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: 20 }}
-            className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 bg-emerald-600 text-white text-sm font-mono font-bold px-4 py-2.5 rounded-xl shadow-lg"
+            className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 bg-go text-white text-sm font-bold px-4 py-2.5 rounded-xl shadow-lg"
           >
             Invite sent!
           </motion.div>

--- a/client/src/components/FriendsOnlineSection.tsx
+++ b/client/src/components/FriendsOnlineSection.tsx
@@ -23,14 +23,14 @@ export default function FriendsOnlineSection({
   if (onlineFriends.length === 0) return null;
 
   return (
-    <div className="bg-gray-800/50 rounded-2xl border border-gray-700 p-4">
+    <div className="bg-surface rounded-2xl border border-line p-4">
       <div className="flex items-center justify-between mb-3">
-        <h2 className="text-sm font-bold font-mono text-gray-400 uppercase tracking-wider">
-          Friends Online
+        <h2 className="text-xs font-semibold text-faint uppercase tracking-wider">
+          Friends online
         </h2>
         <button
           onClick={onOpenFriends}
-          className="text-[10px] font-mono text-gray-600 hover:text-emerald-400 transition-colors"
+          className="text-[10px] text-faint hover:text-accent transition-colors"
         >
           See all
         </button>
@@ -45,36 +45,34 @@ export default function FriendsOnlineSection({
           return (
             <div
               key={f.id}
-              className="flex items-center gap-2.5 py-2 px-2.5 rounded-xl hover:bg-gray-700/50 transition-colors group"
+              className="flex items-center gap-2.5 py-2 px-2.5 rounded-xl hover:bg-raise transition-colors group"
             >
               <div
-                className={`w-2 h-2 rounded-full flex-shrink-0 ${inSession ? "bg-emerald-400 animate-pulse" : "bg-yellow-400"}`}
+                className={`w-2 h-2 rounded-full flex-shrink-0 ${inSession ? "bg-go animate-pulse" : "bg-gold"}`}
               />
               <div className="flex-1 min-w-0">
-                <p className="text-sm font-bold text-white truncate">
+                <p className="text-sm font-semibold text-ink truncate">
                   {name}
                 </p>
                 {inSession && worldInfo ? (
-                  <p className="text-[10px] text-emerald-400 font-mono truncate">
+                  <p className="text-[10px] text-go truncate">
                     {worldInfo.emoji} In {worldInfo.label}
                   </p>
                 ) : (
-                  <p className="text-[10px] text-gray-500 font-mono">
-                    Online
-                  </p>
+                  <p className="text-[10px] text-faint">Online</p>
                 )}
               </div>
               {inSession && f.current_session_id ? (
                 <button
                   onClick={() => onJoinSession(f.current_session_id!)}
-                  className="text-[10px] bg-emerald-500/20 hover:bg-emerald-500/40 text-emerald-300 font-mono font-bold px-2 py-1 rounded-lg transition-colors"
+                  className="text-[10px] bg-go/15 hover:bg-go/30 text-go font-bold px-2.5 py-1 rounded-lg transition-colors"
                 >
                   Join
                 </button>
               ) : (
                 <button
                   onClick={() => onInvite(f.id)}
-                  className="text-[10px] bg-gray-700/50 hover:bg-gray-700 text-gray-400 font-mono font-bold px-2 py-1 rounded-lg transition-colors opacity-0 group-hover:opacity-100"
+                  className="text-[10px] bg-raise hover:bg-line text-muted font-bold px-2.5 py-1 rounded-lg transition-colors opacity-0 group-hover:opacity-100"
                 >
                   Invite
                 </button>
@@ -85,7 +83,7 @@ export default function FriendsOnlineSection({
         {onlineFriends.length > 5 && (
           <button
             onClick={onOpenFriends}
-            className="w-full text-center text-[10px] font-mono text-gray-500 hover:text-emerald-400 py-1.5 transition-colors"
+            className="w-full text-center text-[10px] text-faint hover:text-accent py-1.5 transition-colors"
           >
             +{onlineFriends.length - 5} more
           </button>

--- a/client/src/components/FriendsPanel.tsx
+++ b/client/src/components/FriendsPanel.tsx
@@ -25,7 +25,7 @@ const WORLD_LABEL: Record<string, { emoji: string; label: string }> =
 function StatusDot({ inSession }: { inSession: boolean }) {
   return (
     <div
-      className={`w-2.5 h-2.5 rounded-full flex-shrink-0 ${inSession ? "bg-emerald-400 animate-pulse" : "bg-gray-600"}`}
+      className={`w-2.5 h-2.5 rounded-full flex-shrink-0 ${inSession ? "bg-go animate-pulse" : "bg-faint"}`}
       title={inSession ? "In session" : "Offline"}
     />
   );
@@ -47,16 +47,16 @@ function FriendRow({
   const name = friend.display_name ?? friend.username;
 
   return (
-    <div className="flex items-center gap-3 py-2.5 px-3 rounded-xl hover:bg-gray-700/50 transition-colors group">
+    <div className="flex items-center gap-3 py-2.5 px-3 rounded-xl hover:bg-raise transition-colors group">
       <StatusDot inSession={inSession} />
       <div className="flex-1 min-w-0">
-        <p className="text-sm font-bold text-white truncate">{name}</p>
+        <p className="text-sm font-bold text-ink truncate">{name}</p>
         {inSession && worldInfo ? (
-          <p className="text-xs text-emerald-400 font-mono truncate">
+          <p className="text-xs text-go truncate">
             {worldInfo.emoji} In {worldInfo.label}
           </p>
         ) : (
-          <p className="text-xs text-gray-500 font-mono truncate">
+          <p className="text-xs text-faint font-mono truncate">
             @{friend.discriminator ? formatTag(friend.username, friend.discriminator) : friend.username}
           </p>
         )}
@@ -64,14 +64,14 @@ function FriendRow({
       {inSession && friend.current_session_id ? (
         <button
           onClick={() => onJoin(friend.current_session_id!)}
-          className="text-xs bg-emerald-500/20 hover:bg-emerald-500/40 text-emerald-300 font-mono font-bold px-2.5 py-1 rounded-lg transition-colors"
+          className="text-xs bg-go/15 hover:bg-go/30 text-go font-bold px-2.5 py-1 rounded-lg transition-colors"
         >
           Join
         </button>
       ) : (
         <button
           onClick={onInvite}
-          className="text-xs bg-gray-700/50 hover:bg-gray-700 text-gray-400 font-mono font-bold px-2.5 py-1 rounded-lg transition-colors opacity-0 group-hover:opacity-100"
+          className="text-xs bg-raise hover:bg-line text-muted font-bold px-2.5 py-1 rounded-lg transition-colors opacity-0 group-hover:opacity-100"
         >
           Invite
         </button>
@@ -92,23 +92,23 @@ function RequestRow({
   onDecline: (id: string) => void;
 }) {
   return (
-    <div className="flex items-center gap-3 py-2.5 px-3 rounded-xl bg-gray-700/30">
+    <div className="flex items-center gap-3 py-2.5 px-3 rounded-xl bg-raise">
       <div className="flex-1 min-w-0">
-        <p className="text-sm font-bold text-white truncate">
+        <p className="text-sm font-bold text-ink truncate">
           {requester.display_name ?? requester.username}
         </p>
-        <p className="text-xs text-gray-500 font-mono">wants to be friends</p>
+        <p className="text-xs text-faint">wants to be friends</p>
       </div>
       <div className="flex gap-1.5">
         <button
           onClick={() => onAccept(friendshipId)}
-          className="text-xs bg-emerald-500 hover:bg-emerald-400 text-white font-bold px-2.5 py-1 rounded-lg transition-colors"
+          className="text-xs bg-go hover:brightness-105 text-white font-bold px-2.5 py-1 rounded-lg transition-all"
         >
           ✓
         </button>
         <button
           onClick={() => onDecline(friendshipId)}
-          className="text-xs bg-gray-600 hover:bg-gray-500 text-white font-bold px-2.5 py-1 rounded-lg transition-colors"
+          className="text-xs bg-line hover:bg-faint text-ink font-bold px-2.5 py-1 rounded-lg transition-colors"
         >
           ✕
         </button>
@@ -144,35 +144,35 @@ export default function FriendsPanel({
           {/* Vertically-centered panel on the left */}
           <div className="fixed inset-x-2 sm:inset-x-auto sm:left-4 top-0 bottom-0 z-40 flex items-stretch py-3 pointer-events-none">
             <motion.div
-              className="pointer-events-auto w-full sm:w-80 bg-gray-900 border border-gray-700 flex flex-col shadow-2xl rounded-2xl overflow-hidden"
+              className="pointer-events-auto w-full sm:w-80 bg-surface border border-line flex flex-col shadow-2xl rounded-2xl overflow-hidden"
               initial={{ x: -60, opacity: 0 }}
               animate={{ x: 0, opacity: 1 }}
               exit={{ x: -60, opacity: 0 }}
               transition={{ type: "spring", damping: 28, stiffness: 300 }}
             >
               {/* Header */}
-              <div className="flex items-center justify-between px-4 py-4 border-b border-gray-700">
-                <h2 className="font-bold text-white font-mono tracking-widest">
-                  FRIENDS
+              <div className="flex items-center justify-between px-4 py-4 border-b border-line">
+                <h2 className="font-display text-lg text-ink tracking-wide">
+                  Friends
                 </h2>
                 <button
                   onClick={onClose}
-                  className="text-gray-500 hover:text-white transition-colors"
+                  className="text-faint hover:text-ink transition-colors"
                 >
                   ✕
                 </button>
               </div>
 
               {/* Tabs */}
-              <div className="flex border-b border-gray-700">
+              <div className="flex border-b border-line">
                 {(["friends", "requests", "find"] as Tab[]).map((t) => (
                   <button
                     key={t}
                     onClick={() => setTab(t)}
-                    className={`flex-1 py-2.5 text-xs font-mono font-bold capitalize transition-colors ${
+                    className={`flex-1 py-2.5 text-xs font-bold capitalize transition-colors ${
                       tab === t
-                        ? "text-emerald-400 border-b-2 border-emerald-400"
-                        : "text-gray-500 hover:text-gray-300"
+                        ? "text-accent border-b-2 border-accent"
+                        : "text-muted hover:text-ink"
                     }`}
                   >
                     {t}
@@ -191,7 +191,7 @@ export default function FriendsPanel({
                 {tab === "friends" && (
                   <div>
                     {friends.length === 0 ? (
-                      <p className="text-gray-500 text-sm font-mono text-center py-8">
+                      <p className="text-faint text-sm text-center py-8">
                         No friends yet.
                         <br />
                         Use the &quot;Find&quot; tab to add some!
@@ -213,7 +213,7 @@ export default function FriendsPanel({
                 {tab === "requests" && (
                   <div className="space-y-2">
                     {requests.length === 0 ? (
-                      <p className="text-gray-500 text-sm font-mono text-center py-8">
+                      <p className="text-faint text-sm text-center py-8">
                         No pending requests
                       </p>
                     ) : (
@@ -235,7 +235,7 @@ export default function FriendsPanel({
                   <div>
                     <div className="flex gap-2 mb-3">
                       <input
-                        className="flex-1 bg-gray-800 border border-gray-600 rounded-xl px-3 py-2 text-white text-sm font-mono placeholder-gray-600 focus:outline-none focus:border-emerald-500"
+                        className="flex-1 bg-raise border border-line rounded-xl px-3 py-2 text-ink text-sm placeholder-faint focus:outline-none focus:border-accent"
                         placeholder="Search name or tag#0000"
                         value={searchQuery}
                         onChange={(e) => setSearchQuery(e.target.value)}
@@ -244,7 +244,7 @@ export default function FriendsPanel({
                       <button
                         onClick={handleSearch}
                         disabled={loading}
-                        className="bg-emerald-600 hover:bg-emerald-500 text-white font-bold px-3 py-2 rounded-xl text-sm transition-colors disabled:opacity-40"
+                        className="bg-accent hover:brightness-105 text-white font-bold px-3 py-2 rounded-xl text-sm transition-all disabled:opacity-40"
                       >
                         {loading ? "…" : "Go"}
                       </button>
@@ -256,28 +256,28 @@ export default function FriendsPanel({
                         return (
                           <div
                             key={user.id}
-                            className="flex items-center gap-3 py-2 px-3 rounded-xl bg-gray-800/50"
+                            className="flex items-center gap-3 py-2 px-3 rounded-xl bg-raise"
                           >
                             <div className="flex-1 min-w-0">
-                              <p className="text-sm font-bold text-white truncate">
+                              <p className="text-sm font-bold text-ink truncate">
                                 {user.display_name ?? user.username}
                               </p>
-                              <p className="text-xs text-gray-500 font-mono">
+                              <p className="text-xs text-faint font-mono">
                                 @{user.discriminator ? formatTag(user.username, user.discriminator) : user.username}
                               </p>
                             </div>
                             {alreadyFriend ? (
-                              <span className="text-xs text-gray-500 font-mono">
+                              <span className="text-xs text-faint">
                                 Friends
                               </span>
                             ) : sent ? (
-                              <span className="text-xs text-emerald-400 font-mono">
+                              <span className="text-xs text-go">
                                 Sent ✓
                               </span>
                             ) : (
                               <button
                                 onClick={() => sendRequest(user.id)}
-                                className="text-xs bg-emerald-500/20 hover:bg-emerald-500/40 text-emerald-300 font-mono font-bold px-2.5 py-1 rounded-lg transition-colors"
+                                className="text-xs bg-accent/15 hover:bg-accent/30 text-accent font-bold px-2.5 py-1 rounded-lg transition-colors"
                               >
                                 + Add
                               </button>
@@ -291,14 +291,14 @@ export default function FriendsPanel({
               </div>
 
               {/* Footer: my profile */}
-              <div className="border-t border-gray-700 px-4 py-3 flex items-center gap-3">
-                <div className="w-8 h-8 rounded-full bg-emerald-500/20 border border-emerald-500/40 flex items-center justify-center text-emerald-400 text-sm font-bold">
+              <div className="border-t border-line px-4 py-3 flex items-center gap-3">
+                <div className="w-8 h-8 rounded-full bg-accent/15 border border-accent/40 flex items-center justify-center text-accent text-sm font-bold">
                   {(myProfile.display_name ?? myProfile.username)
                     .charAt(0)
                     .toUpperCase()}
                 </div>
                 <div className="flex-1 min-w-0">
-                  <p className="text-sm font-bold text-white truncate">
+                  <p className="text-sm font-bold text-ink truncate">
                     {myProfile.display_name ?? myProfile.username}
                   </p>
                   <button
@@ -308,14 +308,14 @@ export default function FriendsPanel({
                         : myProfile.username;
                       navigator.clipboard.writeText(tag);
                     }}
-                    className="text-xs text-gray-500 font-mono hover:text-emerald-400 transition-colors"
+                    className="text-xs text-faint font-mono hover:text-accent transition-colors"
                     title="Copy tag to clipboard"
                   >
                     @{myProfile.discriminator ? formatTag(myProfile.username, myProfile.discriminator) : myProfile.username}
                   </button>
                 </div>
                 {myProfile.is_premium && (
-                  <span className="text-xs font-mono text-yellow-400 bg-yellow-400/10 px-2 py-0.5 rounded-full">
+                  <span className="text-xs font-bold text-gold bg-gold/10 px-2 py-0.5 rounded-full">
                     PRO
                   </span>
                 )}

--- a/client/src/components/HomeDashboard.tsx
+++ b/client/src/components/HomeDashboard.tsx
@@ -7,6 +7,14 @@ import { useTasks } from "@/hooks/useTasks";
 import { useOnlineFriends } from "@/hooks/useOnlineFriends";
 import TaskSection from "./TaskSection";
 import FriendsOnlineSection from "./FriendsOnlineSection";
+import ThemeToggle from "./ThemeToggle";
+import {
+  UsersIcon,
+  ChartIcon,
+  PencilIcon,
+  StarIcon,
+  SignOutIcon,
+} from "./Icons";
 import type { Profile } from "@/lib/types";
 import type { Socket } from "socket.io-client";
 
@@ -36,13 +44,13 @@ function QuickStat({
   accent?: boolean;
 }) {
   return (
-    <div className="bg-gray-800/60 rounded-xl px-3 py-3 text-center flex-1">
-      <p className="text-gray-500 text-[10px] font-mono font-bold uppercase tracking-wider">
+    <div className="bg-surface border border-line rounded-xl px-3 py-3 text-center flex-1">
+      <p className="text-faint text-[10px] font-semibold uppercase tracking-wider">
         {label}
       </p>
       <p
-        className={`text-xl font-bold font-mono mt-0.5 ${
-          accent ? "text-emerald-400" : "text-white"
+        className={`text-xl font-bold font-mono tabular-nums mt-0.5 ${
+          accent ? "text-accent" : "text-ink"
         }`}
       >
         {value}
@@ -106,67 +114,62 @@ export default function HomeDashboard({
 
   return (
     <div
-      className="min-h-screen bg-gray-900 flex flex-col"
+      className="min-h-screen bg-bg texture-dots flex flex-col"
       onClick={() => setProfileMenuOpen(false)}
     >
       {/* Top bar */}
-      <div className="grid grid-cols-[1fr_auto_1fr] items-center px-4 py-2.5 bg-gray-800/80 border-b border-gray-700">
-        <div className="flex items-center justify-end pr-2">
+      <div className="flex items-center justify-between px-4 py-2.5 bg-surface/80 backdrop-blur border-b border-line">
+        <div className="flex items-center gap-2">
+          <span className="font-display text-lg text-ink tracking-wide">
+            Duodoro
+          </span>
+          {activeSessionId && (
+            <div
+              className="w-2 h-2 rounded-full bg-gold animate-pulse"
+              title="Session in progress"
+            />
+          )}
+        </div>
+
+        <div className="flex items-center gap-1">
           <button
             onClick={(e) => {
               e.stopPropagation();
               onOpenFriends();
             }}
-            className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-mono font-bold text-gray-400 hover:text-white hover:bg-gray-700 transition-all"
+            className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-semibold text-muted hover:text-ink hover:bg-raise transition-colors"
           >
-            {"👥"} <span className="hidden sm:inline">Friends</span>
+            <UsersIcon /> <span className="hidden sm:inline">Friends</span>
           </button>
-        </div>
-
-        <div className="flex flex-col items-center px-3 py-0.5">
-          <span className="text-white font-black font-mono tracking-widest text-sm">
-            Duodoro
-          </span>
-          <div
-            className={`w-2 h-2 rounded-full ${activeSessionId ? "bg-yellow-400" : "bg-red-400"}`}
-            style={{
-              boxShadow: activeSessionId
-                ? "0 0 6px #facc15"
-                : "0 0 6px #f87171",
-            }}
-          />
-        </div>
-
-        <div className="flex items-center gap-1.5 pl-2">
           <button
             onClick={(e) => {
               e.stopPropagation();
               onOpenStats();
             }}
-            className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-mono font-bold text-gray-400 hover:text-white hover:bg-gray-700 transition-all"
+            className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-semibold text-muted hover:text-ink hover:bg-raise transition-colors"
           >
-            {"📊"} <span className="hidden sm:inline">Stats</span>
+            <ChartIcon /> <span className="hidden sm:inline">Stats</span>
           </button>
-          <div className="flex-1" />
-          <div className="relative">
+          <ThemeToggle />
+          <div className="relative ml-1">
             <button
               onClick={(e) => {
                 e.stopPropagation();
                 setProfileMenuOpen((o) => !o);
               }}
-              className="w-8 h-8 rounded-full bg-emerald-500/20 border border-emerald-500/40 flex items-center justify-center text-emerald-400 text-sm font-bold hover:bg-emerald-500/30 transition-colors"
+              className="w-8 h-8 rounded-full bg-accent/15 border border-accent/40 flex items-center justify-center text-accent text-sm font-bold hover:bg-accent/25 transition-colors"
             >
               {initial}
             </button>
             {profileMenuOpen && (
               <div
-                className="absolute top-10 right-0 z-50 bg-gray-800 border border-gray-700 rounded-xl p-3 shadow-2xl min-w-44"
+                className="absolute top-10 right-0 z-50 bg-surface border border-line rounded-xl p-3 shadow-xl min-w-48"
                 onClick={(e) => e.stopPropagation()}
               >
-                <p className="text-white font-bold text-sm mb-0.5">
+                <p className="text-ink font-bold text-sm mb-0.5">
                   {displayName}
                 </p>
-                <p className="text-gray-500 text-xs font-mono mb-3">
+                <p className="text-faint text-xs font-mono mb-3">
                   @{profile.discriminator ? formatTag(profile.username, profile.discriminator) : profile.username}
                 </p>
                 <button
@@ -174,9 +177,9 @@ export default function HomeDashboard({
                     onEditAvatar();
                     setProfileMenuOpen(false);
                   }}
-                  className="w-full text-left text-xs font-mono text-gray-400 hover:text-white py-1.5 transition-colors"
+                  className="w-full flex items-center gap-2 text-left text-xs text-muted hover:text-ink py-1.5 transition-colors"
                 >
-                  {"✏️"} Edit character
+                  <PencilIcon className="w-3.5 h-3.5" /> Edit character
                 </button>
                 {!profile.username_changed && (
                   <button
@@ -184,9 +187,9 @@ export default function HomeDashboard({
                       onChangeUsername();
                       setProfileMenuOpen(false);
                     }}
-                    className="w-full text-left text-xs font-mono text-emerald-400 hover:text-emerald-300 py-1.5 transition-colors"
+                    className="w-full flex items-center gap-2 text-left text-xs text-accent hover:text-accent-deep py-1.5 transition-colors"
                   >
-                    {"✏️"} Change username (1x)
+                    <PencilIcon className="w-3.5 h-3.5" /> Change username (1x)
                   </button>
                 )}
                 <button
@@ -194,16 +197,16 @@ export default function HomeDashboard({
                     onChangeDisplayName();
                     setProfileMenuOpen(false);
                   }}
-                  className="w-full text-left text-xs font-mono text-gray-400 hover:text-white py-1.5 transition-colors"
+                  className="w-full flex items-center gap-2 text-left text-xs text-muted hover:text-ink py-1.5 transition-colors"
                 >
-                  {"✏️"} Change display name
+                  <PencilIcon className="w-3.5 h-3.5" /> Change display name
                 </button>
                 {!isPremium && (
                   <button
                     onClick={() => setProfileMenuOpen(false)}
-                    className="w-full text-left text-xs font-mono text-yellow-400 hover:text-yellow-300 py-1.5 transition-colors"
+                    className="w-full flex items-center gap-2 text-left text-xs text-gold hover:text-gold-deep py-1.5 transition-colors"
                   >
-                    {"⭐"} Upgrade to Premium
+                    <StarIcon className="w-3.5 h-3.5" /> Upgrade to Premium
                   </button>
                 )}
                 <button
@@ -211,9 +214,9 @@ export default function HomeDashboard({
                     onSignOut();
                     setProfileMenuOpen(false);
                   }}
-                  className="w-full text-left text-xs font-mono text-gray-400 hover:text-red-400 py-1.5 transition-colors"
+                  className="w-full flex items-center gap-2 text-left text-xs text-muted hover:text-danger py-1.5 transition-colors"
                 >
-                  Sign out
+                  <SignOutIcon className="w-3.5 h-3.5" /> Sign out
                 </button>
               </div>
             )}
@@ -225,12 +228,10 @@ export default function HomeDashboard({
       <div className="flex-1 overflow-y-auto">
         <div className="max-w-lg mx-auto px-4 py-6 space-y-6">
           <div>
-            <h1 className="text-2xl font-bold text-white font-mono">
+            <h1 className="font-display text-3xl text-ink">
               {greeting}, {displayName}
             </h1>
-            <p className="text-gray-500 text-sm font-mono mt-0.5">
-              Ready to focus?
-            </p>
+            <p className="text-muted text-sm mt-1">Ready to focus?</p>
           </div>
 
           {!loading && personalStats && (
@@ -280,22 +281,24 @@ export default function HomeDashboard({
           />
 
           <div>
-            <h2 className="text-sm font-bold font-mono text-gray-400 uppercase tracking-wider mb-3">
-              Choose World
+            <h2 className="text-xs font-semibold text-faint uppercase tracking-wider mb-3">
+              Choose a world
             </h2>
             <div className="grid grid-cols-4 gap-2">
               {WORLDS.map((w) => (
                 <button
                   key={w.id}
                   onClick={() => setSelectedWorld(w.id)}
-                  className={`py-2.5 px-1 rounded-xl border text-xs font-mono transition-all text-center ${
+                  className={`py-2.5 px-1 rounded-xl border text-xs transition-all text-center ${
                     selectedWorld === w.id
-                      ? "border-emerald-500 bg-emerald-500/20 text-emerald-300"
-                      : "border-gray-700 bg-gray-800/50 text-gray-400 hover:border-gray-600"
+                      ? "border-accent bg-accent/10 text-ink shadow-sm"
+                      : "border-line bg-surface text-muted hover:border-faint"
                   }`}
                 >
                   <span className="text-base block">{w.emoji}</span>
-                  <span className="mt-0.5 block text-[10px]">{w.label}</span>
+                  <span className="mt-0.5 block text-[10px] font-medium">
+                    {w.label}
+                  </span>
                 </button>
               ))}
             </div>
@@ -305,20 +308,20 @@ export default function HomeDashboard({
             {activeSessionId && (
               <button
                 onClick={onRejoinSession}
-                className="w-full bg-yellow-500 hover:bg-yellow-400 active:scale-[0.98] text-gray-900 font-black px-8 py-4 rounded-2xl shadow-lg shadow-yellow-500/20 font-mono tracking-widest transition-all border-b-4 border-yellow-700 text-lg"
+                className="w-full bg-gold hover:brightness-105 active:scale-[0.98] text-white font-display px-8 py-4 rounded-2xl shadow-lg tracking-wide transition-all border-b-4 border-gold-deep text-xl"
               >
-                RETURN TO SESSION
+                Return to session
               </button>
             )}
             <button
               onClick={() => onFocus(selectedWorld)}
-              className={`w-full active:scale-[0.98] text-white font-black px-8 rounded-2xl shadow-lg font-mono tracking-widest transition-all border-b-4 ${
+              className={`w-full active:scale-[0.98] text-white font-display px-8 rounded-2xl shadow-lg tracking-wide transition-all border-b-4 ${
                 activeSessionId
-                  ? "bg-gray-700 hover:bg-gray-600 shadow-gray-700/20 border-gray-800 py-3 text-sm"
-                  : "bg-emerald-500 hover:bg-emerald-400 shadow-emerald-500/20 border-emerald-700 py-4 text-lg"
+                  ? "bg-raise hover:bg-line text-ink border-line py-3 text-base"
+                  : "bg-accent hover:brightness-105 border-accent-deep py-4 text-xl"
               }`}
             >
-              {activeSessionId ? "NEW SESSION" : "FOCUS"}
+              {activeSessionId ? "New session" : "Focus"}
             </button>
           </div>
         </div>

--- a/client/src/components/Icons.tsx
+++ b/client/src/components/Icons.tsx
@@ -1,0 +1,118 @@
+// Small stroke icon set — replaces emoji in UI chrome (buttons, menus).
+// All icons inherit color via currentColor and size via className (default 16px).
+
+interface IconProps {
+  className?: string;
+}
+
+function base(className?: string) {
+  return {
+    viewBox: "0 0 24 24",
+    fill: "none",
+    stroke: "currentColor",
+    strokeWidth: 2,
+    strokeLinecap: "round" as const,
+    strokeLinejoin: "round" as const,
+    className: className ?? "w-4 h-4",
+  };
+}
+
+export function SunIcon({ className }: IconProps) {
+  return (
+    <svg {...base(className)}>
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+    </svg>
+  );
+}
+
+export function MoonIcon({ className }: IconProps) {
+  return (
+    <svg {...base(className)}>
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
+  );
+}
+
+export function UsersIcon({ className }: IconProps) {
+  return (
+    <svg {...base(className)}>
+      <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+      <circle cx="9" cy="7" r="4" />
+      <path d="M23 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" />
+    </svg>
+  );
+}
+
+export function ChartIcon({ className }: IconProps) {
+  return (
+    <svg {...base(className)}>
+      <path d="M4 20V10M10 20V4M16 20v-7M22 20H2" />
+    </svg>
+  );
+}
+
+export function NoteIcon({ className }: IconProps) {
+  return (
+    <svg {...base(className)}>
+      <path d="M14 3v5h5M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-5z" />
+      <path d="M9 13h6M9 17h4" />
+    </svg>
+  );
+}
+
+export function PencilIcon({ className }: IconProps) {
+  return (
+    <svg {...base(className)}>
+      <path d="M17 3a2.83 2.83 0 0 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z" />
+    </svg>
+  );
+}
+
+export function StarIcon({ className }: IconProps) {
+  return (
+    <svg {...base(className)}>
+      <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+    </svg>
+  );
+}
+
+export function HeartIcon({ className }: IconProps) {
+  return (
+    <svg {...base(className)}>
+      <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+    </svg>
+  );
+}
+
+export function CloseIcon({ className }: IconProps) {
+  return (
+    <svg {...base(className)}>
+      <path d="M18 6L6 18M6 6l12 12" />
+    </svg>
+  );
+}
+
+export function PlusIcon({ className }: IconProps) {
+  return (
+    <svg {...base(className)}>
+      <path d="M12 5v14M5 12h14" />
+    </svg>
+  );
+}
+
+export function CheckIcon({ className }: IconProps) {
+  return (
+    <svg {...base(className)}>
+      <path d="M20 6L9 17l-5-5" />
+    </svg>
+  );
+}
+
+export function SignOutIcon({ className }: IconProps) {
+  return (
+    <svg {...base(className)}>
+      <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4M16 17l5-5-5-5M21 12H9" />
+    </svg>
+  );
+}

--- a/client/src/components/InvitePopup.tsx
+++ b/client/src/components/InvitePopup.tsx
@@ -13,22 +13,22 @@ export default function InvitePopup({
   const world = WORLDS.find((w) => w.id === invite.worldId);
   return (
     <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 backdrop-blur-sm">
-      <div className="bg-gray-800 border border-gray-600 rounded-2xl p-6 max-w-xs w-full shadow-2xl text-center space-y-4">
+      <div className="bg-surface border border-line rounded-2xl p-6 max-w-xs w-full shadow-2xl text-center space-y-4">
         <p className="text-3xl">{world?.emoji ?? "🌍"}</p>
-        <p className="text-white font-bold font-mono text-sm">
+        <p className="text-ink font-bold text-sm">
           {invite.fromName} invited you to focus
           {world ? ` in ${world.label}` : ""}!
         </p>
         <div className="flex gap-3">
           <button
             onClick={onDismiss}
-            className="flex-1 py-3 sm:py-2.5 rounded-xl bg-gray-700 hover:bg-gray-600 text-gray-300 font-mono font-bold text-sm transition-colors"
+            className="flex-1 py-3 sm:py-2.5 rounded-xl bg-raise hover:bg-line text-muted font-bold text-sm transition-colors"
           >
             Dismiss
           </button>
           <button
             onClick={onAccept}
-            className="flex-1 py-3 sm:py-2.5 rounded-xl bg-emerald-500 hover:bg-emerald-400 text-white font-mono font-bold text-sm transition-colors"
+            className="flex-1 py-3 sm:py-2.5 rounded-xl bg-accent hover:brightness-105 text-white font-bold text-sm transition-all"
           >
             Accept
           </button>

--- a/client/src/components/LandingPage.tsx
+++ b/client/src/components/LandingPage.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { motion } from "framer-motion";
 import PixelCharacter from "./PixelCharacter";
+import ThemeToggle from "./ThemeToggle";
 import { signInWithProvider } from "@/lib/supabase";
 import { DEFAULT_AVATAR } from "@/lib/avatarData";
 
@@ -13,6 +14,13 @@ const RIGHT_CHAR = {
   outfitColor: "#C9428B",
   skinColor: "#F3C08C",
 };
+
+const FEATURES = [
+  "Synchronized focus timer",
+  "Friends & invites",
+  "Shared session goals",
+  "Stats & streaks",
+];
 
 function DiscordIcon() {
   return (
@@ -45,6 +53,117 @@ function GoogleIcon() {
   );
 }
 
+/** The little pixel night scene, framed like a window into the app */
+function HeroScene() {
+  return (
+    <div
+      className="relative w-full h-56 sm:h-64 rounded-2xl overflow-hidden border border-line shadow-xl"
+      style={{
+        background:
+          "linear-gradient(180deg, #0f172a 0%, #1e3a5f 60%, #7EC8E3 100%)",
+      }}
+    >
+      {/* Stars */}
+      {[...Array(24)].map((_, i) => (
+        <div
+          key={i}
+          className="absolute rounded-full bg-white"
+          style={{
+            width: i % 4 === 0 ? 2 : 1,
+            height: i % 4 === 0 ? 2 : 1,
+            left: `${(i * 37 + 11) % 100}%`,
+            top: `${(i * 17 + 5) % 55}%`,
+            opacity: 0.5 + (i % 3) * 0.15,
+          }}
+        />
+      ))}
+
+      {/* Ground */}
+      <div
+        className="absolute bottom-0 left-0 right-0"
+        style={{
+          height: "30%",
+          background: "linear-gradient(180deg, #4a7c59 0%, #3d6849 100%)",
+        }}
+      >
+        <div className="absolute top-0 left-0 right-0 h-1.5 bg-green-600/40" />
+      </div>
+
+      {/* Trees */}
+      {[8, 18, 76, 88].map((left, i) => (
+        <div
+          key={i}
+          className="absolute bottom-[26%]"
+          style={{ left: `${left}%` }}
+        >
+          <div className="flex flex-col items-center">
+            <div
+              className="w-0 h-0"
+              style={{
+                borderLeft: "8px solid transparent",
+                borderRight: "8px solid transparent",
+                borderBottom: "12px solid #2d6a4f",
+              }}
+            />
+            <div
+              className="w-0 h-0 -mt-1"
+              style={{
+                borderLeft: "10px solid transparent",
+                borderRight: "10px solid transparent",
+                borderBottom: "14px solid #40916c",
+              }}
+            />
+            <div
+              className="w-0 h-0 -mt-1"
+              style={{
+                borderLeft: "12px solid transparent",
+                borderRight: "12px solid transparent",
+                borderBottom: "14px solid #52b788",
+              }}
+            />
+            <div className="w-2 h-6 bg-amber-900/70" />
+          </div>
+        </div>
+      ))}
+
+      {/* Heart at center */}
+      <motion.div
+        className="absolute bottom-[28%] left-1/2 -translate-x-1/2 text-2xl"
+        animate={{ y: [0, -8, 0], scale: [1, 1.15, 1] }}
+        transition={{ duration: 2.5, repeat: Infinity, ease: "easeInOut" }}
+      >
+        ❤️
+      </motion.div>
+
+      {/* Demo characters walking toward each other */}
+      <motion.div
+        className="absolute bottom-[26%]"
+        animate={{ left: ["5%", "38%"] }}
+        transition={{
+          duration: 4,
+          repeat: Infinity,
+          repeatType: "reverse",
+          ease: "linear",
+        }}
+      >
+        <PixelCharacter {...LEFT_CHAR} anim="walk" facing="right" size={3} />
+      </motion.div>
+      <motion.div
+        className="absolute bottom-[26%]"
+        animate={{ right: ["5%", "38%"] }}
+        transition={{
+          duration: 4,
+          repeat: Infinity,
+          repeatType: "reverse",
+          ease: "linear",
+        }}
+      >
+        <PixelCharacter {...RIGHT_CHAR} anim="walk" facing="left" size={3} />
+      </motion.div>
+    </div>
+  );
+}
+
 export default function LandingPage() {
   const [loading, setLoading] = useState<"google" | "discord" | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -61,174 +180,73 @@ export default function LandingPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-950 text-white flex flex-col overflow-hidden">
-      {/* ── Pixel sky scene ── */}
-      <div
-        className="relative w-full flex-shrink-0 overflow-hidden"
-        style={{
-          height: "55vh",
-          background:
-            "linear-gradient(180deg, #0f172a 0%, #1e3a5f 60%, #7EC8E3 100%)",
-        }}
-      >
-        {/* Stars */}
-        {[...Array(30)].map((_, i) => (
-          <div
-            key={i}
-            className="absolute rounded-full bg-white"
-            style={{
-              width: i % 4 === 0 ? 2 : 1,
-              height: i % 4 === 0 ? 2 : 1,
-              left: `${(i * 37 + 11) % 100}%`,
-              top: `${(i * 17 + 5) % 55}%`,
-              opacity: 0.5 + (i % 3) * 0.15,
-            }}
-          />
-        ))}
+    <div className="min-h-screen bg-bg texture-dots flex flex-col">
+      {/* Top bar */}
+      <header className="flex items-center justify-between px-5 py-4 max-w-2xl w-full mx-auto">
+        <span className="font-display text-xl text-ink tracking-wide">
+          Duodoro
+        </span>
+        <ThemeToggle />
+      </header>
 
-        {/* Ground */}
-        <div
-          className="absolute bottom-0 left-0 right-0"
-          style={{
-            height: "30%",
-            background: "linear-gradient(180deg, #4a7c59 0%, #3d6849 100%)",
-          }}
-        >
-          <div className="absolute top-0 left-0 right-0 h-1.5 bg-green-600/40" />
-        </div>
-
-        {/* Trees */}
-        {[8, 18, 76, 88].map((left, i) => (
-          <div
-            key={i}
-            className="absolute bottom-[26%]"
-            style={{ left: `${left}%` }}
-          >
-            <div className="flex flex-col items-center">
-              <div
-                className="w-0 h-0"
-                style={{
-                  borderLeft: "8px solid transparent",
-                  borderRight: "8px solid transparent",
-                  borderBottom: "12px solid #2d6a4f",
-                }}
-              />
-              <div
-                className="w-0 h-0 -mt-1"
-                style={{
-                  borderLeft: "10px solid transparent",
-                  borderRight: "10px solid transparent",
-                  borderBottom: "14px solid #40916c",
-                }}
-              />
-              <div
-                className="w-0 h-0 -mt-1"
-                style={{
-                  borderLeft: "12px solid transparent",
-                  borderRight: "12px solid transparent",
-                  borderBottom: "14px solid #52b788",
-                }}
-              />
-              <div className="w-2 h-6 bg-amber-900/70" />
-            </div>
+      {/* Hero */}
+      <main className="flex-1 flex flex-col items-center justify-center px-5 pb-12 w-full">
+        <div className="w-full max-w-md flex flex-col items-center gap-7">
+          <div className="text-center">
+            <h1 className="font-display text-5xl sm:text-6xl text-ink leading-none">
+              Focus together
+            </h1>
+            <p className="mt-3 text-muted text-base sm:text-lg">
+              A shared pomodoro timer for long-distance couples and friends.
+              Walk toward each other while you work — meet in the middle on
+              every break.
+            </p>
           </div>
-        ))}
 
-        {/* Heart at center */}
-        <motion.div
-          className="absolute bottom-[28%] left-1/2 -translate-x-1/2 text-3xl"
-          animate={{ y: [0, -8, 0], scale: [1, 1.15, 1] }}
-          transition={{ duration: 2.5, repeat: Infinity, ease: "easeInOut" }}
-        >
-          ❤️
-        </motion.div>
+          <HeroScene />
 
-        {/* Demo characters walking toward each other */}
-        <motion.div
-          className="absolute bottom-[26%]"
-          animate={{ left: ["5%", "40%"] }}
-          transition={{
-            duration: 4,
-            repeat: Infinity,
-            repeatType: "reverse",
-            ease: "linear",
-          }}
-        >
-          <PixelCharacter {...LEFT_CHAR} anim="walk" facing="right" size={3} />
-        </motion.div>
-        <motion.div
-          className="absolute bottom-[26%]"
-          animate={{ right: ["5%", "40%"] }}
-          transition={{
-            duration: 4,
-            repeat: Infinity,
-            repeatType: "reverse",
-            ease: "linear",
-          }}
-        >
-          <PixelCharacter {...RIGHT_CHAR} anim="walk" facing="left" size={3} />
-        </motion.div>
-      </div>
+          {/* Auth buttons */}
+          <div className="flex flex-col gap-3 w-full max-w-xs">
+            <button
+              onClick={() => handleAuth("google")}
+              disabled={loading !== null}
+              className="flex items-center justify-center gap-3 w-full bg-surface hover:bg-raise active:scale-[0.98] text-ink font-semibold py-3.5 px-6 rounded-xl border border-line transition-all shadow-sm disabled:opacity-60"
+            >
+              <GoogleIcon />
+              {loading === "google" ? "Signing in..." : "Continue with Google"}
+            </button>
 
-      {/* ── Copy + CTAs ── */}
-      <div className="flex-1 flex flex-col items-center justify-center px-6 py-10 gap-6 text-center">
-        <div>
-          <h1 className="text-5xl font-black font-mono tracking-tight text-white drop-shadow-lg">
-            Duodoro
-          </h1>
-          <p className="mt-2 text-gray-400 text-lg font-mono">
-            Focus together, no matter the distance
+            <button
+              onClick={() => handleAuth("discord")}
+              disabled={loading !== null}
+              className="flex items-center justify-center gap-3 w-full bg-[#5865F2] hover:bg-[#4752c4] active:scale-[0.98] text-white font-semibold py-3.5 px-6 rounded-xl transition-all shadow-sm disabled:opacity-60"
+            >
+              <DiscordIcon />
+              {loading === "discord" ? "Signing in..." : "Continue with Discord"}
+            </button>
+
+            {error && (
+              <p className="text-danger text-sm text-center">{error}</p>
+            )}
+          </div>
+
+          {/* Feature pills */}
+          <div className="flex flex-wrap justify-center gap-2">
+            {FEATURES.map((f) => (
+              <span
+                key={f}
+                className="bg-surface text-muted text-xs px-3 py-1.5 rounded-full border border-line"
+              >
+                {f}
+              </span>
+            ))}
+          </div>
+
+          <p className="text-faint text-xs max-w-xs text-center">
+            By signing in you agree to our terms of service. No spam, ever.
           </p>
         </div>
-
-        {/* Feature pills */}
-        <div className="flex flex-wrap justify-center gap-2">
-          {[
-            "👥 Friends list",
-            "🎮 Break mini-game",
-            "📝 Shared journal",
-            "🐾 Pets (Premium)",
-          ].map((f) => (
-            <span
-              key={f}
-              className="bg-gray-800 text-gray-300 text-xs font-mono px-3 py-1.5 rounded-full border border-gray-700"
-            >
-              {f}
-            </span>
-          ))}
-        </div>
-
-        {/* Auth buttons */}
-        <div className="flex flex-col gap-3 w-full max-w-xs">
-          <button
-            onClick={() => handleAuth("google")}
-            disabled={loading !== null}
-            className="flex items-center justify-center gap-3 w-full bg-white hover:bg-gray-100 active:scale-95 text-gray-900 font-bold py-3.5 px-6 rounded-xl transition-all shadow-lg disabled:opacity-60"
-          >
-            <GoogleIcon />
-            {loading === "google" ? "Signing in..." : "Continue with Google"}
-          </button>
-
-          <button
-            onClick={() => handleAuth("discord")}
-            disabled={loading !== null}
-            className="flex items-center justify-center gap-3 w-full bg-[#5865F2] hover:bg-[#4752c4] active:scale-95 text-white font-bold py-3.5 px-6 rounded-xl transition-all shadow-lg disabled:opacity-60"
-          >
-            <DiscordIcon />
-            {loading === "discord" ? "Signing in..." : "Continue with Discord"}
-          </button>
-
-          {error && (
-            <p className="text-red-400 text-sm font-mono text-center">
-              {error}
-            </p>
-          )}
-        </div>
-
-        <p className="text-gray-600 text-xs font-mono max-w-xs">
-          By signing in you agree to our terms of service. No spam, ever.
-        </p>
-      </div>
+      </main>
     </div>
   );
 }

--- a/client/src/components/PetPicker.tsx
+++ b/client/src/components/PetPicker.tsx
@@ -14,13 +14,13 @@ export default function PetPicker({
 }) {
   return (
     <div className="flex items-center gap-2 flex-wrap justify-center">
-      <span className="text-gray-600 text-xs font-mono">PET:</span>
+      <span className="text-faint text-xs font-medium uppercase tracking-wide">Pet:</span>
       <button
         onClick={() => (isPremium ? onSelect(null) : onPremiumClick())}
         className={`w-7 h-7 rounded-full border text-xs flex items-center justify-center transition-all ${
           selected === null
-            ? "border-gray-500 bg-gray-700 text-gray-300"
-            : "border-gray-700 bg-gray-800 text-gray-600 hover:border-gray-600"
+            ? "border-faint bg-raise text-ink"
+            : "border-line bg-surface text-faint hover:border-faint"
         }`}
         title="No pet"
       >
@@ -32,8 +32,8 @@ export default function PetPicker({
           onClick={() => (isPremium ? onSelect(type) : onPremiumClick())}
           className={`w-7 h-7 rounded-full border text-sm flex items-center justify-center transition-all ${
             selected === type
-              ? "border-emerald-500 bg-emerald-500/20"
-              : "border-gray-700 bg-gray-800 hover:border-gray-500"
+              ? "border-accent bg-accent/15"
+              : "border-line bg-surface hover:border-faint"
           } ${!isPremium ? "opacity-50" : ""}`}
           title={isPremium ? label : `${label} (Premium)`}
         >

--- a/client/src/components/PremiumModal.tsx
+++ b/client/src/components/PremiumModal.tsx
@@ -56,13 +56,13 @@ export default function PremiumModal({ open, onClose }: Props) {
             transition={{ type: "spring", duration: 0.4 }}
           >
             <div
-              className="bg-gray-900 border border-gray-700 rounded-2xl p-8 max-w-sm w-full shadow-2xl relative"
+              className="bg-surface border border-line rounded-2xl p-8 max-w-sm w-full shadow-2xl relative"
               onClick={(e) => e.stopPropagation()}
             >
               {/* Close */}
               <button
                 onClick={onClose}
-                className="absolute top-2 right-2 sm:top-4 sm:right-4 w-10 h-10 sm:w-auto sm:h-auto flex items-center justify-center text-gray-500 hover:text-white transition-colors text-xl"
+                className="absolute top-2 right-2 sm:top-4 sm:right-4 w-10 h-10 sm:w-auto sm:h-auto flex items-center justify-center text-faint hover:text-ink transition-colors text-xl"
               >
                 ✕
               </button>
@@ -70,10 +70,10 @@ export default function PremiumModal({ open, onClose }: Props) {
               {/* Header */}
               <div className="text-center mb-6">
                 <div className="text-5xl mb-3">🐾</div>
-                <h2 className="text-2xl font-black font-mono text-white">
+                <h2 className="font-display text-2xl text-ink">
                   Duodoro Premium
                 </h2>
-                <p className="text-gray-400 text-sm mt-1 font-mono">
+                <p className="text-muted text-sm mt-1">
                   Coming soon — join the waitlist
                 </p>
               </div>
@@ -83,7 +83,7 @@ export default function PremiumModal({ open, onClose }: Props) {
                 {FEATURES.map((f) => (
                   <li
                     key={f.label}
-                    className="flex items-center gap-3 text-sm text-gray-300"
+                    className="flex items-center gap-3 text-sm text-ink"
                   >
                     <span className="text-xl flex-shrink-0">{f.icon}</span>
                     <span>{f.label}</span>
@@ -93,7 +93,7 @@ export default function PremiumModal({ open, onClose }: Props) {
 
               {/* Waitlist signup */}
               {status === "done" ? (
-                <div className="text-center text-emerald-400 font-mono text-sm py-3">
+                <div className="text-center text-go text-sm py-3">
                   ✓ You&apos;re on the list! We&apos;ll let you know when
                   Premium launches.
                 </div>
@@ -106,22 +106,22 @@ export default function PremiumModal({ open, onClose }: Props) {
                       value={email}
                       onChange={(e) => setEmail(e.target.value)}
                       onKeyDown={(e) => e.key === "Enter" && handleWaitlist()}
-                      className="flex-1 bg-gray-800 border border-gray-600 rounded-xl px-4 py-2.5 text-white text-sm font-mono placeholder-gray-600 focus:outline-none focus:border-emerald-500"
+                      className="flex-1 bg-raise border border-line rounded-xl px-4 py-2.5 text-ink text-sm placeholder-faint focus:outline-none focus:border-accent"
                     />
                     <button
                       onClick={handleWaitlist}
                       disabled={status === "loading" || !email.includes("@")}
-                      className="bg-emerald-500 hover:bg-emerald-400 active:scale-95 disabled:opacity-40 text-white font-bold px-4 py-2.5 rounded-xl transition-all font-mono text-sm"
+                      className="bg-accent hover:brightness-105 active:scale-95 disabled:opacity-40 text-white font-bold px-4 py-2.5 rounded-xl transition-all text-sm"
                     >
                       {status === "loading" ? "..." : "Notify me"}
                     </button>
                   </div>
                   {status === "error" && (
-                    <p className="text-red-400 text-xs font-mono mt-2 text-center">
+                    <p className="text-danger text-xs mt-2 text-center">
                       Something went wrong. Try again.
                     </p>
                   )}
-                  <p className="text-gray-600 text-xs font-mono text-center mt-3">
+                  <p className="text-faint text-xs text-center mt-3">
                     Stripe integration coming soon • No spam, ever
                   </p>
                 </>

--- a/client/src/components/SessionHUD.tsx
+++ b/client/src/components/SessionHUD.tsx
@@ -22,7 +22,7 @@ function DurationSlider({
 }) {
   return (
     <div className="flex items-center gap-3 w-full">
-      <span className="text-gray-500 text-xs font-mono w-14 text-right shrink-0">
+      <span className="text-muted text-xs font-medium w-14 text-right shrink-0">
         {label}
       </span>
       <input
@@ -32,9 +32,10 @@ function DurationSlider({
         step={step}
         value={value}
         onChange={(e) => onChange(Number(e.target.value))}
-        className="flex-1 accent-emerald-500 h-1.5"
+        className="flex-1 h-1.5"
+        style={{ accentColor: "var(--accent)" }}
       />
-      <span className="text-emerald-400 text-xs font-mono font-bold w-12 shrink-0">
+      <span className="text-accent text-xs font-mono font-bold w-12 shrink-0">
         {value}
         {unit}
       </span>
@@ -56,8 +57,8 @@ function PhaseDots({
           key={i}
           className={`w-2.5 h-2.5 rounded-full border transition-all ${
             i < filled
-              ? "bg-emerald-500 border-emerald-500"
-              : "bg-transparent border-gray-600"
+              ? "bg-accent border-accent"
+              : "bg-transparent border-line"
           }`}
         />
       ))}
@@ -92,11 +93,11 @@ interface SessionHUDProps {
 }
 
 const phaseLabel: Record<GamePhase, (playerCount: number) => string> = {
-  waiting: (pc) => (pc < 1 ? "SETTING UP..." : "READY TO FOCUS"),
-  focus: () => "FOCUS TIME",
-  celebration: () => "YOU MET!",
-  break: () => "BREAK TIME",
-  returning: () => "HEADING BACK...",
+  waiting: (pc) => (pc < 1 ? "Setting up..." : "Ready to focus"),
+  focus: () => "Focus time",
+  celebration: () => "You met!",
+  break: () => "Break time",
+  returning: () => "Heading back...",
 };
 
 export default function SessionHUD({
@@ -127,8 +128,8 @@ export default function SessionHUD({
 
   return (
     <div className="flex-1 flex items-start justify-center px-6 pt-4 overflow-y-auto">
-      <div className="bg-gray-900/80 backdrop-blur-sm border border-gray-700/60 rounded-2xl px-8 py-5 flex flex-col items-center gap-3 shadow-2xl mb-4">
-        <div className="text-sm font-mono font-bold tracking-widest text-gray-400 uppercase">
+      <div className="bg-surface/85 backdrop-blur border border-line rounded-2xl px-8 py-5 flex flex-col items-center gap-3 shadow-xl mb-4">
+        <div className="font-display text-lg tracking-wide text-ink">
           {phaseLabel[phase](playerCount)}
         </div>
 
@@ -137,17 +138,13 @@ export default function SessionHUD({
         )}
 
         {showTimer && (
-          <div className="text-6xl font-mono font-bold tracking-widest tabular-nums drop-shadow-lg flex flex-col items-center">
+          <div className="text-6xl font-mono font-bold tabular-nums flex flex-col items-center">
             {phase === "focus" && serverMode === "flow" && (
-              <span className="text-xs text-emerald-500 mb-1 tracking-widest font-bold">
-                FLOW ELAPSED
+              <span className="text-xs text-calm mb-1 tracking-widest font-bold uppercase">
+                Flow elapsed
               </span>
             )}
-            <span
-              className={
-                phase === "break" ? "text-blue-400" : "text-emerald-400"
-              }
-            >
+            <span className={phase === "break" ? "text-calm" : "text-accent"}>
               {phase === "focus" && serverMode === "flow"
                 ? formatTime(Math.round(flowElapsed))
                 : formatTime(timeLeft)}
@@ -157,23 +154,23 @@ export default function SessionHUD({
 
         {!sessionStarted && phase === "waiting" && (
           <div className="w-full max-w-xs space-y-4 mt-1">
-            <div className="flex bg-gray-800 rounded-lg p-1 border border-gray-700">
+            <div className="flex bg-raise rounded-lg p-1 border border-line">
               <button
                 onClick={() => onTimerModeChange("pomodoro")}
-                className={`flex-1 py-2 sm:py-1 text-xs font-mono font-bold rounded-md transition-colors ${
+                className={`flex-1 py-2 sm:py-1 text-xs font-bold rounded-md transition-colors ${
                   timerMode === "pomodoro"
-                    ? "bg-emerald-500 text-white"
-                    : "text-gray-400 hover:text-white"
+                    ? "bg-accent text-white"
+                    : "text-muted hover:text-ink"
                 }`}
               >
                 Pomodoro
               </button>
               <button
                 onClick={() => onTimerModeChange("flow")}
-                className={`flex-1 py-2 sm:py-1 text-xs font-mono font-bold rounded-md transition-colors ${
+                className={`flex-1 py-2 sm:py-1 text-xs font-bold rounded-md transition-colors ${
                   timerMode === "flow"
-                    ? "bg-blue-500 text-white"
-                    : "text-gray-400 hover:text-white"
+                    ? "bg-calm text-white"
+                    : "text-muted hover:text-ink"
                 }`}
               >
                 Flowmodoro
@@ -182,7 +179,7 @@ export default function SessionHUD({
             {timerMode === "pomodoro" ? (
               <>
                 <DurationSlider
-                  label="FOCUS"
+                  label="Focus"
                   value={focusDuration}
                   onChange={onFocusDurationChange}
                   min={5}
@@ -191,7 +188,7 @@ export default function SessionHUD({
                   unit="m"
                 />
                 <DurationSlider
-                  label="BREAK"
+                  label="Break"
                   value={breakDuration}
                   onChange={onBreakDurationChange}
                   min={1}
@@ -201,7 +198,7 @@ export default function SessionHUD({
                 />
               </>
             ) : (
-              <div className="text-center text-xs text-gray-400 font-mono px-4 py-2 bg-gray-800/50 rounded-lg border border-gray-700/50">
+              <div className="text-center text-xs text-muted px-4 py-2 bg-raise rounded-lg border border-line">
                 Focus as long as you want. When you&apos;re done, you&apos;ll
                 earn a break tailored to how long you worked (5:1 ratio).
               </div>
@@ -221,22 +218,26 @@ export default function SessionHUD({
         {/* Player indicators */}
         <div className="flex items-center gap-2">
           <div
-            className={`w-2 h-2 rounded-full ${playerCount >= 1 ? "bg-emerald-400" : "bg-gray-600"}`}
+            className={`w-2 h-2 rounded-full ${playerCount >= 1 ? "bg-go" : "bg-faint"}`}
           />
-          <span className="text-gray-500 text-xs font-mono">YOU</span>
+          <span className="text-muted text-xs font-medium uppercase tracking-wide">
+            You
+          </span>
           {playerCount >= 2 && (
             <>
-              <div className="w-8 h-px bg-gray-700" />
-              <div className="w-2 h-2 rounded-full bg-emerald-400" />
-              <span className="text-gray-500 text-xs font-mono">PARTNER</span>
+              <div className="w-8 h-px bg-line" />
+              <div className="w-2 h-2 rounded-full bg-go" />
+              <span className="text-muted text-xs font-medium uppercase tracking-wide">
+                Partner
+              </span>
             </>
           )}
           {playerCount < 2 && phase === "waiting" && (
             <>
-              <div className="w-8 h-px bg-gray-700" />
-              <div className="w-2 h-2 rounded-full bg-gray-600" />
-              <span className="text-gray-500 text-xs font-mono">
-                WAITING...
+              <div className="w-8 h-px bg-line" />
+              <div className="w-2 h-2 rounded-full bg-faint" />
+              <span className="text-faint text-xs font-medium uppercase tracking-wide">
+                Waiting...
               </span>
             </>
           )}
@@ -247,36 +248,39 @@ export default function SessionHUD({
           {canStart && (
             <button
               onClick={onStart}
-              className={`${timerMode === "flow" ? "bg-blue-500 hover:bg-blue-400 border-blue-700" : "bg-emerald-500 hover:bg-emerald-400 border-emerald-700"} active:scale-95 text-white font-bold px-10 py-3 rounded-full shadow-lg font-mono tracking-widest transition-all border-b-4 text-sm`}
+              className={`${
+                timerMode === "flow"
+                  ? "bg-calm hover:brightness-105 border-calm-deep"
+                  : "bg-accent hover:brightness-105 border-accent-deep"
+              } active:scale-95 text-white font-display px-10 py-3 rounded-full shadow-lg tracking-wide transition-all border-b-4 text-base`}
             >
-              {"▶"} START{playerCount < 2 ? " SOLO" : " SESSION"}
+              Start{playerCount < 2 ? " solo" : " session"}
             </button>
           )}
           {playerCount < 2 && phase === "waiting" && (
-            <p className="text-gray-500 text-xs font-mono text-center">
+            <p className="text-faint text-xs text-center">
               Friends can join from their dashboard
             </p>
           )}
           {phase === "focus" && serverMode === "flow" && (
             <button
               onClick={onFinishFlow}
-              className="bg-blue-500 hover:bg-blue-400 active:scale-95 text-white font-bold px-10 py-3 rounded-full shadow-lg font-mono tracking-widest transition-all border-b-4 border-blue-700 text-sm mt-2"
+              className="bg-calm hover:brightness-105 active:scale-95 text-white font-display px-10 py-3 rounded-full shadow-lg tracking-wide transition-all border-b-4 border-calm-deep text-base mt-2"
             >
-              {"⏸"} TAKE BREAK
+              Take break
             </button>
           )}
           {canStop && (
             <button
               onClick={onStop}
-              className="text-gray-400 hover:text-red-420 text-xs font-mono transition-colors mt-2"
+              className="text-muted hover:text-danger text-xs transition-colors mt-2"
             >
               end session
             </button>
           )}
           <button
             onClick={onLeave}
-            className="text-xs font-mono transition-colors mt-2 hover:opacity-80"
-            style={{ color: "#f89c9c89" }}
+            className="text-xs text-danger/60 hover:text-danger transition-colors mt-2"
           >
             {"←"} leave session
           </button>

--- a/client/src/components/SessionTopBar.tsx
+++ b/client/src/components/SessionTopBar.tsx
@@ -1,22 +1,24 @@
 import type { GamePhase } from "./GameWorld";
+import ThemeToggle from "./ThemeToggle";
+import {
+  UsersIcon,
+  ChartIcon,
+  NoteIcon,
+  PencilIcon,
+  StarIcon,
+  SignOutIcon,
+} from "./Icons";
 
 function SessionStatusDot({ phase }: { phase: GamePhase }) {
   const color =
     phase === "focus"
-      ? "bg-emerald-400"
+      ? "bg-go"
       : phase === "waiting"
-        ? "bg-red-400"
-        : "bg-yellow-400";
-  const shadow =
-    phase === "focus"
-      ? "0 0 6px #34d399"
-      : phase === "waiting"
-        ? "0 0 6px #f87171"
-        : "0 0 6px #facc15";
+        ? "bg-faint"
+        : "bg-gold";
   return (
     <div
-      className={`w-2 h-2 rounded-full ${color}`}
-      style={{ boxShadow: shadow }}
+      className={`w-2 h-2 rounded-full ${color} ${phase !== "waiting" ? "animate-pulse" : ""}`}
     />
   );
 }
@@ -62,8 +64,15 @@ export default function SessionTopBar({
   onOpenPremium,
   onSignOut,
 }: SessionTopBarProps) {
+  const tabClass = (open: boolean) =>
+    `flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-semibold transition-colors ${
+      open
+        ? "bg-raise text-ink"
+        : "text-muted hover:text-ink hover:bg-raise"
+    }`;
+
   return (
-    <div className="grid grid-cols-[1fr_auto_1fr] items-center px-4 py-2.5 bg-gray-800/90 backdrop-blur border-b border-gray-700 z-10">
+    <div className="grid grid-cols-[1fr_auto_1fr] items-center px-4 py-2.5 bg-surface/85 backdrop-blur border-b border-line z-10">
       {/* Left: Friends */}
       <div className="flex items-center justify-end pr-2">
         <button
@@ -71,13 +80,9 @@ export default function SessionTopBar({
             e.stopPropagation();
             onToggleFriends();
           }}
-          className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-mono font-bold transition-all ${
-            friendsOpen
-              ? "bg-gray-600 text-white"
-              : "text-gray-400 hover:text-white hover:bg-gray-700"
-          }`}
+          className={tabClass(friendsOpen)}
         >
-          {"👥"} <span className="hidden sm:inline">Friends</span>
+          <UsersIcon /> <span className="hidden sm:inline">Friends</span>
         </button>
       </div>
 
@@ -87,42 +92,35 @@ export default function SessionTopBar({
           e.stopPropagation();
           onGoHome();
         }}
-        className="flex flex-col items-center px-3 py-0.5 rounded-lg hover:bg-gray-700/50 transition-colors"
+        className="flex flex-col items-center px-3 py-0.5 rounded-lg hover:bg-raise transition-colors"
       >
-        <span className="text-white font-black font-mono tracking-widest text-sm">
+        <span className="font-display text-ink tracking-wide text-base leading-tight">
           Duodoro
         </span>
         <SessionStatusDot phase={phase} />
       </button>
 
-      {/* Right: Notes, Stats, Account */}
+      {/* Right: Notes, Stats, Theme, Account */}
       <div className="flex items-center gap-1.5 pl-2">
         <button
           onClick={(e) => {
             e.stopPropagation();
             onToggleNotes();
           }}
-          className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-mono font-bold transition-all ${
-            notesOpen
-              ? "bg-gray-600 text-white"
-              : "text-gray-400 hover:text-white hover:bg-gray-700"
-          }`}
+          className={tabClass(notesOpen)}
         >
-          {"📝"} <span className="hidden sm:inline">Notes</span>
+          <NoteIcon /> <span className="hidden sm:inline">Notes</span>
         </button>
         <button
           onClick={(e) => {
             e.stopPropagation();
             onToggleStats();
           }}
-          className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-mono font-bold transition-all ${
-            statsOpen
-              ? "bg-gray-600 text-white"
-              : "text-gray-400 hover:text-white hover:bg-gray-700"
-          }`}
+          className={tabClass(statsOpen)}
         >
-          {"📊"} <span className="hidden sm:inline">Stats</span>
+          <ChartIcon /> <span className="hidden sm:inline">Stats</span>
         </button>
+        <ThemeToggle />
         <div className="flex-1" />
         <div className="relative">
           <button
@@ -130,40 +128,40 @@ export default function SessionTopBar({
               e.stopPropagation();
               onToggleProfileMenu();
             }}
-            className="w-7 h-7 rounded-full bg-emerald-500/20 border border-emerald-500/40 flex items-center justify-center text-emerald-400 text-xs font-bold hover:bg-emerald-500/30 transition-colors"
+            className="w-7 h-7 rounded-full bg-accent/15 border border-accent/40 flex items-center justify-center text-accent text-xs font-bold hover:bg-accent/25 transition-colors"
           >
             {initial}
           </button>
           {profileMenuOpen && (
             <div
-              className="absolute top-9 right-0 z-50 bg-gray-800 border border-gray-700 rounded-xl p-3 shadow-2xl min-w-44"
+              className="absolute top-9 right-0 z-50 bg-surface border border-line rounded-xl p-3 shadow-xl min-w-48"
               onClick={(e) => e.stopPropagation()}
             >
-              <p className="text-white font-bold text-sm mb-0.5">
+              <p className="text-ink font-bold text-sm mb-0.5">
                 {displayName}
               </p>
-              <p className="text-gray-500 text-xs font-mono mb-3">
+              <p className="text-faint text-xs font-mono mb-3">
                 @{username}{discriminator ? `#${discriminator}` : ""}
               </p>
               <button
                 onClick={onEditAvatar}
-                className="w-full text-left text-xs font-mono text-gray-400 hover:text-white py-1.5 transition-colors"
+                className="w-full flex items-center gap-2 text-left text-xs text-muted hover:text-ink py-1.5 transition-colors"
               >
-                {"✏️"} Edit character
+                <PencilIcon className="w-3.5 h-3.5" /> Edit character
               </button>
               {!isPremium && (
                 <button
                   onClick={onOpenPremium}
-                  className="w-full text-left text-xs font-mono text-yellow-400 hover:text-yellow-300 py-1.5 transition-colors"
+                  className="w-full flex items-center gap-2 text-left text-xs text-gold hover:text-gold-deep py-1.5 transition-colors"
                 >
-                  {"⭐"} Upgrade to Premium
+                  <StarIcon className="w-3.5 h-3.5" /> Upgrade to Premium
                 </button>
               )}
               <button
                 onClick={onSignOut}
-                className="w-full text-left text-xs font-mono text-gray-400 hover:text-red-400 py-1.5 transition-colors"
+                className="w-full flex items-center gap-2 text-left text-xs text-muted hover:text-danger py-1.5 transition-colors"
               >
-                Sign out
+                <SignOutIcon className="w-3.5 h-3.5" /> Sign out
               </button>
             </div>
           )}

--- a/client/src/components/StatsPanel.tsx
+++ b/client/src/components/StatsPanel.tsx
@@ -43,11 +43,11 @@ const WORLD_EMOJI: Record<string, string> = {
 
 function StatCard({ label, value }: { label: string; value: string }) {
   return (
-    <div className="bg-gray-800/60 rounded-xl px-3 py-2.5 text-center">
-      <p className="text-gray-500 text-[10px] font-mono font-bold uppercase tracking-wider">
+    <div className="bg-raise rounded-xl px-3 py-2.5 text-center">
+      <p className="text-faint text-[10px] font-semibold uppercase tracking-wider">
         {label}
       </p>
-      <p className="text-white text-lg font-bold font-mono mt-0.5">{value}</p>
+      <p className="text-ink text-lg font-bold font-mono tabular-nums mt-0.5">{value}</p>
     </div>
   );
 }
@@ -56,19 +56,19 @@ function StatCard({ label, value }: { label: string; value: string }) {
 
 function PartnerRow({ duo, rank }: { duo: DuoStats; rank: number }) {
   return (
-    <div className="flex items-center gap-3 py-2 px-3 rounded-xl hover:bg-gray-700/50 transition-colors">
-      <span className="text-gray-600 text-xs font-mono font-bold w-5">
+    <div className="flex items-center gap-3 py-2 px-3 rounded-xl hover:bg-raise transition-colors">
+      <span className={`text-xs font-bold w-5 ${rank === 1 ? "text-gold" : "text-faint"}`}>
         {rank === 1 ? "★" : `#${rank}`}
       </span>
       <div className="flex-1 min-w-0">
-        <p className="text-sm font-bold text-white truncate">
+        <p className="text-sm font-bold text-ink truncate">
           {duo.partnerName}
         </p>
-        <p className="text-xs text-gray-500 font-mono">
+        <p className="text-xs text-faint">
           {duo.sessionsTogether} sessions
         </p>
       </div>
-      <span className="text-emerald-400 text-xs font-mono font-bold">
+      <span className="text-accent text-xs font-mono font-bold">
         {formatDuration(duo.totalCoFocusTime)}
       </span>
     </div>
@@ -79,27 +79,27 @@ function PartnerRow({ duo, rank }: { duo: DuoStats; rank: number }) {
 
 function SessionRow({ session }: { session: SessionWithPartner }) {
   return (
-    <div className="flex items-center gap-2 py-2 px-3 rounded-xl bg-gray-800/40">
+    <div className="flex items-center gap-2 py-2 px-3 rounded-xl bg-raise">
       <span className="text-sm">{WORLD_EMOJI[session.world] ?? "🌍"}</span>
       <div className="flex-1 min-w-0">
-        <p className="text-xs font-bold text-white truncate">
+        <p className="text-xs font-bold text-ink truncate">
           {formatDuration(session.actual_focus)} focus
           {session.partner_name && (
-            <span className="text-gray-500 font-normal">
+            <span className="text-muted font-normal">
               {" "}
               with {session.partner_name}
             </span>
           )}
         </p>
-        <p className="text-[10px] text-gray-600 font-mono">
+        <p className="text-[10px] text-faint font-mono">
           {formatDate(session.ended_at)}
         </p>
       </div>
       <span
-        className={`text-[10px] font-mono font-bold px-1.5 py-0.5 rounded ${
+        className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${
           session.completed
-            ? "bg-emerald-500/20 text-emerald-400"
-            : "bg-red-500/20 text-red-400"
+            ? "bg-go/15 text-go"
+            : "bg-danger/15 text-danger"
         }`}
       >
         {session.completed ? "✓" : "—"}
@@ -139,35 +139,35 @@ export default function StatsPanel({
           />
           <div className="fixed inset-x-2 sm:inset-x-auto sm:right-4 top-0 bottom-0 z-40 flex items-stretch justify-end py-3 pointer-events-none">
             <motion.div
-              className="pointer-events-auto w-full sm:w-80 bg-gray-900 border border-gray-700 flex flex-col shadow-2xl rounded-2xl overflow-hidden"
+              className="pointer-events-auto w-full sm:w-80 bg-surface border border-line flex flex-col shadow-2xl rounded-2xl overflow-hidden"
               initial={{ x: 60, opacity: 0 }}
               animate={{ x: 0, opacity: 1 }}
               exit={{ x: 60, opacity: 0 }}
               transition={{ type: "spring", damping: 28, stiffness: 300 }}
             >
               {/* Header */}
-              <div className="flex items-center justify-between px-4 py-4 border-b border-gray-700">
-                <h2 className="font-bold text-white font-mono tracking-widest">
-                  STATS
+              <div className="flex items-center justify-between px-4 py-4 border-b border-line">
+                <h2 className="font-display text-lg text-ink tracking-wide">
+                  Stats
                 </h2>
                 <button
                   onClick={onClose}
-                  className="text-gray-500 hover:text-white transition-colors"
+                  className="text-faint hover:text-ink transition-colors"
                 >
                   ✕
                 </button>
               </div>
 
               {/* Tabs */}
-              <div className="flex border-b border-gray-700">
+              <div className="flex border-b border-line">
                 {(["personal", "duo", "history"] as Tab[]).map((t) => (
                   <button
                     key={t}
                     onClick={() => setTab(t)}
-                    className={`flex-1 py-2.5 text-xs font-mono font-bold capitalize transition-colors ${
+                    className={`flex-1 py-2.5 text-xs font-bold capitalize transition-colors ${
                       tab === t
-                        ? "text-emerald-400 border-b-2 border-emerald-400"
-                        : "text-gray-500 hover:text-gray-300"
+                        ? "text-accent border-b-2 border-accent"
+                        : "text-muted hover:text-ink"
                     }`}
                   >
                     {t}
@@ -178,7 +178,7 @@ export default function StatsPanel({
               {/* Content */}
               <div className="flex-1 overflow-y-auto p-3">
                 {loading && (
-                  <p className="text-gray-500 text-sm font-mono text-center py-8">
+                  <p className="text-faint text-sm text-center py-8">
                     Loading...
                   </p>
                 )}
@@ -214,7 +214,7 @@ export default function StatsPanel({
                         />
                       </div>
                     ) : (
-                      <p className="text-gray-500 text-sm font-mono text-center py-8">
+                      <p className="text-faint text-sm text-center py-8">
                         No sessions yet.
                         <br />
                         Start focusing to see stats!
@@ -227,7 +227,7 @@ export default function StatsPanel({
                 {!loading && tab === "duo" && (
                   <div>
                     {duoStats.length === 0 ? (
-                      <p className="text-gray-500 text-sm font-mono text-center py-8">
+                      <p className="text-faint text-sm text-center py-8">
                         No partner sessions yet.
                         <br />
                         Focus with a friend to see duo stats!
@@ -250,7 +250,7 @@ export default function StatsPanel({
                 {!loading && tab === "history" && (
                   <div>
                     {recentSessions.length === 0 ? (
-                      <p className="text-gray-500 text-sm font-mono text-center py-8">
+                      <p className="text-faint text-sm text-center py-8">
                         No sessions recorded yet.
                       </p>
                     ) : (
@@ -265,10 +265,10 @@ export default function StatsPanel({
               </div>
 
               {/* Footer */}
-              <div className="border-t border-gray-700 px-4 py-3">
+              <div className="border-t border-line px-4 py-3">
                 <button
                   onClick={onViewFullStats}
-                  className="w-full text-center text-xs font-mono text-emerald-400 hover:text-emerald-300 font-bold transition-colors"
+                  className="w-full text-center text-xs text-accent hover:text-accent-deep font-bold transition-colors"
                 >
                   View detailed stats →
                 </button>

--- a/client/src/components/StatsScreen.tsx
+++ b/client/src/components/StatsScreen.tsx
@@ -58,8 +58,8 @@ function WeeklyChart({ sessions }: { sessions: any[] }) {
   const maxMinutes = Math.max(...dailyData.map((d) => d.minutes), 1);
 
   return (
-    <div className="bg-gray-800/60 rounded-xl p-4">
-      <p className="text-gray-500 text-[10px] font-mono font-bold uppercase tracking-wider mb-3">
+    <div className="bg-surface border border-line rounded-xl p-4">
+      <p className="text-faint text-[10px] font-semibold uppercase tracking-wider mb-3">
         Last 7 Days
       </p>
       <div className="flex items-end gap-2 h-24">
@@ -68,7 +68,7 @@ function WeeklyChart({ sessions }: { sessions: any[] }) {
             key={day.date}
             className="flex-1 flex flex-col items-center gap-1"
           >
-            <span className="text-[9px] text-gray-500 font-mono">
+            <span className="text-[9px] text-faint font-mono">
               {day.minutes > 0 ? `${day.minutes}m` : ""}
             </span>
             <div className="w-full flex items-end" style={{ height: "60px" }}>
@@ -77,11 +77,11 @@ function WeeklyChart({ sessions }: { sessions: any[] }) {
                 style={{
                   height: `${Math.max((day.minutes / maxMinutes) * 100, day.minutes > 0 ? 8 : 2)}%`,
                   backgroundColor:
-                    day.minutes > 0 ? "#34d399" : "rgba(75, 85, 99, 0.4)",
+                    day.minutes > 0 ? "var(--accent)" : "var(--line)",
                 }}
               />
             </div>
-            <span className="text-[9px] text-gray-600 font-mono">
+            <span className="text-[9px] text-faint">
               {day.label}
             </span>
           </div>
@@ -103,13 +103,13 @@ function BigStatCard({
   accent?: boolean;
 }) {
   return (
-    <div className="bg-gray-800/60 rounded-xl px-4 py-3 text-center">
-      <p className="text-gray-500 text-[10px] font-mono font-bold uppercase tracking-wider">
+    <div className="bg-surface border border-line rounded-xl px-4 py-3 text-center">
+      <p className="text-faint text-[10px] font-semibold uppercase tracking-wider">
         {label}
       </p>
       <p
-        className={`text-2xl font-bold font-mono mt-1 ${
-          accent ? "text-emerald-400" : "text-white"
+        className={`text-2xl font-bold font-mono tabular-nums mt-1 ${
+          accent ? "text-accent" : "text-ink"
         }`}
       >
         {value}
@@ -135,19 +135,19 @@ export default function StatsScreen({ open, onClose, userId }: Props) {
     <AnimatePresence>
       {open && (
         <motion.div
-          className="fixed inset-0 z-50 bg-gray-900/95 overflow-y-auto"
+          className="fixed inset-0 z-50 bg-bg overflow-y-auto"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
         >
           {/* Header */}
-          <div className="sticky top-0 z-10 bg-gray-900/90 backdrop-blur border-b border-gray-700 px-6 py-4 flex items-center justify-between">
-            <h1 className="text-white font-black font-mono tracking-widest text-lg">
-              YOUR STATS
+          <div className="sticky top-0 z-10 bg-surface/90 backdrop-blur border-b border-line px-6 py-4 flex items-center justify-between">
+            <h1 className="font-display text-ink tracking-wide text-xl">
+              Your stats
             </h1>
             <button
               onClick={onClose}
-              className="text-gray-500 hover:text-white transition-colors text-lg"
+              className="text-faint hover:text-ink transition-colors text-lg"
             >
               ✕
             </button>
@@ -155,7 +155,7 @@ export default function StatsScreen({ open, onClose, userId }: Props) {
 
           <div className="max-w-2xl mx-auto px-6 py-6 space-y-6">
             {loading && (
-              <p className="text-gray-500 text-sm font-mono text-center py-12">
+              <p className="text-faint text-sm text-center py-12">
                 Loading stats...
               </p>
             )}
@@ -164,7 +164,7 @@ export default function StatsScreen({ open, onClose, userId }: Props) {
               <>
                 {/* Personal Stats Grid */}
                 <div>
-                  <p className="text-gray-400 text-xs font-mono font-bold uppercase tracking-wider mb-3">
+                  <p className="text-faint text-xs font-semibold uppercase tracking-wider mb-3">
                     Personal
                   </p>
                   <div className="grid grid-cols-3 gap-2">
@@ -203,32 +203,32 @@ export default function StatsScreen({ open, onClose, userId }: Props) {
                 {/* Duo Stats */}
                 {duoStats.length > 0 && (
                   <div>
-                    <p className="text-gray-400 text-xs font-mono font-bold uppercase tracking-wider mb-3">
+                    <p className="text-faint text-xs font-semibold uppercase tracking-wider mb-3">
                       Focus Partners
                     </p>
                     <div className="space-y-2">
                       {duoStats.map((duo, i) => (
                         <div
                           key={duo.partnerId}
-                          className="flex items-center gap-3 bg-gray-800/60 rounded-xl px-4 py-3"
+                          className="flex items-center gap-3 bg-surface border border-line rounded-xl px-4 py-3"
                         >
                           <span
-                            className={`text-sm font-bold font-mono ${
-                              i === 0 ? "text-yellow-400" : "text-gray-600"
+                            className={`text-sm font-bold ${
+                              i === 0 ? "text-gold" : "text-faint"
                             }`}
                           >
                             {i === 0 ? "★" : `#${i + 1}`}
                           </span>
                           <div className="flex-1 min-w-0">
-                            <p className="text-sm font-bold text-white truncate">
+                            <p className="text-sm font-bold text-ink truncate">
                               {duo.partnerName}
                             </p>
-                            <p className="text-xs text-gray-500 font-mono">
+                            <p className="text-xs text-faint">
                               {duo.sessionsTogether} sessions together
                             </p>
                           </div>
                           <div className="text-right">
-                            <p className="text-emerald-400 text-sm font-mono font-bold">
+                            <p className="text-accent text-sm font-mono font-bold">
                               {formatDuration(duo.totalCoFocusTime)}
                             </p>
                           </div>
@@ -240,11 +240,11 @@ export default function StatsScreen({ open, onClose, userId }: Props) {
 
                 {/* Session History */}
                 <div>
-                  <p className="text-gray-400 text-xs font-mono font-bold uppercase tracking-wider mb-3">
+                  <p className="text-faint text-xs font-semibold uppercase tracking-wider mb-3">
                     Recent Sessions
                   </p>
                   {recentSessions.length === 0 ? (
-                    <p className="text-gray-600 text-sm font-mono text-center py-6">
+                    <p className="text-faint text-sm text-center py-6">
                       No sessions recorded yet
                     </p>
                   ) : (
@@ -252,30 +252,30 @@ export default function StatsScreen({ open, onClose, userId }: Props) {
                       {recentSessions.map((s) => (
                         <div
                           key={s.id}
-                          className="flex items-center gap-3 bg-gray-800/40 rounded-xl px-4 py-2.5"
+                          className="flex items-center gap-3 bg-surface border border-line rounded-xl px-4 py-2.5"
                         >
                           <span className="text-base">
                             {WORLD_EMOJI[s.world] ?? "🌍"}
                           </span>
                           <div className="flex-1 min-w-0">
-                            <p className="text-sm font-bold text-white">
+                            <p className="text-sm font-bold text-ink">
                               {formatDuration(s.actual_focus)}
                               {s.partner_name && (
-                                <span className="text-gray-500 font-normal text-xs">
+                                <span className="text-muted font-normal text-xs">
                                   {" "}
                                   with {s.partner_name}
                                 </span>
                               )}
                             </p>
-                            <p className="text-[10px] text-gray-600 font-mono">
+                            <p className="text-[10px] text-faint font-mono">
                               {formatDate(s.ended_at)}
                             </p>
                           </div>
                           <span
-                            className={`text-[10px] font-mono font-bold px-2 py-0.5 rounded ${
+                            className={`text-[10px] font-bold px-2 py-0.5 rounded ${
                               s.completed
-                                ? "bg-emerald-500/20 text-emerald-400"
-                                : "bg-red-500/20 text-red-400"
+                                ? "bg-go/15 text-go"
+                                : "bg-danger/15 text-danger"
                             }`}
                           >
                             {s.completed ? "Completed" : "Stopped"}
@@ -290,10 +290,10 @@ export default function StatsScreen({ open, onClose, userId }: Props) {
 
             {!loading && !personalStats && (
               <div className="text-center py-16">
-                <p className="text-gray-500 text-lg font-mono mb-2">
+                <p className="text-muted text-lg font-display mb-2">
                   No stats yet
                 </p>
-                <p className="text-gray-600 text-sm font-mono">
+                <p className="text-faint text-sm">
                   Complete your first focus session to start tracking!
                 </p>
               </div>

--- a/client/src/components/TaskSection.tsx
+++ b/client/src/components/TaskSection.tsx
@@ -26,20 +26,20 @@ export default function TaskSection({
   clearCompleted,
 }: Props) {
   return (
-    <div className="bg-gray-800/50 rounded-2xl border border-gray-700 p-4">
+    <div className="bg-surface rounded-2xl border border-line p-4">
       <div className="flex items-center justify-between mb-3">
-        <h2 className="text-sm font-bold font-mono text-gray-400 uppercase tracking-wider">
+        <h2 className="text-xs font-semibold text-faint uppercase tracking-wider">
           Goals
         </h2>
         {tasks.length > 0 && (
           <div className="flex items-center gap-2">
-            <span className="text-[10px] font-mono text-gray-600">
+            <span className="text-[10px] text-faint">
               {completedTasks.length}/{tasks.length} done
             </span>
             {completedTasks.length > 0 && (
               <button
                 onClick={clearCompleted}
-                className="text-[10px] font-mono text-gray-600 hover:text-red-400 transition-colors"
+                className="text-[10px] text-faint hover:text-danger transition-colors"
               >
                 Clean
               </button>
@@ -61,14 +61,14 @@ export default function TaskSection({
             >
               <button
                 onClick={() => toggleTask(task.id, true)}
-                className="flex-shrink-0 w-4.5 h-4.5 w-[18px] h-[18px] rounded border-2 border-gray-600 hover:border-emerald-500 flex items-center justify-center transition-colors"
+                className="flex-shrink-0 w-[18px] h-[18px] rounded border-2 border-line hover:border-go flex items-center justify-center transition-colors"
               />
-              <p className="flex-1 text-sm text-gray-300 font-mono truncate">
+              <p className="flex-1 text-sm text-ink truncate">
                 {task.content}
               </p>
               <button
                 onClick={() => deleteTask(task.id)}
-                className="text-gray-700 hover:text-red-400 text-xs opacity-0 group-hover:opacity-100 transition-all"
+                className="text-faint hover:text-danger text-xs opacity-0 group-hover:opacity-100 transition-all"
               >
                 {"✕"}
               </button>
@@ -85,16 +85,16 @@ export default function TaskSection({
             >
               <button
                 onClick={() => toggleTask(task.id, false)}
-                className="flex-shrink-0 w-[18px] h-[18px] rounded border-2 border-emerald-600 bg-emerald-600 flex items-center justify-center"
+                className="flex-shrink-0 w-[18px] h-[18px] rounded border-2 border-go bg-go flex items-center justify-center"
               >
                 <span className="text-white text-[10px]">{"✓"}</span>
               </button>
-              <p className="flex-1 text-sm text-gray-600 font-mono truncate line-through">
+              <p className="flex-1 text-sm text-faint truncate line-through">
                 {task.content}
               </p>
               <button
                 onClick={() => deleteTask(task.id)}
-                className="text-gray-700 hover:text-red-400 text-xs opacity-0 group-hover:opacity-100 transition-all"
+                className="text-faint hover:text-danger text-xs opacity-0 group-hover:opacity-100 transition-all"
               >
                 {"✕"}
               </button>
@@ -104,14 +104,14 @@ export default function TaskSection({
       </div>
 
       {tasks.length === 0 && (
-        <p className="text-gray-600 text-xs font-mono text-center py-3">
+        <p className="text-faint text-xs text-center py-3">
           Add goals for your focus session
         </p>
       )}
 
-      <div className="flex gap-2 mt-3 pt-3 border-t border-gray-700">
+      <div className="flex gap-2 mt-3 pt-3 border-t border-line">
         <input
-          className="flex-1 bg-transparent text-sm text-gray-300 placeholder-gray-600 focus:outline-none font-mono"
+          className="flex-1 bg-transparent text-sm text-ink placeholder-faint focus:outline-none"
           placeholder="Add a goal..."
           value={newTask}
           onChange={(e) => setNewTask(e.target.value)}
@@ -121,7 +121,7 @@ export default function TaskSection({
         <button
           onClick={addTask}
           disabled={!newTask.trim()}
-          className="text-emerald-400 font-bold text-lg disabled:opacity-30 transition-opacity"
+          className="text-accent font-bold text-lg disabled:opacity-30 transition-opacity"
         >
           +
         </button>

--- a/client/src/components/ThemeToggle.tsx
+++ b/client/src/components/ThemeToggle.tsx
@@ -1,0 +1,30 @@
+"use client";
+import { useTheme } from "@/hooks/useTheme";
+import { SunIcon, MoonIcon } from "./Icons";
+
+interface Props {
+  className?: string;
+  /** For use over dark game-world scenes regardless of theme */
+  onScene?: boolean;
+}
+
+export default function ThemeToggle({ className, onScene }: Props) {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <button
+      onClick={(e) => {
+        e.stopPropagation();
+        toggleTheme();
+      }}
+      aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+      title={theme === "dark" ? "Light mode" : "Dark mode"}
+      className={`w-8 h-8 rounded-lg flex items-center justify-center transition-colors ${
+        onScene
+          ? "text-white/70 hover:text-white hover:bg-white/10"
+          : "text-muted hover:text-ink hover:bg-raise"
+      } ${className ?? ""}`}
+    >
+      {theme === "dark" ? <SunIcon /> : <MoonIcon />}
+    </button>
+  );
+}

--- a/client/src/components/UsernameChangeModal.tsx
+++ b/client/src/components/UsernameChangeModal.tsx
@@ -49,19 +49,19 @@ export default function UsernameChangeModal({
       <motion.div
         initial={{ opacity: 0, scale: 0.95 }}
         animate={{ opacity: 1, scale: 1 }}
-        className="fixed z-50 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-gray-800 border border-gray-700 rounded-2xl p-6 shadow-2xl w-[calc(100vw-1rem)] sm:w-80"
+        className="fixed z-50 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-surface border border-line rounded-2xl p-6 shadow-2xl w-[calc(100vw-1rem)] sm:w-80"
       >
-        <h3 className="text-white font-bold font-mono tracking-widest text-sm mb-1">
-          CHANGE USERNAME
+        <h3 className="font-display text-ink tracking-wide text-base mb-1">
+          Change username
         </h3>
-        <p className="text-gray-500 text-xs font-mono mb-4">
+        <p className="text-faint text-xs font-mono mb-4">
           Current: @{currentUsername} — you can only do this once!
         </p>
         <input
-          className={`w-full px-3 py-3 sm:py-2 bg-gray-900/60 border rounded-lg text-white text-sm font-mono placeholder-gray-600 focus:outline-none transition-colors mb-1 ${
+          className={`w-full px-3 py-3 sm:py-2 bg-raise border rounded-lg text-ink text-sm font-mono placeholder-faint focus:outline-none transition-colors mb-1 ${
             error
-              ? "border-red-500 focus:border-red-400"
-              : "border-gray-600 focus:border-emerald-500"
+              ? "border-danger focus:border-danger"
+              : "border-line focus:border-accent"
           }`}
           placeholder="new_username"
           value={value}
@@ -74,23 +74,23 @@ export default function UsernameChangeModal({
           onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
           autoFocus
         />
-        <p className="text-gray-600 text-[10px] font-mono mb-3">
+        <p className="text-faint text-[10px] mb-3">
           A new #tag will be generated automatically.
         </p>
         {error && (
-          <p className="text-red-400 text-xs font-mono mb-3">{error}</p>
+          <p className="text-danger text-xs mb-3">{error}</p>
         )}
         <div className="flex gap-2">
           <button
             onClick={onClose}
-            className="flex-1 text-gray-400 hover:text-white text-sm font-mono py-3 sm:py-2 rounded-xl transition-colors"
+            className="flex-1 text-muted hover:text-ink text-sm py-3 sm:py-2 rounded-xl transition-colors"
           >
             Cancel
           </button>
           <button
             onClick={handleSubmit}
             disabled={submitting || value.length < 3}
-            className="flex-1 bg-emerald-500 hover:bg-emerald-400 text-white font-bold text-sm font-mono py-3 sm:py-2 rounded-xl transition-colors disabled:opacity-40"
+            className="flex-1 bg-accent hover:brightness-105 text-white font-bold text-sm py-3 sm:py-2 rounded-xl transition-all disabled:opacity-40"
           >
             {submitting ? "..." : "Confirm"}
           </button>

--- a/client/src/hooks/useTheme.ts
+++ b/client/src/hooks/useTheme.ts
@@ -1,29 +1,40 @@
 "use client";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 
 export type Theme = "light" | "dark";
 
 // Theme is applied to <html data-theme> by an inline script before paint
-// (see layout.tsx); this hook just mirrors it into React state and toggles.
-export function useTheme() {
-  const [theme, setTheme] = useState<Theme>("dark");
+// (see layout.tsx). This hook subscribes to that attribute so every
+// ThemeToggle instance stays in sync, and toggles persist to localStorage.
 
-  useEffect(() => {
-    const t = document.documentElement.dataset.theme;
-    if (t === "light" || t === "dark") setTheme(t);
-  }, []);
+function subscribe(callback: () => void) {
+  const observer = new MutationObserver(callback);
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["data-theme"],
+  });
+  return () => observer.disconnect();
+}
+
+function getSnapshot(): Theme {
+  return document.documentElement.dataset.theme === "light" ? "light" : "dark";
+}
+
+function getServerSnapshot(): Theme {
+  return "dark";
+}
+
+export function useTheme() {
+  const theme = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 
   const toggleTheme = useCallback(() => {
-    setTheme((prev) => {
-      const next = prev === "dark" ? "light" : "dark";
-      document.documentElement.dataset.theme = next;
-      try {
-        localStorage.setItem("duodoro-theme", next);
-      } catch {
-        // localStorage unavailable (private mode) — theme still applies for this session
-      }
-      return next;
-    });
+    const next: Theme = getSnapshot() === "dark" ? "light" : "dark";
+    document.documentElement.dataset.theme = next;
+    try {
+      localStorage.setItem("duodoro-theme", next);
+    } catch {
+      // localStorage unavailable (private mode) — theme still applies for this session
+    }
   }, []);
 
   return { theme, toggleTheme };

--- a/client/src/hooks/useTheme.ts
+++ b/client/src/hooks/useTheme.ts
@@ -1,0 +1,30 @@
+"use client";
+import { useCallback, useEffect, useState } from "react";
+
+export type Theme = "light" | "dark";
+
+// Theme is applied to <html data-theme> by an inline script before paint
+// (see layout.tsx); this hook just mirrors it into React state and toggles.
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>("dark");
+
+  useEffect(() => {
+    const t = document.documentElement.dataset.theme;
+    if (t === "light" || t === "dark") setTheme(t);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((prev) => {
+      const next = prev === "dark" ? "light" : "dark";
+      document.documentElement.dataset.theme = next;
+      try {
+        localStorage.setItem("duodoro-theme", next);
+      } catch {
+        // localStorage unavailable (private mode) — theme still applies for this session
+      }
+      return next;
+    });
+  }, []);
+
+  return { theme, toggleTheme };
+}


### PR DESCRIPTION
## Summary

Redesigned the UI from generated-code gray (gray-900 + emerald + ALL-CAPS mono) to a cozy stationery aesthetic with light/dark mode support. All 7 screens now follow semantic color tokens (warm cream paper light mode, warm charcoal dark mode, terracotta accent for primary actions). No functional changes — this is purely presentational.

## Changes

- **Theme system**: Semantic CSS tokens (`--bg`, `--surface`, `--ink`, `--accent`, etc.) swapped via `data-theme` attribute; light/dark toggle persists to localStorage with no-flash init script
- **Display typography**: Pixelify Sans for wordmarks/headings/buttons (sentence-case); body text in normal Geist
- **Icons**: SVG stroke icon set replaces emoji in UI chrome (Friends, Stats, Notes, Edit, Premium, Sign Out)
- **Landing page**: Pixel hero scene framed as a window card; simplified copy; theme toggle in header
- **Home dashboard**: Cleaner top bar (wordmark left, actions right); cards use themed surfaces; chunky focus button in terracotta
- **Session UI**: Translucent themed surfaces so HUD/top bar read over both bright (beach) and dark (space) worlds
- **Panels & modals**: Friends, Stats, Premium, invite, name-change forms all themed; Avatar Creator uses display font for headings
- **Accessibility**: `useSyncExternalStore` for theme state so all toggles stay in sync
- **Stickies**: Kept intentional paper-note aesthetic (unchanged)

## Tech details

- 7 commits (theme foundation → landing → home → session → panels → type-check/build fix)
- Tests: 6/6 pass (`src/lib/format.test.ts`)
- Build: ✓ (confirmed with placeholder env vars)
- Lint: 29 pre-existing errors in `useStats`/character renderers (out of scope)

## Testing

1. `cd client && npm install && npm run dev` (needs `NEXT_PUBLIC_SUPABASE_URL` + key in `.env.local`)
2. Visit http://localhost:3000 to see landing page → home dashboard → game world
3. Click sun/moon toggle (header, top bar) to switch light/dark mode — persists across page reloads
4. Open panels (Friends, Stats) and modals (Premium, edit avatar) to see themed surfaces

## Design rationale

The old look (gray-900, emerald buttons, monospace everywhere, ALL-CAPS labels) felt like it was generated by a tool. The new look draws from print design — warm paper tones, a terracotta accent that feels more human than electric green, display fonts for emphasis only. Sentence case and proportional type for body content make the interface feel less code-y and more like a real product.
