### PR TITLE
fix: session access control + shared notes visible during the session

### DIFF
--- a/client/src/components/DuoTimer.tsx
+++ b/client/src/components/DuoTimer.tsx
@@ -64,6 +64,18 @@ export default function DuoTimer() {
     if (!game.sessionId) setAppStep("game");
   };
 
+  // ── Socket-reported errors ──────────────────────────────────────────────
+  // A refused or stale join used to be console-only, stranding the user on an
+  // empty game screen reading "Setting up…". Show it and send them home.
+  useEffect(() => {
+    if (!game.sessionError) return;
+    showError(game.sessionError);
+    game.clearSessionError();
+    if (!game.sessionId) setAppStep((step) => (step === "game" ? "home" : step));
+    // showError/setAppStep are stable; re-running on sessionId would re-fire
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [game.sessionError]);
+
   // ── Resume after a page reload ──────────────────────────────────────────
   // The server holds our spot during its reconnect grace window; once we're
   // back on home with an avatar loaded, silently rejoin the stored session —

--- a/client/src/hooks/useFriendSearch.ts
+++ b/client/src/hooks/useFriendSearch.ts
@@ -10,37 +10,21 @@ export function useFriendSearch(myProfileId: string) {
   const [error, setError] = useState<string | null>(null);
   const sb = getSupabase();
 
+  // Goes through the search_profiles RPC rather than selecting from profiles
+  // directly: the table's read policy is scoped to people you actually know,
+  // and the RPC returns public identity fields only — never presence. It also
+  // owns the tag-vs-partial split, wildcard escaping and the caller exclusion.
   const handleSearch = async () => {
     const query = searchQuery.trim();
     if (!query || query.length < 3) return;
     setLoading(true);
-    const hashIdx = query.indexOf("#");
+    setError(null);
 
-    let result;
-    if (hashIdx !== -1 && query.length > hashIdx + 1) {
-      // Full tag search: name#XXXX → exact match
-      const name = query.slice(0, hashIdx).toLowerCase();
-      const disc = query.slice(hashIdx + 1);
-      result = await sb
-        .from("profiles")
-        .select("id, username, discriminator, display_name, is_premium, current_room")
-        .eq("username", name)
-        .eq("discriminator", disc)
-        .neq("id", myProfileId)
-        .limit(10);
-    } else {
-      // Partial search: ilike on username — escape SQL wildcards
-      const escaped = query.replace(/%/g, "\\%").replace(/_/g, "\\_");
-      result = await sb
-        .from("profiles")
-        .select("id, username, discriminator, display_name, is_premium, current_room")
-        .ilike("username", `%${escaped}%`)
-        .neq("id", myProfileId)
-        .limit(10);
-    }
+    const { data, error: err } = await sb.rpc("search_profiles", { query });
+
     // Without this, a failed query is indistinguishable from "no such user"
-    if (result.error) setError("Search failed. Check your connection.");
-    setSearchResults((result.data as Profile[]) ?? []);
+    if (err) setError("Search failed. Check your connection.");
+    setSearchResults((data as Profile[]) ?? []);
     setLoading(false);
   };
 

--- a/client/src/hooks/useGameSession.ts
+++ b/client/src/hooks/useGameSession.ts
@@ -80,6 +80,9 @@ export function useGameSession(profile: Profile | null) {
 
   // ── UI state ────────────────────────────────────────────────────────────
   const [pendingInvite, setPendingInvite] = useState<InviteData | null>(null);
+  // Surfaced as a toast by DuoTimer — these used to be console-only, which left
+  // a refused join sitting on an empty game screen with no explanation.
+  const [sessionError, setSessionError] = useState<string | null>(null);
   const [inviteSentName, setInviteSentName] = useState<string | null>(null);
 
   // Pending outbound invite
@@ -179,7 +182,11 @@ export function useGameSession(profile: Profile | null) {
 
       socket.on("session_error", ({ message }: { message: string }) => {
         console.error("Session error:", message);
-        if (message === "Session not found") {
+        setSessionError(message);
+        // Both mean "you are not in a session" — drop any local state that
+        // says otherwise, so we don't sit on a screen for a session we
+        // aren't actually in.
+        if (message === "Session not found" || message === "This session is private") {
           // Stale resume attempt or expired invite — the server has already
           // removed us from any previous session, so mirror that here
           sessionStorage.removeItem(RESUME_KEY);
@@ -278,6 +285,7 @@ export function useGameSession(profile: Profile | null) {
       socket.on("invite_error", ({ message }: { message: string }) => {
         setInviteSentName(null);
         console.warn("Invite error:", message);
+        setSessionError(message);
       });
     }
 
@@ -559,6 +567,8 @@ export function useGameSession(profile: Profile | null) {
     // Invite state
     pendingInvite,
     dismissInvite,
+    sessionError,
+    clearSessionError: useCallback(() => setSessionError(null), []),
     inviteSentName,
   };
 }

--- a/server/index.js
+++ b/server/index.js
@@ -181,6 +181,20 @@ async function areFriends(userId, otherUserId) {
   return friendIds.includes(otherUserId);
 }
 
+// Knowing a session UUID must not be enough to walk into it. Session ids leak
+// easily — profiles.current_session_id is readable by anyone the DB lets read
+// the row, and ids travel through invites and client state.
+async function canJoinSession(session, userId) {
+  if (!supabase) return true;                            // dev mode, see areFriends
+  if (!userId) return false;
+  if (findPlayerByUserId(session, userId)) return true;  // reconnecting to own slot
+  if (isInvited(session, userId)) return true;           // explicitly invited
+  // Otherwise you must already know someone in there — this is what keeps the
+  // "join" button on a friend's presence card working without an invite.
+  const friendIds = new Set(await getFriendIds(userId));
+  return sessionParticipantIds(session).some((id) => friendIds.has(id));
+}
+
 function broadcastPresence(userId, online) {
   getFriendIds(userId).then(friendIds => {
     for (const fid of friendIds) {
@@ -490,7 +504,7 @@ io.on('connection', (socket) => {
   // join_session: { sessionId, avatar, displayName, pet }
   // Joins an existing session by its UUID.
   // userId comes from verified socket.userId (auth middleware).
-  socket.on('join_session', ({ sessionId, avatar, displayName, pet }) => {
+  socket.on('join_session', async ({ sessionId, avatar, displayName, pet }) => {
     if (!rateLimits.joinSession(socket.id)) {
       socket.emit('session_error', { message: 'Too many requests, slow down' });
       return;
@@ -506,9 +520,6 @@ io.on('connection', (socket) => {
       return;
     }
 
-    const prevSession = socketToSession[socket.id];
-    if (prevSession && prevSession !== sessionId) leaveSession(socket, prevSession);
-
     const session = getSession(sessionId);
     if (!session) {
       socket.emit('session_error', { message: 'Session not found' });
@@ -516,6 +527,17 @@ io.on('connection', (socket) => {
     }
 
     const userId = socket.userId || null;
+
+    // Authorize *before* touching any existing state — a refused join must not
+    // eject the caller from the session they're already in.
+    if (!(await canJoinSession(session, userId))) {
+      socket.emit('session_error', { message: 'This session is private' });
+      console.log(`[${sessionId}] refused join from ${userId}`);
+      return;
+    }
+
+    const prevSession = socketToSession[socket.id];
+    if (prevSession && prevSession !== sessionId) leaveSession(socket, prevSession);
 
     // Reconnect: this user already has a player slot in the session under an
     // old socket id (grace-pending, or a zombie socket the server hasn't

--- a/server/index.js
+++ b/server/index.js
@@ -9,6 +9,8 @@ const {
   addPlayer,
   removePlayer,
   setPlayerPet,
+  inviteUser,
+  isInvited,
   findPlayerByUserId,
   markPlayerDisconnected,
   sessionParticipantIds,
@@ -167,6 +169,16 @@ async function getFriendIds(userId) {
     .or(`requester_id.eq.${userId},addressee_id.eq.${userId}`);
   if (!data) return [];
   return data.map(f => f.requester_id === userId ? f.addressee_id : f.requester_id);
+}
+
+// Dev mode (no Supabase) has no friendship data at all; treat everyone as
+// friends there so local development isn't blocked by an unanswerable check.
+async function areFriends(userId, otherUserId) {
+  if (!supabase) return true;
+  if (!userId || !otherUserId) return false;
+  if (userId === otherUserId) return true;
+  const friendIds = await getFriendIds(userId);
+  return friendIds.includes(otherUserId);
 }
 
 function broadcastPresence(userId, online) {
@@ -389,7 +401,7 @@ io.on('connection', (socket) => {
   });
 
   // ── Invite relay ────────────────────────────────────────────────────────
-  socket.on('send_invite', ({ targetUserId, sessionId, worldId, fromName }) => {
+  socket.on('send_invite', async ({ targetUserId, sessionId, worldId, fromName }) => {
     if (!rateLimits.sendInvite(socket.id)) {
       socket.emit('invite_error', { message: 'Too many invites, slow down' });
       return;
@@ -400,6 +412,15 @@ io.on('connection', (socket) => {
       socket.emit('invite_error', { message: 'You are not in this session' });
       return;
     }
+
+    // Friends only. get_online_friends already validates friendship; without
+    // the same check here, any online user could be pushed an invite whose
+    // attacker-controlled fromName renders in a full-screen modal.
+    if (!(await areFriends(socket.userId, targetUserId))) {
+      socket.emit('invite_error', { message: 'You can only invite friends' });
+      return;
+    }
+
     const targetSocketId = userSockets.get(targetUserId);
     if (!targetSocketId) {
       socket.emit('invite_error', { message: 'Friend is offline' });
@@ -409,6 +430,11 @@ io.on('connection', (socket) => {
     const fromUserId = socket.userId || null;
     const safeName = (typeof fromName === 'string' ? fromName : 'Someone').slice(0, MAX_DISPLAY_NAME);
     const safeWorld = VALID_WORLDS.includes(worldId) ? worldId : null;
+
+    // Allowlist the invitee so the join gate lets them in
+    if (typeof sessionId === 'string' && sessions[sessionId]) {
+      inviteUser(sessions[sessionId], targetUserId);
+    }
     io.to(targetSocketId).emit('session_invite', {
       sessionId: typeof sessionId === 'string' ? sessionId : null,
       worldId: safeWorld,

--- a/server/session.js
+++ b/server/session.js
@@ -12,7 +12,20 @@ function createSessionState(world, hostSocketId) {
     world: world || "forest",
     hostId: hostSocketId,
     players: {},
+    // userIds explicitly invited to this session. Knowing the session UUID is
+    // not by itself permission to join — see canJoinSession in index.js.
+    invitedUserIds: new Set(),
   };
+}
+
+function inviteUser(session, userId) {
+  if (!userId) return false;
+  session.invitedUserIds.add(userId);
+  return true;
+}
+
+function isInvited(session, userId) {
+  return Boolean(userId) && session.invitedUserIds.has(userId);
 }
 
 function addPlayer(session, socketId, { avatar, displayName, userId, pet }) {
@@ -85,6 +98,8 @@ module.exports = {
   addPlayer,
   removePlayer,
   setPlayerPet,
+  inviteUser,
+  isInvited,
   findPlayerByUserId,
   markPlayerDisconnected,
   sessionParticipantIds,

--- a/server/session.test.js
+++ b/server/session.test.js
@@ -6,6 +6,8 @@ import {
   setPlayerPet,
   findPlayerByUserId,
   markPlayerDisconnected,
+  inviteUser,
+  isInvited,
   sessionParticipantIds,
   buildSyncPayload,
 } from "./session.js";
@@ -141,6 +143,41 @@ describe("sessionParticipantIds", () => {
     expect(removePlayer(s, "p1")).toBe(0);
     expect(sessionParticipantIds(s)).toEqual([]);
     expect(snapshot).toEqual(["u1"]);
+  });
+});
+
+describe("invite allowlist", () => {
+  it("a new session has nobody invited", () => {
+    const s = createSessionState("forest", "host");
+    expect(s.invitedUserIds.size).toBe(0);
+    expect(isInvited(s, "u1")).toBe(false);
+  });
+
+  it("records an invited user", () => {
+    const s = createSessionState("forest", "host");
+    expect(inviteUser(s, "u1")).toBe(true);
+    expect(isInvited(s, "u1")).toBe(true);
+    expect(isInvited(s, "u2")).toBe(false);
+  });
+
+  it("is idempotent", () => {
+    const s = createSessionState("forest", "host");
+    inviteUser(s, "u1");
+    inviteUser(s, "u1");
+    expect(s.invitedUserIds.size).toBe(1);
+  });
+
+  it("ignores a null userId rather than allowlisting everyone", () => {
+    const s = createSessionState("forest", "host");
+    expect(inviteUser(s, null)).toBe(false);
+    expect(isInvited(s, null)).toBe(false);
+    expect(isInvited(s, undefined)).toBe(false);
+  });
+
+  it("stays out of the sync payload", () => {
+    const s = createSessionState("forest", "host");
+    inviteUser(s, "u1");
+    expect(buildSyncPayload(s)).not.toHaveProperty("invitedUserIds");
   });
 });
 

--- a/supabase/migrations/011_search_profiles_rpc.sql
+++ b/supabase/migrations/011_search_profiles_rpc.sql
@@ -1,0 +1,67 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- search_profiles RPC
+-- ─────────────────────────────────────────────────────────────────────────────
+--
+-- Prerequisite for migration 012, which stops letting every authenticated user
+-- SELECT every profile row. Friend search is the one legitimate reason to read
+-- a stranger's profile, and it only needs the public identity fields — never
+-- presence (current_session_id / current_world_id / current_room), which is
+-- what makes the current blanket read policy an enumeration path into other
+-- people's live sessions.
+--
+-- SECURITY DEFINER so it keeps working once the table policy narrows.
+
+CREATE OR REPLACE FUNCTION search_profiles(query TEXT)
+RETURNS TABLE (
+  id            UUID,
+  username      TEXT,
+  discriminator TEXT,
+  display_name  TEXT,
+  is_premium    BOOLEAN
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  caller_id UUID := auth.uid();
+  raw       TEXT := lower(trim(coalesce(query, '')));
+  hash_at   INT;
+  want_name TEXT;
+  want_disc TEXT;
+BEGIN
+  IF caller_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  -- Mirrors the client guard; also stops '' matching every row via ILIKE
+  IF char_length(raw) < 3 THEN
+    RETURN;
+  END IF;
+
+  hash_at := position('#' IN raw);
+
+  IF hash_at > 0 AND char_length(raw) > hash_at THEN
+    -- Exact tag lookup: name#0000
+    want_name := substring(raw FROM 1 FOR hash_at - 1);
+    want_disc := substring(raw FROM hash_at + 1);
+    RETURN QUERY
+      SELECT p.id, p.username, p.discriminator, p.display_name, p.is_premium
+        FROM profiles p
+       WHERE p.username = want_name
+         AND p.discriminator = want_disc
+         AND p.id <> caller_id
+       LIMIT 10;
+  ELSE
+    -- Partial match. Escape LIKE wildcards so a user can't scan with '%'.
+    RETURN QUERY
+      SELECT p.id, p.username, p.discriminator, p.display_name, p.is_premium
+        FROM profiles p
+       WHERE p.username ILIKE '%' || replace(replace(raw, '%', '\%'), '_', '\_') || '%'
+         AND p.id <> caller_id
+       LIMIT 10;
+  END IF;
+END $$;
+
+REVOKE ALL ON FUNCTION search_profiles(TEXT) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION search_profiles(TEXT) TO authenticated;

--- a/supabase/migrations/012_restrict_profile_reads.sql
+++ b/supabase/migrations/012_restrict_profile_reads.sql
@@ -1,0 +1,55 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Stop every user being able to read every profile
+-- ─────────────────────────────────────────────────────────────────────────────
+--
+-- profiles_read_all was `USING (true)`: any authenticated user could read any
+-- profile row, including current_session_id / current_world_id / current_room.
+-- Combined with join_session having had no membership check, that was a
+-- complete enumeration path into strangers' live sessions — and independently
+-- it leaks who is online, what they're doing, and when.
+--
+-- Reads are now scoped to people you actually have a relationship with:
+--   * yourself
+--   * anyone you have a friendships row with, in EITHER direction and at ANY
+--     status. Pending matters as much as accepted: the Requests tab joins
+--     profiles for the requester, and those aren't friends yet.
+--
+-- Discovering new people goes through search_profiles() (migration 011), which
+-- is SECURITY DEFINER and returns public identity fields only — no presence.
+--
+-- Requires 011 to be applied first, and the client to be using the RPC,
+-- otherwise friend search silently returns nothing.
+
+DROP POLICY IF EXISTS "profiles_read_all" ON profiles;
+DROP POLICY IF EXISTS "profiles_read_known" ON profiles;
+
+CREATE POLICY "profiles_read_known" ON profiles FOR SELECT TO authenticated
+  USING (
+    id = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM friendships f
+      WHERE (f.requester_id = auth.uid() AND f.addressee_id = profiles.id)
+         OR (f.addressee_id = auth.uid() AND f.requester_id = profiles.id)
+    )
+  );
+
+-- The policy's EXISTS probes friendships by each side independently; the only
+-- existing index is the LEAST/GREATEST expression one, which cannot serve
+-- either lookup. Without these, every profile read becomes a seq scan of
+-- friendships.
+CREATE INDEX IF NOT EXISTS friendships_requester_idx ON friendships (requester_id);
+CREATE INDEX IF NOT EXISTS friendships_addressee_idx ON friendships (addressee_id);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Verification — run AFTER applying.
+-- ─────────────────────────────────────────────────────────────────────────────
+--
+-- 1. Expect exactly one SELECT policy, named profiles_read_known:
+--
+--   SELECT policyname, cmd FROM pg_policies
+--    WHERE tablename = 'profiles' AND cmd = 'SELECT';
+--
+-- 2. Expect both new indexes present:
+--
+--   SELECT indexname FROM pg_indexes
+--    WHERE tablename = 'friendships' ORDER BY indexname;

--- a/supabase/migrations/013_shared_tasks_during_session.sql
+++ b/supabase/migrations/013_shared_tasks_during_session.sql
@@ -1,0 +1,60 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Make shared sticky notes visible during the session, not after it
+-- ─────────────────────────────────────────────────────────────────────────────
+--
+-- tasks_read (007) grants non-owner reads only via:
+--   EXISTS (session_participants sp JOIN sessions s ON s.room_code = ...)
+--
+-- But `sessions` rows are written exclusively by recordSession() on the server,
+-- which fires when a focus phase completes or is stopped. So during `waiting`
+-- and the whole of the first focus round there is no sessions row carrying that
+-- room_code, and the partner's SELECT — plus the realtime subscription in
+-- useStickyNotes, which is RLS-filtered the same way — return nothing.
+--
+-- The result: "Our Goals" silently shows its empty state at exactly the moment
+-- a couple would use it, then fills in later. It looks like the feature is
+-- broken rather than gated.
+--
+-- Fix: also allow reads when the caller is *currently in* that session.
+-- profiles.current_session_id is maintained by the server with the service key,
+-- and migration 010 revoked UPDATE on it from authenticated/anon — so it is a
+-- trustworthy statement of where someone actually is, not a client claim.
+--
+-- The historical clause is kept: past participants keep access to notes from
+-- sessions they were part of.
+
+DROP POLICY IF EXISTS "tasks_read" ON tasks;
+CREATE POLICY "tasks_read" ON tasks FOR SELECT TO authenticated
+  USING (
+    owner_id = auth.uid()
+    OR (
+      is_shared = TRUE
+      AND room_code IS NOT NULL
+      AND (
+        -- In that session right now (server-maintained presence)
+        room_code = (
+          SELECT p.current_session_id::text
+            FROM profiles p
+           WHERE p.id = auth.uid()
+        )
+        -- …or was a participant once it got recorded
+        OR EXISTS (
+          SELECT 1 FROM session_participants sp
+          JOIN sessions s ON s.id = sp.session_id
+          WHERE s.room_code = tasks.room_code
+            AND sp.user_id = auth.uid()
+        )
+      )
+    )
+  );
+
+-- sessions.room_code is the join key in the historical clause above, evaluated
+-- per candidate task row, and was unindexed.
+CREATE INDEX IF NOT EXISTS sessions_room_code_idx ON sessions (room_code);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Verification — run AFTER applying.
+-- ─────────────────────────────────────────────────────────────────────────────
+--
+--   SELECT indexname FROM pg_indexes WHERE tablename = 'sessions';
+--   SELECT policyname FROM pg_policies WHERE tablename = 'tasks' AND cmd = 'SELECT';


### PR DESCRIPTION
## Summary

Two problems: strangers could walk into your live session, and shared sticky notes were invisible for the part of a session you'd actually use them in.

### Strangers could join any session

`join_session` had **no membership check at all** — knowing the session UUID was sufficient. And `profiles_read_all` was `USING (true)`, so every authenticated user could read every profile row, `current_session_id` included. Together that's a complete enumeration path: read a stranger's presence, join their session, and your avatar appears in their world.

`send_invite` had the mirror problem — it checked the target was *online*, never that they were a friend, while `get_online_friends` directly above it does validate friendship. So attacker-controlled `fromName` text could be pushed at any online user, 10/min, and `InvitePopup` renders it in a full-screen modal.

Now: you can join only if you're already a player (reconnect), were explicitly invited, or are a friend of someone currently in the session — that last clause is what keeps the Join button on a friend's presence card working without an invite round trip. The check runs *before* any state is touched, so a refused join no longer ejects you from the session you were already in. Invites are friends-only, and a successful invite allowlists the target.

Profile reads are scoped to yourself plus anyone you share a `friendships` row with, **in either direction and at any status** — pending matters as much as accepted, because the Requests tab joins profiles for people who aren't friends yet. Discovery moves to a `search_profiles` SECURITY DEFINER RPC returning public identity fields only, never presence.

### Shared notes were invisible during the session

`tasks_read` granted non-owner reads only through a join onto `sessions`, but those rows are written exclusively by `recordSession()` when a focus phase **completes**. During `waiting` and the whole first focus round, no row carries that `room_code`, so the partner's query — and the realtime subscription, filtered the same way — returned nothing. "Our Goals" silently showed its empty state at exactly the moment a couple would be planning, then filled in later. Reads now also allow "you are currently in that session", which is trustworthy because migration 010 revoked `current_session_id` from client writes.

## Deploy ordering — important

Migrations **011 and 013 are already applied** to production; they're additive and safe against the currently-deployed client.

**012 is deliberately NOT applied yet.** It narrows the profile read policy, and the currently-deployed client still queries `profiles` directly for search. Applying it before Vercel ships this branch would break friend search in that window. Apply 012 **after** this merges and the deploy completes.

## Notes

- Added indexes on `friendships.requester_id`/`addressee_id` (the new policy's EXISTS probes each side, and the only existing index is the LEAST/GREATEST expression one, which serves neither) and on `sessions.room_code` (join key inside the tasks policy, evaluated per candidate row).
- `areFriends()` and `canJoinSession()` short-circuit to true when Supabase isn't configured — dev mode has no friendship data, so the check is unanswerable there and would otherwise block all local development.
- Session/invite errors now raise a toast and send you home. Previously a refusal left you on an empty game screen reading "Setting up…", which this change would have made much more common.

## Test plan

- [x] 27 server unit tests (5 new for the invite allowlist)
- [x] Access control: 8-assertion suite against a stubbed friendship graph — stranger holding the UUID refused, friend admitted, refused caller keeps their own session, non-friend invite blocked with no modal reaching the target. Three fail against `main`, one reporting "WALKED RIGHT IN"
- [x] Profile reads: verified on Postgres 17 — before, an attacker reads an unrelated stranger and harvests presence table-wide; after, both return zero rows while self / accepted friend / pending requester / `search_profiles` all still work
- [x] Shared notes: verified on Postgres 17 — partner sees the goal mid-session (0 rows before, 1 after) while unshared notes, other rooms and session-less users still read nothing
- [x] `search_profiles`: partial match, exact `name#0000`, short-query and wildcard-scan rejection
- [x] All four earlier suites still green (reconnect grace, two-session leak, leave orphan, abandoned recording)
- [ ] Not browser-verified: the Requests tab under the narrowed policy, and friend search through the RPC

🤖 Generated with [Claude Code](https://claude.com/claude-code)
