### PR TITLE
fix: closing a second tab no longer marks you offline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Local dev needs both processes running. Client env: `NEXT_PUBLIC_SOCKET_URL`, `N
 
 ### Split of responsibilities
 
-- **Socket.IO server** (`server/index.js`) is the source of truth for live session state: phases, timers, players, presence, invites. All session state is **in-memory** (`sessions`, `userSockets` maps) — it does not survive a server restart, and nothing live is read back from the DB.
+- **Socket.IO server** (`server/index.js`) is the source of truth for live session state: phases, timers, players, presence, invites. All session state is **in-memory** (the `sessions` map plus the presence registry in `server/presence.js`) — it does not survive a server restart, and nothing live is read back from the DB.
 - **Supabase** handles auth (JWT), and persistence: profiles, friendships, tasks/sticky notes, and *completed* session history (`sessions` + `session_participants` rows written by the server with the service-role key, bypassing RLS). The client talks to Supabase directly (anon key + RLS) for friends, tasks, and stats.
 - **Client** never trusts its own clock for the timer: the server broadcasts `phase_change` with `phaseStartTime` and durations; the client renders countdowns from `Date.now() - phaseStartTime`.
 
@@ -54,6 +54,7 @@ Security conventions in the socket layer (preserve these when adding events):
 - `io.use()` middleware verifies the Supabase JWT and sets `socket.userId` — **never trust a client-sent userId**.
 - Every inbound payload is validated/sanitized (`sanitizeAvatar`, `VALID_WORLDS`, name length caps, duration clamps `MAX_FOCUS`/`MAX_BREAK`).
 - Mutating events check the socket is actually a player in the session; create/join/invite are rate-limited per socket.
+- Knowing a session id is not permission to use it: `join_session` requires an existing slot, an invite, or friendship with someone already in the session, and `send_invite` is friends-only. Server-side ids are read from `socketToSession`, never taken from the payload.
 
 Pets are part of session state, not just local UI: `set_pet` updates the player's slot server-side (sanitized against `VALID_PETS`) and relays `pet_changed` to the other player, so both sides see the same companion.
 
@@ -72,7 +73,8 @@ Note: `server/session.js` holds the pure session-state helpers (`createSessionSt
 ### Database conventions
 
 - `profiles` extends `auth.users`; usernames use Discord-style `username#discriminator` tags via the `claim_username` RPC (one-time change enforced in SQL, migration 005).
-- Live presence is mirrored into `profiles.current_session_id` / `current_world_id` by the server so friends can see "in a session" from the client's Supabase queries.
+- Live presence is mirrored into `profiles.current_session_id` / `current_world_id` by the server so friends can see "in a session" from the client's Supabase queries. Because only the service key can write those columns (migration 010), they're trusted as proof of where a user is — migration 013's `tasks_read` policy relies on that.
+- Socket presence is tracked per *user* with a set of sockets (`server/presence.js`), not one socket per user: extra tabs must not evict each other, and a user only counts as offline once their last socket closes.
 - RLS is on for all tables; the server's service-role key is what allows it to write session history and presence. Later migrations (004, 007, 009) tightened RLS and pinned function search paths — follow that pattern in new SQL.
 - RLS gates which *rows* a client may write, never which *columns*. Anything privileged (`is_premium`, `username`, presence fields) is protected by column privileges instead — migration 010 revokes table-level UPDATE from `authenticated`/`anon` and grants back only the client-writable columns. A table-level UPDATE grant silently outranks column grants, so never re-grant one. Privileged writes go through `SECURITY DEFINER` RPCs or the service key.
 

--- a/server/index.js
+++ b/server/index.js
@@ -4,6 +4,7 @@ const { Server } = require('socket.io');
 const cors = require('cors');
 const helmet = require('helmet');
 const { createClient } = require('@supabase/supabase-js');
+const { createPresenceRegistry } = require('./presence');
 const {
   createSessionState,
   addPlayer,
@@ -107,9 +108,9 @@ io.use(async (socket, next) => {
 const sessions = {};
 const socketToSession = {};
 
-// Presence: track which users have the app open (userId <-> socketId)
-const userSockets = new Map();   // userId  -> socket.id
-const socketToUser = new Map();  // socket.id -> userId
+// Presence: which users have the app open. Keyed by user with a set of
+// sockets, so extra tabs don't evict each other — see presence.js.
+const presence = createPresenceRegistry();
 
 // ── Simple per-socket rate limiter ───────────────────────────────────────────
 function createRateLimiter(maxPerWindow, windowMs) {
@@ -198,8 +199,8 @@ async function canJoinSession(session, userId) {
 function broadcastPresence(userId, online) {
   getFriendIds(userId).then(friendIds => {
     for (const fid of friendIds) {
-      const fSocketId = userSockets.get(fid);
-      if (fSocketId) {
+      // Every tab the friend has open, not just their most recent one
+      for (const fSocketId of presence.socketsFor(fid)) {
         io.to(fSocketId).emit('presence_update', { userId, online });
       }
     }
@@ -390,14 +391,11 @@ io.on('connection', (socket) => {
   socket.on('register_user', () => {
     const userId = socket.userId;
     if (!userId) return;
-    // If this user already has a socket, clean up the old one
-    const oldSocketId = userSockets.get(userId);
-    if (oldSocketId && oldSocketId !== socket.id) {
-      socketToUser.delete(oldSocketId);
-    }
-    userSockets.set(userId, socket.id);
-    socketToUser.set(socket.id, userId);
-    broadcastPresence(userId, true);
+    // Additive: a second tab joins the user's socket set rather than
+    // replacing the first. Only announce on the offline->online edge, so
+    // opening tabs doesn't spam friends with presence updates.
+    const cameOnline = presence.add(userId, socket.id);
+    if (cameOnline) broadcastPresence(userId, true);
     console.log(`[presence] ${userId} registered (${socket.id})`);
   });
 
@@ -410,7 +408,7 @@ io.on('connection', (socket) => {
     const actualFriendIds = await getFriendIds(userId);
     const friendSet = new Set(actualFriendIds);
     const validIds = (friendIds || []).filter(id => friendSet.has(id));
-    const online = validIds.filter(id => userSockets.has(id));
+    const online = validIds.filter(id => presence.isOnline(id));
     callback(online);
   });
 
@@ -435,8 +433,8 @@ io.on('connection', (socket) => {
       return;
     }
 
-    const targetSocketId = userSockets.get(targetUserId);
-    if (!targetSocketId) {
+    const targetSocketIds = presence.socketsFor(targetUserId);
+    if (targetSocketIds.length === 0) {
       socket.emit('invite_error', { message: 'Friend is offline' });
       return;
     }
@@ -449,12 +447,16 @@ io.on('connection', (socket) => {
     if (typeof sessionId === 'string' && sessions[sessionId]) {
       inviteUser(sessions[sessionId], targetUserId);
     }
-    io.to(targetSocketId).emit('session_invite', {
-      sessionId: typeof sessionId === 'string' ? sessionId : null,
-      worldId: safeWorld,
-      fromName: safeName,
-      fromUserId,
-    });
+    // Deliver to every tab they have open — otherwise the popup can land in a
+    // background tab they aren't looking at.
+    for (const targetSocketId of targetSocketIds) {
+      io.to(targetSocketId).emit('session_invite', {
+        sessionId: typeof sessionId === 'string' ? sessionId : null,
+        worldId: safeWorld,
+        fromName: safeName,
+        fromUserId,
+      });
+    }
     console.log(`[invite] ${safeName} invited ${targetUserId}`);
   });
 
@@ -737,12 +739,12 @@ io.on('connection', (socket) => {
     Object.values(rateLimits).forEach((limiter) => limiter.clear(socket.id));
 
     // Clean up presence
-    const userId = socketToUser.get(socket.id);
+    const { userId, wentOffline } = presence.remove(socket.id);
     if (userId) {
-      userSockets.delete(userId);
-      socketToUser.delete(socket.id);
-      broadcastPresence(userId, false);
-      console.log(`[presence] ${userId} disconnected`);
+      // Only actually offline once the user's last tab is gone.
+      if (wentOffline) broadcastPresence(userId, false);
+      console.log(`[presence] ${userId} socket ${socket.id} closed` +
+        (wentOffline ? ' (now offline)' : ' (other tabs still open)'));
     }
   });
 });

--- a/server/presence.js
+++ b/server/presence.js
@@ -1,0 +1,69 @@
+// Who is online, tracked per *user* rather than per socket.
+//
+// One user can legitimately hold several sockets at once — a second tab, a
+// phone alongside a laptop, or briefly both sides of a reconnect. Collapsing
+// that to a single socketId means the newest tab evicts the previous one, and
+// then closing the newest marks the whole user offline while the first tab is
+// still sitting there connected.
+//
+// Pure data structure, no socket.io. index.js owns the broadcasting.
+
+function createPresenceRegistry() {
+  const socketsByUser = new Map(); // userId   -> Set<socketId>
+  const userBySocket = new Map(); // socketId -> userId
+
+  return {
+    /**
+     * Register a socket for a user.
+     * @returns true when this is the user's first socket, i.e. an
+     *          offline→online transition worth broadcasting.
+     */
+    add(userId, socketId) {
+      if (!userId || !socketId) return false;
+      let sockets = socketsByUser.get(userId);
+      const wasOffline = !sockets || sockets.size === 0;
+      if (!sockets) {
+        sockets = new Set();
+        socketsByUser.set(userId, sockets);
+      }
+      sockets.add(socketId);
+      userBySocket.set(socketId, userId);
+      return wasOffline;
+    },
+
+    /**
+     * Drop a socket.
+     * @returns { userId, wentOffline } — wentOffline is true only when that
+     *          was the user's last remaining socket. userId is null when the
+     *          socket was never registered.
+     */
+    remove(socketId) {
+      const userId = userBySocket.get(socketId);
+      if (!userId) return { userId: null, wentOffline: false };
+      userBySocket.delete(socketId);
+      const sockets = socketsByUser.get(userId);
+      if (!sockets) return { userId, wentOffline: true };
+      sockets.delete(socketId);
+      if (sockets.size > 0) return { userId, wentOffline: false };
+      socketsByUser.delete(userId);
+      return { userId, wentOffline: true };
+    },
+
+    /** Every live socket for a user — invites go to all of their tabs. */
+    socketsFor(userId) {
+      const sockets = socketsByUser.get(userId);
+      return sockets ? [...sockets] : [];
+    },
+
+    isOnline(userId) {
+      const sockets = socketsByUser.get(userId);
+      return Boolean(sockets && sockets.size > 0);
+    },
+
+    userFor(socketId) {
+      return userBySocket.get(socketId) ?? null;
+    },
+  };
+}
+
+module.exports = { createPresenceRegistry };

--- a/server/presence.test.js
+++ b/server/presence.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createPresenceRegistry } from "./presence.js";
+
+describe("presence registry", () => {
+  let p;
+  beforeEach(() => {
+    p = createPresenceRegistry();
+  });
+
+  it("reports the first socket as an offline->online transition", () => {
+    expect(p.isOnline("u1")).toBe(false);
+    expect(p.add("u1", "a")).toBe(true);
+    expect(p.isOnline("u1")).toBe(true);
+  });
+
+  it("does not re-announce a user who is already online", () => {
+    p.add("u1", "a");
+    expect(p.add("u1", "b")).toBe(false);
+  });
+
+  it("keeps a user online while any socket remains", () => {
+    p.add("u1", "a");
+    p.add("u1", "b");
+    expect(p.remove("b")).toEqual({ userId: "u1", wentOffline: false });
+    expect(p.isOnline("u1")).toBe(true);
+  });
+
+  // The bug this module exists for: a second tab used to evict the first, so
+  // closing the *newer* tab marked the user offline everywhere while the
+  // original tab was still connected.
+  it("closing a second tab leaves the first one online", () => {
+    p.add("u1", "tab-a");
+    p.add("u1", "tab-b");
+    p.remove("tab-b");
+    expect(p.isOnline("u1")).toBe(true);
+    expect(p.socketsFor("u1")).toEqual(["tab-a"]);
+  });
+
+  it("goes offline only on the last socket", () => {
+    p.add("u1", "a");
+    p.add("u1", "b");
+    p.remove("a");
+    expect(p.remove("b")).toEqual({ userId: "u1", wentOffline: true });
+    expect(p.isOnline("u1")).toBe(false);
+    expect(p.socketsFor("u1")).toEqual([]);
+  });
+
+  it("lists every socket so invites reach all tabs", () => {
+    p.add("u1", "a");
+    p.add("u1", "b");
+    expect(p.socketsFor("u1").sort()).toEqual(["a", "b"]);
+  });
+
+  it("keeps users independent", () => {
+    p.add("u1", "a");
+    p.add("u2", "b");
+    p.remove("a");
+    expect(p.isOnline("u1")).toBe(false);
+    expect(p.isOnline("u2")).toBe(true);
+  });
+
+  it("maps a socket back to its user", () => {
+    p.add("u1", "a");
+    expect(p.userFor("a")).toBe("u1");
+    expect(p.userFor("nope")).toBe(null);
+  });
+
+  it("removing an unknown socket is a no-op", () => {
+    expect(p.remove("ghost")).toEqual({ userId: null, wentOffline: false });
+  });
+
+  it("adding the same socket twice does not double-count", () => {
+    expect(p.add("u1", "a")).toBe(true);
+    expect(p.add("u1", "a")).toBe(false);
+    expect(p.remove("a").wentOffline).toBe(true);
+  });
+
+  it("ignores falsy ids rather than tracking them", () => {
+    expect(p.add(null, "a")).toBe(false);
+    expect(p.add("u1", null)).toBe(false);
+    expect(p.isOnline(null)).toBe(false);
+  });
+
+  it("a re-registered socket does not resurrect a stale user mapping", () => {
+    p.add("u1", "a");
+    p.remove("a");
+    p.add("u2", "a");
+    expect(p.userFor("a")).toBe("u2");
+    expect(p.isOnline("u1")).toBe(false);
+    expect(p.isOnline("u2")).toBe(true);
+  });
+});

--- a/server/session.test.js
+++ b/server/session.test.js
@@ -82,30 +82,6 @@ describe("buildSyncPayload", () => {
   });
 });
 
-describe("presence maps", () => {
-  it("tracks online users correctly", () => {
-    const userSockets = new Map();
-    const socketToUser = new Map();
-
-    userSockets.set("user-1", "socket-a");
-    socketToUser.set("socket-a", "user-1");
-
-    userSockets.set("user-2", "socket-b");
-    socketToUser.set("socket-b", "user-2");
-
-    expect(userSockets.has("user-1")).toBe(true);
-    expect(userSockets.has("user-3")).toBe(false);
-
-    const friendIds = ["user-1", "user-3", "user-2"];
-    const online = friendIds.filter((id) => userSockets.has(id));
-    expect(online).toEqual(["user-1", "user-2"]);
-
-    userSockets.delete("user-1");
-    socketToUser.delete("socket-a");
-    expect(userSockets.has("user-1")).toBe(false);
-  });
-});
-
 describe("sessionParticipantIds", () => {
   it("collects the authenticated userIds in the session", () => {
     const s = createSessionState("forest", "host");


### PR DESCRIPTION
## Summary

Closing a second tab marked you offline everywhere.

`register_user` stored a single socketId per user and deleted the previous socket's reverse mapping, so opening a second tab evicted the first. Closing that second tab then ran the disconnect cleanup against the whole user: friends' presence dots went dark and invites to you failed with **"Friend is offline"** — while your original tab sat there connected. That tab could never recover either, because `register_user` only fires on `connect`.

Presence is now tracked per *user* with a set of sockets, in a new `server/presence.js`:

- registration is additive, and only announces on the offline→online edge, so opening tabs no longer spams friends with duplicate presence updates
- disconnect broadcasts offline only when the user's **last** socket closes
- `presence_update` fan-out and `session_invite` delivery now reach **every** tab a user has open, rather than only their most recent one — an invite landing exclusively in a background tab was another consequence of the single-socket model

## Notes

- `presence.js` is a pure module with no socket.io, matching how `session.js` holds testable session logic.
- Removed the old `presence maps` test from `session.test.js`. It constructed its own local `Map`s and asserted on those, so it exercised no production code at all — and it encoded exactly the single-socket model this replaces, which made it actively misleading. `presence.test.js` covers the real behavior.
- Migrations 011, 012 and 013 from the previous PR are now all applied and verified in production (`profiles_read_known` is the only SELECT policy on profiles, both friendship indexes exist, `tasks_read` is updated). 012 was deliberately held until the client carrying the `search_profiles` RPC had actually deployed.

## Test plan

- [x] 38 server unit tests, 12 of them new for the presence registry — including the direct regression, that closing a second tab leaves the first online
- [x] Live multi-tab suite (7 assertions) against a stubbed friendship graph: second tab doesn't re-announce, closing it doesn't go dark, `get_online_friends` stays correct, invites still reach the surviving tab, and the last tab closing does go offline. **Four of these fail against `main`**, one reporting the invite bounced with "Friend is offline"
- [x] All five earlier suites still green (reconnect grace, two-session leak, leave orphan, access control, abandoned recording)
- [x] Client tsc, tests, production build
- [ ] Not browser-verified: two real tabs side by side

🤖 Generated with [Claude Code](https://claude.com/claude-code)
