### PR TITLE
fix: data-integrity and RLS holes (abandoned sessions, friendship forgery, self-granted premium)

### DIFF
--- a/client/src/components/FriendsPanel.tsx
+++ b/client/src/components/FriendsPanel.tsx
@@ -125,10 +125,15 @@ export default function FriendsPanel({
   onInviteFriend,
 }: Props) {
   const [tab, setTab] = useState<Tab>("friends");
-  const { friends, requests, acceptRequest, declineRequest } = useFriendsList(myProfile.id, open);
-  const { searchQuery, setSearchQuery, searchResults, loading, handleSearch, sentRequests, sendRequest } = useFriendSearch(myProfile.id);
+  const { friends, requests, acceptRequest, declineRequest, error: listError, clearError: clearListError } = useFriendsList(myProfile.id, open);
+  const { searchQuery, setSearchQuery, searchResults, loading, handleSearch, sentRequests, sendRequest, error: searchError, clearError: clearSearchError } = useFriendSearch(myProfile.id);
 
   const friendIds = new Set(friends.map((f) => f.id));
+  const error = listError ?? searchError;
+  const dismissError = () => {
+    clearListError();
+    clearSearchError();
+  };
 
   return (
     <AnimatePresence>
@@ -184,6 +189,23 @@ export default function FriendsPanel({
                   </button>
                 ))}
               </div>
+
+              {/* Action errors — these operations used to fail silently */}
+              {error && (
+                <div
+                  role="alert"
+                  className="flex items-start gap-2 px-3 py-2.5 bg-danger/10 border-b border-danger/30 text-danger text-xs"
+                >
+                  <span className="flex-1">{error}</span>
+                  <button
+                    onClick={dismissError}
+                    aria-label="Dismiss error"
+                    className="font-bold hover:opacity-70"
+                  >
+                    ✕
+                  </button>
+                </div>
+              )}
 
               {/* Content */}
               <div className="flex-1 overflow-y-auto p-3">

--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -132,12 +132,23 @@ export function useAuth() {
         } else {
           const provisional = profileFromSession(session);
           applyProfile(provisional);
+          // Fallback only: the handle_new_user() trigger already creates this
+          // row at signup, and we also land here when the SELECT above merely
+          // timed out on a slow connection. ignoreDuplicates makes this a
+          // pure insert-if-missing (ON CONFLICT DO NOTHING) — without it, the
+          // conflict path would overwrite a real username with this generated
+          // one, and would need UPDATE rights on columns only the
+          // claim_username RPC should touch.
           sb.from("profiles")
-            .upsert({
-              id: provisional.id,
-              username: provisional.username + "_" + provisional.id.slice(0, 4),
-              display_name: provisional.display_name,
-            })
+            .upsert(
+              {
+                id: provisional.id,
+                username:
+                  provisional.username + "_" + provisional.id.slice(0, 4),
+                display_name: provisional.display_name,
+              },
+              { onConflict: "id", ignoreDuplicates: true },
+            )
             .then(() => {});
         }
       } catch {

--- a/client/src/hooks/useFriendSearch.ts
+++ b/client/src/hooks/useFriendSearch.ts
@@ -7,6 +7,7 @@ export function useFriendSearch(myProfileId: string) {
   const [searchResults, setSearchResults] = useState<Profile[]>([]);
   const [sentRequests, setSentRequests] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const sb = getSupabase();
 
   const handleSearch = async () => {
@@ -37,16 +38,39 @@ export function useFriendSearch(myProfileId: string) {
         .neq("id", myProfileId)
         .limit(10);
     }
+    // Without this, a failed query is indistinguishable from "no such user"
+    if (result.error) setError("Search failed. Check your connection.");
     setSearchResults((result.data as Profile[]) ?? []);
     setLoading(false);
   };
 
   const sendRequest = async (targetId: string) => {
-    await sb
+    setError(null);
+    const { error: err } = await sb
       .from("friendships")
       .insert({ requester_id: myProfileId, addressee_id: targetId });
+    if (err) {
+      // 23505 = friendships_pair_unique. Very common: they already sent *you*
+      // a request, so the pair already exists in the other direction.
+      setError(
+        err.code === "23505"
+          ? "You already have a request or friendship with this person — check the Requests tab."
+          : "Couldn't send that request. Try again.",
+      );
+      return;
+    }
     setSentRequests((prev) => new Set([...prev, targetId]));
   };
 
-  return { searchQuery, setSearchQuery, searchResults, loading, handleSearch, sentRequests, sendRequest };
+  return {
+    searchQuery,
+    setSearchQuery,
+    searchResults,
+    loading,
+    handleSearch,
+    sentRequests,
+    sendRequest,
+    error,
+    clearError: () => setError(null),
+  };
 }

--- a/client/src/hooks/useFriendsList.ts
+++ b/client/src/hooks/useFriendsList.ts
@@ -7,6 +7,7 @@ export function useFriendsList(myProfileId: string, active: boolean) {
   const [requests, setRequests] = useState<
     { id: string; requester: Profile }[]
   >([]);
+  const [error, setError] = useState<string | null>(null);
   const sb = getSupabase();
 
   const fetchFriends = useCallback(async () => {
@@ -71,22 +72,49 @@ export function useFriendsList(myProfileId: string, active: boolean) {
   }, [sb, fetchFriends]);
 
   const acceptRequest = async (friendshipId: string) => {
-    await sb
+    setError(null);
+    const { error: err } = await sb
       .from("friendships")
       .update({ status: "accepted" })
       .eq("id", friendshipId);
+    if (err) {
+      setError("Couldn't accept that request. Try again.");
+      return;
+    }
     fetchFriends();
   };
 
-  const declineRequest = async (friendshipId: string) => {
-    await sb.from("friendships").delete().eq("id", friendshipId);
+  // RLS refusing a DELETE is not an error — it just matches zero rows. So we
+  // ask for the deleted rows back and treat an empty result as a failure,
+  // rather than optimistically refetching and showing the entry again.
+  const deleteFriendship = async (friendshipId: string, label: string) => {
+    setError(null);
+    const { data, error: err } = await sb
+      .from("friendships")
+      .delete()
+      .eq("id", friendshipId)
+      .select("id");
+    if (err || !data || data.length === 0) {
+      setError(`Couldn't ${label}. You may not have permission.`);
+      return;
+    }
     fetchFriends();
   };
 
-  const removeFriend = async (friendshipId: string) => {
-    await sb.from("friendships").delete().eq("id", friendshipId);
-    fetchFriends();
-  };
+  const declineRequest = (friendshipId: string) =>
+    deleteFriendship(friendshipId, "decline that request");
 
-  return { friends, requests, acceptRequest, declineRequest, removeFriend, fetchFriends };
+  const removeFriend = (friendshipId: string) =>
+    deleteFriendship(friendshipId, "remove that friend");
+
+  return {
+    friends,
+    requests,
+    acceptRequest,
+    declineRequest,
+    removeFriend,
+    fetchFriends,
+    error,
+    clearError: () => setError(null),
+  };
 }

--- a/server/index.js
+++ b/server/index.js
@@ -11,6 +11,7 @@ const {
   setPlayerPet,
   findPlayerByUserId,
   markPlayerDisconnected,
+  sessionParticipantIds,
   buildSyncPayload,
 } = require('./session');
 require('dotenv').config();
@@ -181,7 +182,10 @@ function broadcastPresence(userId, online) {
 
 // ── Session Recording ──────────────────────────────────────────────────────
 
-async function recordSession(sessionId, session, completed) {
+// participantIds lets callers pass a snapshot taken *before* they mutate
+// session.players — the abandoned-session path records the last player leaving,
+// by which point they're already gone from the live map.
+async function recordSession(sessionId, session, completed, participantIds) {
   if (!supabase) return;
 
   const elapsed = session.phaseStartTime
@@ -189,9 +193,7 @@ async function recordSession(sessionId, session, completed) {
     : 0;
   const actualFocus = completed ? session.focusDuration : Math.min(elapsed, session.focusDuration);
 
-  const userIds = Object.values(session.players)
-    .map(p => p.userId)
-    .filter(Boolean);
+  const userIds = participantIds ?? sessionParticipantIds(session);
 
   if (userIds.length === 0) return;
 
@@ -312,13 +314,17 @@ function finalizePlayerRemoval(sessionId, socketId) {
   const player = session.players[socketId];
   if (player.userId) clearPresence(player.userId);
 
+  // Snapshot participants before the removal — if this is the last player, the
+  // abandoned-focus record below still needs to know who was in the session.
+  const participantIds = sessionParticipantIds(session);
+
   const playerCount = removePlayer(session, socketId);
   console.log(`[${sessionId}] ${socketId} left (${playerCount} remaining)`);
 
   io.to(sessionId).emit('player_left', { playerId: socketId });
 
   if (playerCount === 0) {
-    if (session.phase === 'focus') recordSession(sessionId, session, false);
+    if (session.phase === 'focus') recordSession(sessionId, session, false, participantIds);
     if (session.phaseTimer) clearTimeout(session.phaseTimer);
     delete sessions[sessionId];
     console.log(`[${sessionId}] Session deleted`);

--- a/server/session.js
+++ b/server/session.js
@@ -53,6 +53,19 @@ function removePlayer(session, socketId) {
   return Object.keys(session.players).length;
 }
 
+// Distinct authenticated userIds currently holding a slot. Deduped because
+// session_participants has a unique (session_id, user_id) index — a repeated id
+// would fail the whole batch insert, losing the entire record.
+function sessionParticipantIds(session) {
+  return [
+    ...new Set(
+      Object.values(session.players)
+        .map((p) => p.userId)
+        .filter(Boolean),
+    ),
+  ];
+}
+
 function buildSyncPayload(session) {
   return {
     mode: session.mode,
@@ -74,5 +87,6 @@ module.exports = {
   setPlayerPet,
   findPlayerByUserId,
   markPlayerDisconnected,
+  sessionParticipantIds,
   buildSyncPayload,
 };

--- a/server/session.test.js
+++ b/server/session.test.js
@@ -6,6 +6,7 @@ import {
   setPlayerPet,
   findPlayerByUserId,
   markPlayerDisconnected,
+  sessionParticipantIds,
   buildSyncPayload,
 } from "./session.js";
 
@@ -100,6 +101,46 @@ describe("presence maps", () => {
     userSockets.delete("user-1");
     socketToUser.delete("socket-a");
     expect(userSockets.has("user-1")).toBe(false);
+  });
+});
+
+describe("sessionParticipantIds", () => {
+  it("collects the authenticated userIds in the session", () => {
+    const s = createSessionState("forest", "host");
+    addPlayer(s, "p1", { avatar: {}, displayName: "A", userId: "u1" });
+    addPlayer(s, "p2", { avatar: {}, displayName: "B", userId: "u2" });
+    expect(sessionParticipantIds(s).sort()).toEqual(["u1", "u2"]);
+  });
+
+  it("skips anonymous players", () => {
+    const s = createSessionState("forest", "host");
+    addPlayer(s, "p1", { avatar: {}, displayName: "A", userId: "u1" });
+    addPlayer(s, "p2", { avatar: {}, displayName: "B", userId: null });
+    expect(sessionParticipantIds(s)).toEqual(["u1"]);
+  });
+
+  // session_participants has a unique (session_id, user_id) index, so a
+  // repeated id would fail the batch insert and lose the whole record
+  it("dedupes a userId holding two slots", () => {
+    const s = createSessionState("forest", "host");
+    addPlayer(s, "p1", { avatar: {}, displayName: "A", userId: "u1" });
+    addPlayer(s, "p2", { avatar: {}, displayName: "A", userId: "u1" });
+    expect(sessionParticipantIds(s)).toEqual(["u1"]);
+  });
+
+  it("returns an empty array for an empty session", () => {
+    expect(sessionParticipantIds(createSessionState("forest", "host"))).toEqual([]);
+  });
+
+  // The abandoned-focus bug: the last player is removed before recording, so
+  // the live map is empty by then and a snapshot is the only source of truth.
+  it("snapshot survives removal of the last player", () => {
+    const s = createSessionState("forest", "host");
+    addPlayer(s, "p1", { avatar: {}, displayName: "A", userId: "u1" });
+    const snapshot = sessionParticipantIds(s);
+    expect(removePlayer(s, "p1")).toBe(0);
+    expect(sessionParticipantIds(s)).toEqual([]);
+    expect(snapshot).toEqual(["u1"]);
   });
 });
 

--- a/supabase/migrations/010_lock_privileged_columns.sql
+++ b/supabase/migrations/010_lock_privileged_columns.sql
@@ -1,0 +1,102 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Lock down privileged columns + fix friendship UPDATE/DELETE
+-- ─────────────────────────────────────────────────────────────────────────────
+--
+-- Three holes, all reachable with nothing but the public anon key:
+--
+--   1. profiles_update_own allows updating ANY column of your own row, so a
+--      user could set is_premium = true, rewrite username/discriminator to
+--      bypass claim_username's one-time rule, clear username_changed, reset
+--      display_name_changed_at to dodge the 7-day cooldown, or spoof
+--      current_session_id so friends see a bogus "join" target.
+--
+--   2. friendships_accept is `FOR UPDATE ... USING (addressee_id = auth.uid())`
+--      with no WITH CHECK and no column restriction. Postgres reuses USING as
+--      the check, and both the old and new row satisfy it as long as
+--      addressee_id stays put — so anyone holding a single pending request
+--      could rewrite that row's requester_id to an arbitrary victim and set
+--      status = 'accepted', forging a friendship. That grants presence
+--      visibility, invites, and shared-task reads against someone who never
+--      interacted with them.
+--
+--   3. friendships has no DELETE policy at all, so declining a request or
+--      removing a friend silently matched zero rows and the entry came right
+--      back on the next refetch.
+--
+-- RLS alone can't fix 1 and 2: a policy gates WHICH ROWS you may write, not
+-- WHICH COLUMNS. Column privileges are the right tool. Note that in Postgres a
+-- table-level UPDATE grant outranks column-level grants entirely, so the
+-- table-level grant has to go first — otherwise the GRANTs below are dead
+-- weight. Supabase hands `authenticated` table-wide UPDATE by default.
+--
+-- The privileged writes keep working because they don't go through this role:
+-- claim_username / change_display_name are SECURITY DEFINER (they execute as
+-- the owner), and the presence writes use the service key, which bypasses both
+-- RLS and these grants.
+
+-- ── profiles ──────────────────────────────────────────────────────────────
+REVOKE UPDATE ON profiles FROM authenticated, anon;
+
+-- Only what the client legitimately writes directly:
+--   avatar_config — AvatarCreator save
+--   display_name  — set once during first-run setup (see caveat below)
+--   updated_at    — touched alongside those writes
+GRANT UPDATE (avatar_config, display_name, updated_at) ON profiles TO authenticated;
+
+-- CAVEAT: display_name stays directly writable because first-run setup writes
+-- it straight to the table, before any cooldown should apply. That means the
+-- 7-day cooldown in change_display_name is still bypassable by calling the
+-- REST API directly. It's cosmetic abuse (renaming yourself often), not
+-- privilege escalation, so it's deliberately left for a follow-up that folds
+-- the first-set into an RPC and drops display_name from this grant.
+
+-- ── friendships ───────────────────────────────────────────────────────────
+REVOKE UPDATE ON friendships FROM authenticated, anon;
+
+-- Accepting a request is the only legitimate client-side update, and status is
+-- the only column it needs. With requester_id/addressee_id no longer writable,
+-- the forgery in (2) is impossible regardless of policy wording.
+GRANT UPDATE (status) ON friendships TO authenticated;
+
+-- Defense in depth: pin the post-update row as well, so a future re-widening
+-- of the grants can't silently reopen the hole.
+DROP POLICY IF EXISTS "friendships_accept" ON friendships;
+CREATE POLICY "friendships_accept" ON friendships FOR UPDATE TO authenticated
+  USING (addressee_id = auth.uid())
+  WITH CHECK (addressee_id = auth.uid() AND status IN ('pending', 'accepted'));
+
+-- Either party may withdraw: the addressee declines or unfriends, the
+-- requester cancels a pending request or unfriends.
+DROP POLICY IF EXISTS "friendships_delete" ON friendships;
+CREATE POLICY "friendships_delete" ON friendships FOR DELETE TO authenticated
+  USING (requester_id = auth.uid() OR addressee_id = auth.uid());
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Verification — run this AFTER applying, in the same SQL editor.
+-- ─────────────────────────────────────────────────────────────────────────────
+--
+-- 1. Expect exactly avatar_config, display_name, updated_at for profiles, and
+--    exactly status for friendships. Any other row means the REVOKE didn't
+--    take (most likely something re-granted table-wide UPDATE afterwards).
+--
+--   SELECT table_name, column_name
+--     FROM information_schema.column_privileges
+--    WHERE grantee = 'authenticated'
+--      AND privilege_type = 'UPDATE'
+--      AND table_name IN ('profiles', 'friendships')
+--    ORDER BY table_name, column_name;
+--
+-- 2. Expect NO rows. A row here means table-level UPDATE is still granted,
+--    which silently outranks every column grant above and leaves all three
+--    holes open.
+--
+--   SELECT grantee, table_name
+--     FROM information_schema.table_privileges
+--    WHERE grantee IN ('authenticated', 'anon')
+--      AND privilege_type = 'UPDATE'
+--      AND table_name IN ('profiles', 'friendships');
+--
+-- 3. Expect a friendships_delete row alongside the others.
+--
+--   SELECT policyname, cmd FROM pg_policies
+--    WHERE tablename = 'friendships' ORDER BY policyname;


### PR DESCRIPTION
## Summary

Four bugs where the app claimed to protect data it wasn't actually protecting. Three of them need a SQL migration you'll have to apply by hand.

### 1. Abandoned focus sessions were never recorded *(server)*

`finalizePlayerRemoval` called `removePlayer` **before** `recordSession`, and `recordSession` builds its participant list from `session.players` and bails when that list is empty. So the last player leaving mid-focus wrote nothing at all — no `sessions` row, no participants — even though `CLAUDE.md` documents abandoned focus as being recorded. In practice it only ever worked via the explicit stop button.

`recordSession` now takes an optional `participantIds` snapshot, captured before the player map is mutated. The new `sessionParticipantIds` helper lives in `session.js` per the repo convention and **dedupes** ids, because `session_participants` has a unique `(session_id, user_id)` index — a repeated id would fail the batch insert and lose the whole record.

### 2. RLS let anyone forge a friendship with a third party *(migration 010)*

`friendships_accept` was `FOR UPDATE ... USING (addressee_id = auth.uid())` with no `WITH CHECK` and no column restriction. Postgres reuses `USING` as the check, and both the old and new row satisfy it as long as `addressee_id` stays put — so anyone holding a single pending request could rewrite that row's `requester_id` to an arbitrary victim and set `status = 'accepted'`. The victim then sees them as a friend, which grants presence visibility, invites, and shared-task reads.

### 3. Anyone could grant themselves premium *(migration 010)*

`profiles_update_own` allowed updating **any** column of your own row with the public anon key: `is_premium`, `username`/`discriminator` (bypassing `claim_username`'s one-time rule), `username_changed`, `display_name_changed_at` (dodging the 7-day cooldown), and `current_session_id` (spoofing a join target friends can see).

### 4. Declining or removing a friend silently did nothing *(migration 010 + client)*

`friendships` had no DELETE policy, so `.delete()` matched zero rows, returned no error, and the entry reappeared on the next refetch.

## How the RLS fixes work

RLS can't fix 2 and 3 — a policy gates which **rows** you may write, not which **columns**. Migration 010 uses column privileges instead. The important subtlety: in Postgres a table-level UPDATE grant **outranks** column-level grants entirely, and Supabase grants `authenticated` table-wide UPDATE by default — so the migration revokes that first, otherwise the column grants would be dead weight.

The privileged writes are unaffected because they don't go through that role: `claim_username` and `change_display_name` are `SECURITY DEFINER`, and presence writes use the service key.

## Notes / caveats

- **`display_name` stays client-writable, so its 7-day cooldown is still bypassable.** First-run setup writes it directly to the table before any cooldown should apply. This is cosmetic abuse rather than privilege escalation; documented in the migration as a follow-up that folds the first-set into an RPC.
- The client's fallback profile upsert is now insert-if-missing (`ON CONFLICT DO NOTHING`). It previously would **overwrite a real username with a generated one** whenever the preceding SELECT merely timed out on a slow connection — and its conflict path would have needed UPDATE rights on exactly the columns this migration revokes.
- Auto-accepting when a reciprocal friend request already exists would be nicer than the new error message, but that's a behavior change rather than error reporting — left as a follow-up.

## Test plan

- [x] 22 server unit tests (5 new for `sessionParticipantIds`, incl. the dedupe and post-removal-snapshot cases)
- [x] Client tsc, tests, production build clean; no new lint violations
- [x] Abandoned-recording verified against a stubbed Supabase REST API — 7 assertions covering solo-abandon and two-player cases (including that the *first* of two leaving must **not** record); fails against `main`, passes here
- [x] Reconnect-grace suite still green (13 assertions), so the `finalizePlayerRemoval` change didn't regress it
- [ ] **Migration 010 is unapplied.** Run it in the Supabase SQL editor; verification queries are at the bottom of the file. I could not test the SQL — no local Postgres, and I didn't want to touch production.
- [ ] After applying: confirm decline-request works and that a non-privileged `is_premium` update is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)