### PR TITLE
chore: zero eslint errors, make the lint job blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - run: npx tsc --noEmit
         working-directory: client
 
+      - run: npm run lint
+        working-directory: client
+
       - run: npm run test:run
         working-directory: client
 
@@ -56,10 +59,3 @@ jobs:
           NEXT_PUBLIC_SUPABASE_URL: https://example.supabase.co
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ci-dummy-anon-key
           NEXT_PUBLIC_SOCKET_URL: http://localhost:3001
-
-# No lint job yet, deliberately. `npm run lint` currently reports ~28
-# pre-existing violations (mostly no-explicit-any in hooks/ plus a few
-# setState-in-effect) in files unrelated to any current work. Adding it as a
-# failing-but-advisory check would paint every PR red and train us to ignore
-# CI; adding it as `|| true` would paint every PR green and hide the signal.
-# The fix is to burn the violations down, then add a blocking lint job here.

--- a/client/src/components/DisplayNameChangeModal.tsx
+++ b/client/src/components/DisplayNameChangeModal.tsx
@@ -44,8 +44,8 @@ export default function DisplayNameChangeModal({
     setError("");
     try {
       await onSubmit(trimmed);
-    } catch (err: any) {
-      setError(err?.message ?? "Failed to change display name");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to change display name");
       setSubmitting(false);
     }
   };

--- a/client/src/components/PetCharacter.tsx
+++ b/client/src/components/PetCharacter.tsx
@@ -145,20 +145,21 @@ export default function PetCharacter({
   const [walkFrame, setWalkFrame] = useState(0);
 
   useEffect(() => {
-    if (anim !== "walk") {
-      setWalkFrame(0);
-      return;
-    }
+    // See PixelCharacter: resetting the frame in the effect body was a
+    // synchronous setState, so the resting frame is derived instead.
+    if (anim !== "walk") return;
     const id = setInterval(() => setWalkFrame((f) => (f + 1) % 2), 250);
     return () => clearInterval(id);
   }, [anim]);
+
+  const frame = anim === "walk" ? walkFrame : 0;
 
   let animClass = "";
   if (anim === "idle") animClass = "pixel-idle";
   if (anim === "jump") animClass = "pixel-jump";
   if (anim === "float") animClass = "pixel-float";
 
-  const legUp = walkFrame === 0;
+  const legUp = frame === 0;
 
   const PetPixels = {
     cat: CatPixels,

--- a/client/src/components/PixelCharacter.tsx
+++ b/client/src/components/PixelCharacter.tsx
@@ -176,13 +176,16 @@ export default function PixelCharacter({
   const [walkFrame, setWalkFrame] = useState(0);
 
   useEffect(() => {
-    if (anim !== "walk") {
-      setWalkFrame(0);
-      return;
-    }
+    // Only run the cycle while walking. The not-walking case used to
+    // setWalkFrame(0) synchronously here, which is a cascading render — the
+    // resting frame is derived below instead.
+    if (anim !== "walk") return;
     const id = setInterval(() => setWalkFrame((f) => (f + 1) % 4), 180);
     return () => clearInterval(id);
   }, [anim]);
+
+  // Anything that isn't a walk renders the neutral stance.
+  const frame = anim === "walk" ? walkFrame : 0;
 
   const pantsColor = darken(outfitColor, 0.3);
   const shoeColor = "#2a2a2a";
@@ -200,7 +203,7 @@ export default function PixelCharacter({
 
   const legPos =
     anim === "walk"
-      ? getWalkLegPos(walkFrame)
+      ? getWalkLegPos(frame)
       : { leftLegY: 18, rightLegY: 18, leftFootY: 23, rightFootY: 23 };
 
   // Sit pose offsets — legs come forward, arms go down
@@ -240,7 +243,7 @@ export default function PixelCharacter({
           {/* Left arm */}
           <g
             transform={
-              anim === "walk" && walkFrame % 4 < 2 ? "translate(0,1)" : ""
+              anim === "walk" && frame % 4 < 2 ? "translate(0,1)" : ""
             }
           >
             <rect x={1} y={12} width={3} height={2} fill={outfitColor} />
@@ -249,7 +252,7 @@ export default function PixelCharacter({
           {/* Right arm */}
           <g
             transform={
-              anim === "walk" && walkFrame % 4 >= 2 ? "translate(0,1)" : ""
+              anim === "walk" && frame % 4 >= 2 ? "translate(0,1)" : ""
             }
           >
             <rect x={12} y={12} width={3} height={2} fill={outfitColor} />

--- a/client/src/components/UsernameChangeModal.tsx
+++ b/client/src/components/UsernameChangeModal.tsx
@@ -34,8 +34,8 @@ export default function UsernameChangeModal({
     setError("");
     try {
       await onSubmit(value);
-    } catch (err: any) {
-      setError(err?.message ?? "Failed to change username");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to change username");
       setSubmitting(false);
     }
   };

--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -42,10 +42,8 @@ export function useAuth() {
   useEffect(() => {
     let mounted = true;
     let sessionHandled = false;
-    let timeoutId: ReturnType<typeof setTimeout>;
-
     const hasOAuthCode = window.location.search.includes("code=");
-    timeoutId = setTimeout(
+    const timeoutId = setTimeout(
       () => {
         if (mounted) setAppStep("landing");
       },

--- a/client/src/hooks/useFriendsList.ts
+++ b/client/src/hooks/useFriendsList.ts
@@ -2,6 +2,18 @@ import { useEffect, useState, useCallback } from "react";
 import { getSupabase } from "@/lib/supabase";
 import type { Profile } from "@/lib/types";
 
+// Shape of the embedded-resource rows PostgREST returns for the two queries
+// below. There are no generated DB types in this repo, so the client can't
+// infer them.
+type FriendshipRow = {
+  id: string;
+  requester_id: string;
+  addressee_id: string;
+  requester: Profile | null;
+  addressee: Profile | null;
+};
+type RequestRow = { id: string; requester: Profile | null };
+
 export function useFriendsList(myProfileId: string, active: boolean) {
   const [friends, setFriends] = useState<Profile[]>([]);
   const [requests, setRequests] = useState<
@@ -23,10 +35,15 @@ export function useFriendsList(myProfileId: string, active: boolean) {
       .eq("status", "accepted");
 
     if (data) {
+      const rows = data as unknown as FriendshipRow[];
       setFriends(
-        data.map((f: any) =>
-          f.requester_id === myProfileId ? f.addressee : f.requester,
-        ) as Profile[],
+        rows
+          .map((f) =>
+            f.requester_id === myProfileId ? f.addressee : f.requester,
+          )
+          // An unreadable profile embeds as null; dropping those beats
+          // pushing a hole into the list for the UI to dereference.
+          .filter((p): p is Profile => Boolean(p)),
       );
     }
 
@@ -43,7 +60,11 @@ export function useFriendsList(myProfileId: string, active: boolean) {
 
     if (reqs) {
       setRequests(
-        reqs.map((r: any) => ({ id: r.id, requester: r.requester as Profile })),
+        (reqs as unknown as RequestRow[])
+          .filter((r): r is { id: string; requester: Profile } =>
+            Boolean(r.requester),
+          )
+          .map((r) => ({ id: r.id, requester: r.requester })),
       );
     }
   }, [sb, myProfileId]);

--- a/client/src/hooks/useFriendsList.ts
+++ b/client/src/hooks/useFriendsList.ts
@@ -70,6 +70,11 @@ export function useFriendsList(myProfileId: string, active: boolean) {
   }, [sb, myProfileId]);
 
   useEffect(() => {
+    // The rule can't see through the async boundary: these fetchers await a
+    // network round trip before any setState, so nothing here is a synchronous
+    // cascading render. Suppressed rather than restructured — the alternative
+    // is a data-fetching library, which is a bigger change than this earns.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (active) fetchFriends();
   }, [active, fetchFriends]);
 

--- a/client/src/hooks/useGameSession.ts
+++ b/client/src/hooks/useGameSession.ts
@@ -295,6 +295,10 @@ export function useGameSession(profile: Profile | null) {
       cancelled = true;
       socketRef.current?.disconnect();
     };
+    // Deliberately mount-only: this owns the single socket connection for the
+    // session's lifetime. sb is a module-level singleton, so sb.auth is stable
+    // and listing it would not change when this runs.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // ── Register presence ───────────────────────────────────────────────────

--- a/client/src/hooks/useOnlineFriends.ts
+++ b/client/src/hooks/useOnlineFriends.ts
@@ -4,6 +4,14 @@ import { getSupabase } from "@/lib/supabase";
 import type { Profile } from "@/lib/types";
 import type { Socket } from "socket.io-client";
 
+// PostgREST embedded-resource shape; no generated DB types in this repo.
+type FriendshipRow = {
+  requester_id: string;
+  addressee_id: string;
+  requester: Profile | null;
+  addressee: Profile | null;
+};
+
 export function useOnlineFriends(
   userId: string,
   socketRef: { current: Socket | null },
@@ -27,9 +35,9 @@ export function useOnlineFriends(
       .eq("status", "accepted");
     if (data) {
       setFriends(
-        data.map((f: any) =>
-          f.requester_id === userId ? f.addressee : f.requester,
-        ) as Profile[],
+        (data as unknown as FriendshipRow[])
+          .map((f) => (f.requester_id === userId ? f.addressee : f.requester))
+          .filter((p): p is Profile => Boolean(p)),
       );
     }
   }, [sb, userId]);

--- a/client/src/hooks/useOnlineFriends.ts
+++ b/client/src/hooks/useOnlineFriends.ts
@@ -43,6 +43,11 @@ export function useOnlineFriends(
   }, [sb, userId]);
 
   useEffect(() => {
+    // The rule can't see through the async boundary: these fetchers await a
+    // network round trip before any setState, so nothing here is a synchronous
+    // cascading render. Suppressed rather than restructured — the alternative
+    // is a data-fetching library, which is a bigger change than this earns.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchFriends();
   }, [fetchFriends]);
 

--- a/client/src/hooks/useStickyNotes.ts
+++ b/client/src/hooks/useStickyNotes.ts
@@ -40,7 +40,12 @@ export function useStickyNotes(
   }, [sb, roomCode]);
 
   useEffect(() => {
+    // The rule can't see through the async boundary: these fetchers await a
+    // network round trip before any setState, so nothing here is a synchronous
+    // cascading render. Suppressed rather than restructured — the alternative
+    // is a data-fetching library, which is a bigger change than this earns.
     if (open) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       fetchMine();
       fetchShared();
     }

--- a/client/src/hooks/useTasks.ts
+++ b/client/src/hooks/useTasks.ts
@@ -19,6 +19,11 @@ export function useTasks(ownerId: string) {
   }, [sb, ownerId]);
 
   useEffect(() => {
+    // The rule can't see through the async boundary: these fetchers await a
+    // network round trip before any setState, so nothing here is a synchronous
+    // cascading render. Suppressed rather than restructured — the alternative
+    // is a data-fetching library, which is a bigger change than this earns.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchTasks();
   }, [fetchTasks]);
 


### PR DESCRIPTION
## Summary

Takes the client from 28 → 0 eslint errors and turns the lint job on as a blocking check. CI has had no lint gate since it was created, because a blocking job would have failed every PR and an advisory one would have hidden the signal — both reasons are now gone.

Six commits, and they are not all the same kind of change:

**Real fixes**

- `PixelCharacter` and `PetCharacter` called `setWalkFrame(0)` **synchronously in an effect body** whenever the animation stopped being a walk. That's a genuine cascading render, in two components that render inside the game world — which already re-renders twice a second from the clock tick. The effect now only owns the walk interval and the resting frame is derived.
- `useFriendsList` and `useOnlineFriends` used `any` to sidestep PostgREST's embedded-resource shape. Typing the rows also let me **drop rows whose embedded profile came back null** instead of passing them through. That's newly reachable: migration 012 scoped profile reads to people you share a friendship row with, so an embed can legitimately resolve to `null`, and the old cast would have pushed a hole into a `Profile[]` for the UI to dereference.

**Cosmetic**

- Two `catch (err: any)` narrowed to `err instanceof Error`. I checked this doesn't swallow Supabase failures — both sites receive errors thrown from `sb.rpc()`, and `PostgrestError extends Error`, so messages still come through.
- One `prefer-const`, and the standing `exhaustive-deps` warning on the socket effect replaced with a disable that states why it's deliberately mount-only.

**Suppressed, not fixed — calling this out explicitly**

The last four `set-state-in-effect` errors (`useTasks`, `useStickyNotes`, `useFriendsList`, `useOnlineFriends`) are all one shape: an effect calling an async fetcher that awaits a network round trip before any `setState`. Nothing there is a synchronous cascading render; the rule just can't see through the async boundary. Each is suppressed with that explanation at the call site. Actually restructuring them means introducing a data-fetching library across four hooks — a bigger, riskier change than a lint cleanup earns, and a decision worth making on its own merits.

So: **8 of 12 errors were genuinely fixed, 4 were suppressed with a documented reason.**

## Notes

- The lint step runs inside the existing `client` job rather than as a separate one, so a lint failure blocks the same check the tests and build already gate.
- Two of these components (`PixelCharacter`, `PetCharacter`) are pure SVG sprite rendering with no test coverage, so the animation change is verified by reading rather than by execution — see the test plan.

## Test plan

- [x] `npm run lint` exits 0 (was 12 errors + 1 warning)
- [x] Client tsc, tests, production build; 38 server tests
- [x] Walk-frame change is behavior-preserving by inspection: both sprites already gated their leg positions on `anim === "walk"`, so the derived value is identical in every branch that reads it. The one difference is that resuming a walk picks up mid-cycle rather than from frame 0 — imperceptible at a 180ms/250ms cadence
- [ ] Not browser-verified: the walking animation actually rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)
