### PR TITLE
fix: reconnect instead of giving up, and attach the resume handlers at all

### DIFF
--- a/client/src/components/ConnectionBanner.tsx
+++ b/client/src/components/ConnectionBanner.tsx
@@ -17,8 +17,11 @@ interface Props {
 /**
  * Tells you when *your own* connection dropped. The countdown on screen is
  * driven by an absolute server timestamp so it stays accurate while offline,
- * but phase changes won't arrive — and if socket.io's retries run out, the
- * server's reconnect grace window will have expired and the session is gone.
+ * but phase changes won't arrive until the socket is back.
+ *
+ * "Retry" reconnects in place. It used to reload the page, which was the only
+ * recovery available when nothing could re-open the socket — a full reload
+ * costs the React tree and re-runs auth for what is usually a brief outage.
  */
 export default function ConnectionBanner({ state, inSession, onRetry }: Props) {
   const visible = inSession && (state === "reconnecting" || state === "offline");
@@ -47,7 +50,7 @@ export default function ConnectionBanner({ state, inSession, onRetry }: Props) {
                 onClick={onRetry}
                 className="underline underline-offset-2 hover:no-underline"
               >
-                Reload
+                Retry
               </button>
             </>
           ) : (

--- a/client/src/components/DuoTimer.tsx
+++ b/client/src/components/DuoTimer.tsx
@@ -118,7 +118,7 @@ export default function DuoTimer() {
       <ConnectionBanner
         state={game.connectionState}
         inSession={Boolean(game.sessionId)}
-        onRetry={() => window.location.reload()}
+        onRetry={game.reconnect}
       />
 
       {game.pendingInvite && (

--- a/client/src/hooks/useGameSession.test.tsx
+++ b/client/src/hooks/useGameSession.test.tsx
@@ -165,4 +165,45 @@ describe("useGameSession connection lifecycle", () => {
     await waitFor(() => expect(fakeSocket.connectCalls).toBeGreaterThan(before));
   });
 
+  // Manual reconnects don't emit the manager's "reconnect" event, so rejoin
+  // must hang off plain "connect" or the player silently isn't in the session.
+  it("rejoins the session on a manual reconnect, not just an automatic one", async () => {
+    const { result } = renderHook(() => useGameSession(null));
+    await waitFor(() => expect(fakeSocket.listenerCount("connect")).toBeGreaterThan(0));
+
+    act(() => fakeSocket.connect());
+    act(() =>
+      fakeSocket.fire("sync_state", {
+        mode: "pomodoro",
+        phase: "waiting",
+        focusDuration: 1500,
+        breakDuration: 300,
+        phaseStartTime: null,
+        world: "forest",
+        players: {},
+        playerCount: 1,
+        sessionId: "sess-1",
+      }),
+    );
+    await waitFor(() => expect(result.current.sessionId).toBe("sess-1"));
+
+    // joinSession caches the avatar/name the rejoin needs
+    act(() =>
+      result.current.joinSession("sess-1", {
+        skinColor: "#e0ac69",
+        hairStyle: "bob",
+        hairColor: "#222222",
+        eyeStyle: "normal",
+        outfitColor: "#3355aa",
+      }),
+    );
+
+    act(() => fakeSocket.disconnect());
+    fakeSocket.emitted.length = 0;
+    act(() => fakeSocket.connect());
+
+    await waitFor(() =>
+      expect(fakeSocket.emittedNames()).toContain("join_session"),
+    );
+  });
 });

--- a/client/src/hooks/useGameSession.test.tsx
+++ b/client/src/hooks/useGameSession.test.tsx
@@ -206,4 +206,20 @@ describe("useGameSession connection lifecycle", () => {
       expect(fakeSocket.emittedNames()).toContain("join_session"),
     );
   });
+
+  // The banner's action used to be a full page reload — the only recovery
+  // available when nothing could re-open the socket.
+  it("exposes a reconnect() the connection banner can call", async () => {
+    const { result } = renderHook(() => useGameSession(null));
+    await waitFor(() => expect(fakeSocket.listenerCount("connect")).toBeGreaterThan(0));
+
+    act(() => fakeSocket.connect());
+    act(() => fakeSocket.disconnect());
+    act(() => fakeSocket.io.fire("reconnect_failed"));
+    await waitFor(() => expect(result.current.connectionState).toBe("offline"));
+
+    const before = fakeSocket.connectCalls;
+    act(() => result.current.reconnect());
+    await waitFor(() => expect(fakeSocket.connectCalls).toBeGreaterThan(before));
+  });
 });

--- a/client/src/hooks/useGameSession.test.tsx
+++ b/client/src/hooks/useGameSession.test.tsx
@@ -123,4 +123,46 @@ describe("useGameSession connection lifecycle", () => {
     );
   });
 
+  // The core bug: after reconnect_failed nothing ever called socket.connect()
+  // again, so a tab backgrounded past the retry budget was stranded even
+  // though the server still held the slot.
+  it("reconnects when the tab returns after the retry budget is exhausted", async () => {
+    const { result } = renderHook(() => useGameSession(null));
+    await waitFor(() => expect(fakeSocket.listenerCount("connect")).toBeGreaterThan(0));
+
+    act(() => fakeSocket.connect());
+    act(() => fakeSocket.fire("session_created", { sessionId: "sess-1" }));
+    await waitFor(() => expect(result.current.sessionId).toBe("sess-1"));
+
+    // Drop, then exhaust socket.io's automatic retries.
+    act(() => fakeSocket.disconnect());
+    act(() => fakeSocket.io.fire("reconnect_failed"));
+    await waitFor(() => expect(result.current.connectionState).toBe("offline"));
+
+    const before = fakeSocket.connectCalls;
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+
+    await waitFor(() =>
+      expect(fakeSocket.connectCalls).toBeGreaterThan(before),
+    );
+  });
+
+  it("reconnects when the browser reports the network is back", async () => {
+    const { result } = renderHook(() => useGameSession(null));
+    await waitFor(() => expect(fakeSocket.listenerCount("connect")).toBeGreaterThan(0));
+
+    act(() => fakeSocket.connect());
+    act(() => fakeSocket.fire("session_created", { sessionId: "sess-1" }));
+    await waitFor(() => expect(result.current.sessionId).toBe("sess-1"));
+
+    act(() => fakeSocket.disconnect());
+    act(() => fakeSocket.io.fire("reconnect_failed"));
+    await waitFor(() => expect(result.current.connectionState).toBe("offline"));
+
+    const before = fakeSocket.connectCalls;
+    act(() => window.dispatchEvent(new Event("online")));
+
+    await waitFor(() => expect(fakeSocket.connectCalls).toBeGreaterThan(before));
+  });
+
 });

--- a/client/src/hooks/useGameSession.test.tsx
+++ b/client/src/hooks/useGameSession.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+
+// ── Fake socket.io ───────────────────────────────────────────────────────────
+// Enough of the surface useGameSession touches: per-event listener lists, a
+// manager (`io`) with its own listeners, and connect/disconnect that flip state
+// and fire the right events.
+function createFakeSocket() {
+  const handlers = new Map<string, ((...a: unknown[]) => void)[]>();
+  const managerHandlers = new Map<string, ((...a: unknown[]) => void)[]>();
+  const add = (m: Map<string, ((...a: unknown[]) => void)[]>) =>
+    (ev: string, fn: (...a: unknown[]) => void) => {
+      m.set(ev, [...(m.get(ev) ?? []), fn]);
+    };
+  const remove = (m: Map<string, ((...a: unknown[]) => void)[]>) =>
+    (ev: string, fn: (...a: unknown[]) => void) => {
+      m.set(ev, (m.get(ev) ?? []).filter((f) => f !== fn));
+    };
+
+  const socket = {
+    id: "sock-1",
+    connected: false,
+    auth: {} as Record<string, unknown>,
+    emitted: [] as { ev: string; payload: unknown }[],
+    connectCalls: 0,
+
+    on: add(handlers),
+    off: remove(handlers),
+    once: add(handlers),
+    emit(ev: string, payload?: unknown) {
+      socket.emitted.push({ ev, payload });
+    },
+    disconnect() {
+      socket.connected = false;
+      socket.fire("disconnect");
+    },
+    connect() {
+      socket.connectCalls++;
+      socket.connected = true;
+      socket.fire("connect");
+    },
+    io: {
+      on: add(managerHandlers),
+      off: remove(managerHandlers),
+      fire(ev: string, ...args: unknown[]) {
+        (managerHandlers.get(ev) ?? []).forEach((f) => f(...args));
+      },
+    },
+
+    // test helpers
+    fire(ev: string, ...args: unknown[]) {
+      (handlers.get(ev) ?? []).forEach((f) => f(...args));
+    },
+    listenerCount(ev: string) {
+      return (handlers.get(ev) ?? []).length;
+    },
+    emittedNames() {
+      return socket.emitted.map((e) => e.ev);
+    },
+  };
+  return socket;
+}
+
+let fakeSocket: ReturnType<typeof createFakeSocket>;
+
+vi.mock("socket.io-client", () => ({
+  io: () => fakeSocket,
+  Socket: class {},
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  getSupabase: () => ({
+    auth: {
+      getSession: async () => ({
+        data: { session: { access_token: "tok" } },
+      }),
+    },
+  }),
+}));
+
+vi.mock("@/lib/sounds", () => ({ playSound: () => {} }));
+
+import { useGameSession } from "./useGameSession";
+
+const setVisibility = (state: "visible" | "hidden") => {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+};
+
+describe("useGameSession connection lifecycle", () => {
+  beforeEach(() => {
+    fakeSocket = createFakeSocket();
+    setVisibility("visible");
+    sessionStorage.clear();
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  // The socket is created after an await inside connectSocket(), so any effect
+  // that reads socketRef.current on mount sees null. Handlers registered that
+  // way are silently never attached.
+  it("wires tab-wake and reconnect handlers to the socket once it exists", async () => {
+    renderHook(() => useGameSession(null));
+    await waitFor(() => expect(fakeSocket.listenerCount("connect")).toBeGreaterThan(0));
+    expect(fakeSocket.listenerCount("disconnect")).toBeGreaterThan(0);
+  });
+
+  it("asks the server to resync when the tab becomes visible mid-session", async () => {
+    const { result } = renderHook(() => useGameSession(null));
+    await waitFor(() => expect(fakeSocket.listenerCount("connect")).toBeGreaterThan(0));
+
+    // Get into a session: connect, then let the server confirm one.
+    act(() => fakeSocket.connect());
+    act(() => fakeSocket.fire("session_created", { sessionId: "sess-1" }));
+    await waitFor(() => expect(result.current.sessionId).toBe("sess-1"));
+
+    fakeSocket.emitted.length = 0;
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+
+    await waitFor(() =>
+      expect(fakeSocket.emittedNames()).toContain("request_sync"),
+    );
+  });
+
+});

--- a/client/src/hooks/useGameSession.ts
+++ b/client/src/hooks/useGameSession.ts
@@ -337,11 +337,16 @@ export function useGameSession(profile: Profile | null) {
         if (!socket.connected) reconnectNow();
       };
 
-      socket.io.on("reconnect", rejoinIfNeeded);
+      // Hangs off plain "connect", not the manager's "reconnect": that event
+      // only fires for socket.io's own automatic retries, so a reconnect we
+      // triggered ourselves would land the socket back online without ever
+      // rejoining the session. Safe to run on every connect — join_session
+      // re-keys an existing slot, and this no-ops before there is a session.
+      socket.on("connect", rejoinIfNeeded);
       document.addEventListener("visibilitychange", onVisibility);
       window.addEventListener("online", onOnline);
       detachResume = () => {
-        socket.io.off("reconnect", rejoinIfNeeded);
+        socket.off("connect", rejoinIfNeeded);
         document.removeEventListener("visibilitychange", onVisibility);
         window.removeEventListener("online", onOnline);
       };

--- a/client/src/hooks/useGameSession.ts
+++ b/client/src/hooks/useGameSession.ts
@@ -124,6 +124,7 @@ export function useGameSession(profile: Profile | null) {
   // ── Socket setup ────────────────────────────────────────────────────────
   useEffect(() => {
     let cancelled = false;
+    let detachResume = () => {};
 
     async function connectSocket() {
       const {
@@ -287,12 +288,45 @@ export function useGameSession(profile: Profile | null) {
         console.warn("Invite error:", message);
         setSessionError(message);
       });
+
+      // ── Resume handlers ───────────────────────────────────────────────
+      // These used to live in a separate mount effect that read
+      // socketRef.current — but the socket is created after an await here, so
+      // that ref was still null and the listeners were never attached at all.
+      // Mobile browsers close backgrounded WebSockets aggressively, so this is
+      // the path that gets a player back into their session.
+      const rejoinIfNeeded = () => {
+        const sid = sessionIdRef.current;
+        const avatar = lastAvatarRef.current;
+        if (!sid || !avatar) return;
+        socket.emit("join_session", {
+          sessionId: sid,
+          avatar,
+          displayName: lastDisplayNameRef.current,
+          pet: myPetRef.current,
+        });
+      };
+
+      const onVisibility = () => {
+        if (document.visibilityState !== "visible") return;
+        if (sessionIdRef.current && socket.connected) {
+          socket.emit("request_sync");
+        }
+      };
+
+      socket.io.on("reconnect", rejoinIfNeeded);
+      document.addEventListener("visibilitychange", onVisibility);
+      detachResume = () => {
+        socket.io.off("reconnect", rejoinIfNeeded);
+        document.removeEventListener("visibilitychange", onVisibility);
+      };
     }
 
     connectSocket();
 
     return () => {
       cancelled = true;
+      detachResume();
       socketRef.current?.disconnect();
     };
     // Deliberately mount-only: this owns the single socket connection for the
@@ -316,49 +350,6 @@ export function useGameSession(profile: Profile | null) {
       socket.off("connect", onConnect);
     };
   }, [profile?.id]);
-
-  // ── Resume sync: rejoin on reconnect, request sync on tab wake ──────────
-  // Mobile browsers (esp. iOS Safari) close backgrounded WebSockets after
-  // ~30s. The server removes the player on disconnect, so on reconnect we
-  // re-emit join_session with the cached avatar so the new socket lands
-  // back inside the same session. When the tab just loses focus without
-  // disconnecting, request_sync refreshes phase/state in case we drifted.
-  useEffect(() => {
-    const socket = socketRef.current;
-    if (!socket) return;
-
-    const rejoinIfNeeded = () => {
-      const sid = sessionIdRef.current;
-      const avatar = lastAvatarRef.current;
-      if (!sid || !avatar) return;
-      socket.emit("join_session", {
-        sessionId: sid,
-        avatar,
-        displayName: lastDisplayNameRef.current,
-        pet: myPetRef.current,
-      });
-    };
-
-    const onVisibility = () => {
-      if (typeof document === "undefined") return;
-      if (document.visibilityState !== "visible") return;
-      if (!sessionIdRef.current) return;
-      if (socket.connected) {
-        socket.emit("request_sync");
-      }
-    };
-
-    socket.io.on("reconnect", rejoinIfNeeded);
-    if (typeof document !== "undefined") {
-      document.addEventListener("visibilitychange", onVisibility);
-    }
-    return () => {
-      socket.io.off("reconnect", rejoinIfNeeded);
-      if (typeof document !== "undefined") {
-        document.removeEventListener("visibilitychange", onVisibility);
-      }
-    };
-  }, []);
 
   // ── Sound effects on phase transitions ──────────────────────────────────
   useEffect(() => {

--- a/client/src/hooks/useGameSession.ts
+++ b/client/src/hooks/useGameSession.ts
@@ -134,8 +134,14 @@ export function useGameSession(profile: Profile | null) {
 
       const socket = io(SOCKET_URL, {
         reconnection: true,
-        reconnectionAttempts: 10,
+        // Ten attempts against socket.io's 5s backoff cap is ~40s, which
+        // expires *inside* the server's 60s reconnect grace — the automatic
+        // retries gave up while the slot was still being held. 20 covers it
+        // with margin. Beyond that the tab-wake / online handlers take over,
+        // so a longer outage still recovers without a reload.
+        reconnectionAttempts: 20,
         reconnectionDelay: 1000,
+        reconnectionDelayMax: 5000,
         auth: { token: session?.access_token ?? "" },
       });
       socketRef.current = socket;

--- a/client/src/hooks/useGameSession.ts
+++ b/client/src/hooks/useGameSession.ts
@@ -307,18 +307,43 @@ export function useGameSession(profile: Profile | null) {
         });
       };
 
+      // socket.io stops for good once reconnectionAttempts is exhausted, and
+      // nothing else ever calls connect(). A phone backgrounded for a minute
+      // therefore landed on "connection lost" permanently — while the server
+      // was still holding the player's slot for RECONNECT_GRACE_MS. These are
+      // the two moments worth retrying on: the user looked at the tab again,
+      // or the OS says the network is back.
+      const reconnectNow = async () => {
+        if (socket.connected) return;
+        setConnectionState("reconnecting");
+        // The access token may well have expired while we were away.
+        const {
+          data: { session: fresh },
+        } = await sb.auth.getSession();
+        if (fresh?.access_token) socket.auth = { token: fresh.access_token };
+        socket.connect();
+      };
+
       const onVisibility = () => {
         if (document.visibilityState !== "visible") return;
-        if (sessionIdRef.current && socket.connected) {
-          socket.emit("request_sync");
+        if (!socket.connected) {
+          reconnectNow();
+          return;
         }
+        if (sessionIdRef.current) socket.emit("request_sync");
+      };
+
+      const onOnline = () => {
+        if (!socket.connected) reconnectNow();
       };
 
       socket.io.on("reconnect", rejoinIfNeeded);
       document.addEventListener("visibilitychange", onVisibility);
+      window.addEventListener("online", onOnline);
       detachResume = () => {
         socket.io.off("reconnect", rejoinIfNeeded);
         document.removeEventListener("visibilitychange", onVisibility);
+        window.removeEventListener("online", onOnline);
       };
     }
 

--- a/client/src/hooks/useGameSession.ts
+++ b/client/src/hooks/useGameSession.ts
@@ -65,6 +65,9 @@ export function useGameSession(profile: Profile | null) {
   // ── Connection ──────────────────────────────────────────────────────────
   const [myId, setMyId] = useState<string>("");
   const socketRef = useRef<Socket | null>(null);
+  // Populated once the socket exists, so the UI can ask for a reconnect
+  // without reaching into the socket itself.
+  const reconnectRef = useRef<() => void>(() => {});
   // "reconnecting" = socket.io is retrying and the server is likely still
   // holding our slot; "offline" = retries exhausted, the session is gone.
   const [connectionState, setConnectionState] = useState<
@@ -330,6 +333,8 @@ export function useGameSession(profile: Profile | null) {
         socket.connect();
       };
 
+      reconnectRef.current = () => void reconnectNow();
+
       const onVisibility = () => {
         if (document.visibilityState !== "visible") return;
         if (!socket.connected) {
@@ -573,6 +578,7 @@ export function useGameSession(profile: Profile | null) {
     myId,
     socketRef,
     connectionState,
+    reconnect: useCallback(() => reconnectRef.current(), []),
     // Derived
     timeLeft,
     flowElapsed,


### PR DESCRIPTION
## Summary

Backgrounding your phone for a minute mid-focus stranded you on "CONNECTION LOST" permanently — during the exact window the server was still holding your slot.

**And while fixing it I found something worse: the resume handlers were never attached at all.**

### The dead listeners

The rejoin-on-reconnect and resync-on-tab-wake handlers lived in their own mount effect that read `socketRef.current`. But the socket is created *after* an `await sb.auth.getSession()` inside the setup effect — so that ref was still `null` when this effect ran. It hit `if (!socket) return` and neither listener was ever registered.

So neither mechanism has been working: no `request_sync` when a tab came back, and no automatic rejoin after socket.io reconnected. Mobile browsers close backgrounded WebSockets aggressively, which is precisely the case both were written for. A test asserting `request_sync` on tab wake fails against `main`.

### The reconnect dead end

`reconnectionAttempts: 10` against socket.io's 5s backoff cap exhausts in roughly 40 seconds — **inside** the server's 60s `RECONNECT_GRACE_MS`. After that `reconnect_failed` fires and **nothing in the client ever calls `socket.connect()` again**; I grepped. The visibility handler that would be the obvious recovery point was gated on `if (socket.connected)`, so it did nothing in the one case that mattered.

Net effect: the reconnect grace period I added earlier was being defeated by the client giving up first.

Now: reconnect on tab-visible and on the browser's `online` event, both refreshing the access token first since it may have expired while away; automatic attempts raised to 20 so they outlast the grace window; and the banner's action reconnects in place instead of hard-reloading.

### The follow-on

`rejoinIfNeeded` hung off the manager's `"reconnect"` event, which socket.io only emits for its *own* automatic retries. A reconnect we trigger ourselves would bring the socket back online without ever re-entering the session — a live-looking game screen the server no longer considers you part of. Moved to plain `"connect"`, which is safe to run every time: `join_session` re-keys an existing slot, and it no-ops before there is a session.

## Notes

- Adds the first React test in the repo — jsdom with a fake socket.io and Supabase. 6 tests; **4 of them fail against `main`**.
- Three of these bugs are in code paths I added or touched in earlier PRs this session. The dead-listener one predates me, but I'd been reasoning about that effect as though it ran.

## Test plan

- [x] 6 new hook tests: handlers attach to the real socket, `request_sync` on tab wake, reconnect after the retry budget is exhausted, reconnect on `online`, rejoin on a manual reconnect, and `reconnect()` exposed for the banner
- [x] Client lint (now blocking), tsc, 12 tests, production build; 38 server tests
- [ ] **Not verified against a real browser or a real server.** The socket is faked, so this proves the wiring and state machine, not the actual recovery. Worth one manual check: start a session, background the tab for ~90s, come back, confirm you're still in it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
