### PR TITLE
fix: stop strangers writing into your shared goals

### DIFF
--- a/client/src/components/HomeDashboard.tsx
+++ b/client/src/components/HomeDashboard.tsx
@@ -94,6 +94,8 @@ export default function HomeDashboard({
     pendingTasks,
     completedTasks,
     clearCompleted,
+    error: taskError,
+    clearError: clearTaskError,
   } = useTasks(profile.id);
 
   const { friends, onlineFriendIds } = useOnlineFriends(profile.id, socketRef);
@@ -277,6 +279,8 @@ export default function HomeDashboard({
             toggleTask={toggleTask}
             deleteTask={deleteTask}
             clearCompleted={clearCompleted}
+            error={taskError}
+            onDismissError={clearTaskError}
           />
 
           <FriendsOnlineSection

--- a/client/src/components/StickyNote.tsx
+++ b/client/src/components/StickyNote.tsx
@@ -130,6 +130,8 @@ export default function StickyNote({ open, onClose, userId, roomCode }: Props) {
     toggleTask,
     deleteTask,
     clearCompleted,
+    error,
+    clearError,
   } = useStickyNotes(open, userId, roomCode);
 
   const color = NOTE_COLORS[colorIdx];
@@ -296,6 +298,21 @@ export default function StickyNote({ open, onClose, userId, roomCode }: Props) {
               )}
 
               {/* Task list */}
+              {error && (
+                <div
+                  role="alert"
+                  className="mx-4 mb-1 flex items-start gap-2 px-3 py-2 rounded-lg bg-danger/10 border border-danger/30 text-danger text-xs"
+                >
+                  <span className="flex-1">{error}</span>
+                  <button
+                    onClick={clearError}
+                    aria-label="Dismiss error"
+                    className="font-bold hover:opacity-70"
+                  >
+                    ✕
+                  </button>
+                </div>
+              )}
               <div className="flex-1 overflow-y-auto px-4 py-2">
                 {tab === "shared" && !roomCode ? (
                   <p

--- a/client/src/components/TaskSection.tsx
+++ b/client/src/components/TaskSection.tsx
@@ -12,6 +12,8 @@ interface Props {
   toggleTask: (id: string, done: boolean) => void;
   deleteTask: (id: string) => void;
   clearCompleted: () => void;
+  error?: string | null;
+  onDismissError?: () => void;
 }
 
 export default function TaskSection({
@@ -24,9 +26,28 @@ export default function TaskSection({
   toggleTask,
   deleteTask,
   clearCompleted,
+  error,
+  onDismissError,
 }: Props) {
   return (
     <div className="bg-surface rounded-2xl border border-line p-4">
+      {error && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 mb-3 px-3 py-2 rounded-lg bg-danger/10 border border-danger/30 text-danger text-xs"
+        >
+          <span className="flex-1">{error}</span>
+          {onDismissError && (
+            <button
+              onClick={onDismissError}
+              aria-label="Dismiss error"
+              className="font-bold hover:opacity-70"
+            >
+              ✕
+            </button>
+          )}
+        </div>
+      )}
       <div className="flex items-center justify-between mb-3">
         <h2 className="text-xs font-semibold text-faint uppercase tracking-wider">
           Goals

--- a/client/src/hooks/useStickyNotes.ts
+++ b/client/src/hooks/useStickyNotes.ts
@@ -13,6 +13,9 @@ export function useStickyNotes(
   const [tab, setTab] = useState<Tab>("mine");
   const [myTasks, setMyTasks] = useState<Task[]>([]);
   const [sharedTasks, setSharedTasks] = useState<Task[]>([]);
+  // Writes can legitimately be refused now that migration 016 scopes shared
+  // notes to the session you're in; these used to update local state blindly.
+  const [error, setError] = useState<string | null>(null);
   const [showOptions, setShowOptions] = useState(false);
   const [colorIdx, setColorIdx] = useState(0);
   const optionsRef = useRef<HTMLDivElement>(null);
@@ -92,15 +95,38 @@ export function useStickyNotes(
       is_shared: shared,
       room_code: shared ? roomCode : null,
     };
-    const { data } = await sb.from("tasks").insert(row).select().single();
-    if (data) {
-      if (shared) setSharedTasks((p) => [...p, data as Task]);
-      else setMyTasks((p) => [...p, data as Task]);
+    const { data, error: err } = await sb
+      .from("tasks")
+      .insert(row)
+      .select()
+      .single();
+    if (err || !data) {
+      // Shared writes are scoped to the session you're actually in (016), so
+      // this can fail for a real reason rather than a transient one.
+      setError(
+        shared
+          ? "Couldn't add that shared goal. Are you still in the session?"
+          : "Couldn't save that note.",
+      );
+      return;
     }
+    if (shared) setSharedTasks((p) => [...p, data as Task]);
+    else setMyTasks((p) => [...p, data as Task]);
   };
 
   const toggleTask = async (id: string, done: boolean) => {
-    await sb.from("tasks").update({ is_done: done }).eq("id", id);
+    setError(null);
+    // RLS refusing this is not an error — it matches zero rows. Ticking off a
+    // note you don't own silently reverted on the next fetch.
+    const { data, error: err } = await sb
+      .from("tasks")
+      .update({ is_done: done })
+      .eq("id", id)
+      .select("id");
+    if (err || !data || data.length === 0) {
+      setError("Couldn't update that note.");
+      return;
+    }
     const update = (list: Task[]) =>
       list.map((t) => (t.id === id ? { ...t, is_done: done } : t));
     setMyTasks(update);
@@ -108,15 +134,35 @@ export function useStickyNotes(
   };
 
   const deleteTask = async (id: string) => {
-    await sb.from("tasks").delete().eq("id", id);
+    setError(null);
+    const { data, error: err } = await sb
+      .from("tasks")
+      .delete()
+      .eq("id", id)
+      .select("id");
+    if (err || !data || data.length === 0) {
+      setError("Couldn't delete that note.");
+      return;
+    }
     setMyTasks((p) => p.filter((t) => t.id !== id));
     setSharedTasks((p) => p.filter((t) => t.id !== id));
   };
 
   const clearCompleted = async () => {
     const list = tab === "mine" ? myTasks : sharedTasks;
-    const done = list.filter((t) => t.is_done);
-    for (const t of done) await deleteTask(t.id);
+    const ids = list.filter((t) => t.is_done).map((t) => t.id);
+    if (ids.length > 0) {
+      setError(null);
+      // One round trip, not one per note
+      const { error: err } = await sb.from("tasks").delete().in("id", ids);
+      if (err) {
+        setError("Couldn't clear those notes.");
+        return;
+      }
+      const drop = (l: Task[]) => l.filter((t) => !ids.includes(t.id));
+      setMyTasks(drop);
+      setSharedTasks(drop);
+    }
     setShowOptions(false);
   };
 
@@ -137,5 +183,7 @@ export function useStickyNotes(
     toggleTask,
     deleteTask,
     clearCompleted,
+    error,
+    clearError: () => setError(null),
   };
 }

--- a/client/src/hooks/useTasks.ts
+++ b/client/src/hooks/useTasks.ts
@@ -6,6 +6,10 @@ import type { Task } from "@/lib/types";
 export function useTasks(ownerId: string) {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [newTask, setNewTask] = useState("");
+  // Writes can legitimately be refused now that migration 016 scopes them, and
+  // an RLS refusal on update/delete is not an error — it matches zero rows. So
+  // these check what actually happened instead of assuming success.
+  const [error, setError] = useState<string | null>(null);
   const sb = getSupabase();
 
   const fetchTasks = useCallback(async () => {
@@ -30,22 +34,45 @@ export function useTasks(ownerId: string) {
   const addTask = async () => {
     const text = newTask.trim();
     if (!text) return;
-    const { data } = await sb
+    setError(null);
+    const { data, error: err } = await sb
       .from("tasks")
       .insert({ owner_id: ownerId, content: text })
       .select()
       .single();
-    if (data) setTasks((p) => [...p, data as Task]);
+    if (err || !data) {
+      setError("Couldn't save that task.");
+      return;
+    }
+    setTasks((p) => [...p, data as Task]);
     setNewTask("");
   };
 
   const toggleTask = async (id: string, done: boolean) => {
-    await sb.from("tasks").update({ is_done: done }).eq("id", id);
+    setError(null);
+    const { data, error: err } = await sb
+      .from("tasks")
+      .update({ is_done: done })
+      .eq("id", id)
+      .select("id");
+    if (err || !data || data.length === 0) {
+      setError("Couldn't update that task.");
+      return;
+    }
     setTasks((p) => p.map((t) => (t.id === id ? { ...t, is_done: done } : t)));
   };
 
   const deleteTask = async (id: string) => {
-    await sb.from("tasks").delete().eq("id", id);
+    setError(null);
+    const { data, error: err } = await sb
+      .from("tasks")
+      .delete()
+      .eq("id", id)
+      .select("id");
+    if (err || !data || data.length === 0) {
+      setError("Couldn't delete that task.");
+      return;
+    }
     setTasks((p) => p.filter((t) => t.id !== id));
   };
 
@@ -53,9 +80,14 @@ export function useTasks(ownerId: string) {
   const completedTasks = tasks.filter((t) => t.is_done);
 
   const clearCompleted = async () => {
-    const done = completedTasks;
-    for (const t of done) {
-      await sb.from("tasks").delete().eq("id", t.id);
+    const ids = completedTasks.map((t) => t.id);
+    if (ids.length === 0) return;
+    setError(null);
+    // One round trip, not one per task
+    const { error: err } = await sb.from("tasks").delete().in("id", ids);
+    if (err) {
+      setError("Couldn't clear those tasks.");
+      return;
     }
     setTasks((p) => p.filter((t) => !t.is_done));
   };
@@ -70,5 +102,7 @@ export function useTasks(ownerId: string) {
     pendingTasks,
     completedTasks,
     clearCompleted,
+    error,
+    clearError: () => setError(null),
   };
 }

--- a/supabase/migrations/016_task_write_scope.sql
+++ b/supabase/migrations/016_task_write_scope.sql
@@ -1,0 +1,74 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Constrain where tasks can be written, and cap their size
+-- ─────────────────────────────────────────────────────────────────────────────
+--
+-- tasks_insert (001) is `WITH CHECK (owner_id = auth.uid())` and says nothing
+-- about room_code. So any authenticated user can POST a row with
+-- is_shared = true and an arbitrary room_code, landing text directly in a
+-- couple's "Our Goals" panel.
+--
+-- That is reachable, not theoretical. Migration 012 deliberately lets someone
+-- with a *pending* friendship row read your profile — the Requests tab joins
+-- profiles for people who aren't friends yet, so it has to. That read includes
+-- current_session_id. Sending a friend request is therefore enough to learn a
+-- live session id, and nothing then stopped writing into it. The victim can't
+-- even remove the row: tasks_delete is owner-only.
+--
+-- Insert is now scoped the same way migration 013 scoped reads — to the
+-- session you are actually in, which only the service key can set (010).
+-- Personal tasks (room_code IS NULL) are unaffected.
+--
+-- content also had no server-side length limit; the 120-character cap is a
+-- maxLength attribute on an input, which the REST API doesn't enforce. 500
+-- leaves room for the existing UI without allowing a row to be used as blob
+-- storage. Applied as NOT VALID so a long legacy row can't block the
+-- migration, then validated separately.
+
+DROP POLICY IF EXISTS "tasks_insert" ON tasks;
+CREATE POLICY "tasks_insert" ON tasks FOR INSERT TO authenticated
+  WITH CHECK (
+    owner_id = auth.uid()
+    AND (
+      room_code IS NULL
+      OR room_code = (
+        SELECT p.current_session_id::text
+          FROM profiles p
+         WHERE p.id = auth.uid()
+      )
+    )
+  );
+
+-- Same scope on UPDATE: without it, someone could flip an existing personal
+-- task's room_code to a session they aren't in and achieve the same thing.
+DROP POLICY IF EXISTS "tasks_update" ON tasks;
+CREATE POLICY "tasks_update" ON tasks FOR UPDATE TO authenticated
+  USING (owner_id = auth.uid())
+  WITH CHECK (
+    owner_id = auth.uid()
+    AND (
+      room_code IS NULL
+      OR room_code = (
+        SELECT p.current_session_id::text
+          FROM profiles p
+         WHERE p.id = auth.uid()
+      )
+    )
+  );
+
+ALTER TABLE tasks DROP CONSTRAINT IF EXISTS tasks_content_length;
+ALTER TABLE tasks ADD CONSTRAINT tasks_content_length
+  CHECK (char_length(content) <= 500) NOT VALID;
+ALTER TABLE tasks VALIDATE CONSTRAINT tasks_content_length;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Verification — run AFTER applying.
+-- ─────────────────────────────────────────────────────────────────────────────
+--
+--   SELECT policyname, cmd FROM pg_policies
+--    WHERE tablename = 'tasks' ORDER BY cmd, policyname;
+--
+--   SELECT conname, convalidated FROM pg_constraint
+--    WHERE conrelid = 'tasks'::regclass AND conname = 'tasks_content_length';
+--
+-- If VALIDATE fails, some existing row is over 500 chars. Find them with:
+--   SELECT id, char_length(content) FROM tasks WHERE char_length(content) > 500;


### PR DESCRIPTION
## Summary

A stranger could write into your couple's shared goals, and you couldn't delete it.

`tasks_insert` (migration 001) is `WITH CHECK (owner_id = auth.uid())` and says nothing about `room_code` — so any authenticated user could POST a row with `is_shared = true` and an arbitrary `room_code`, landing text directly in someone else's "Our Goals" panel.

**That's reachable, not theoretical.** Migration 012 deliberately lets someone with a *pending* friendship row read your profile — the Requests tab joins profiles for people who aren't friends yet, so it has to. That read includes `current_session_id`. **Sending a friend request is therefore enough to learn a live session id**, and nothing then stopped writing into it. The victim couldn't even remove the row, because `tasks_delete` is owner-only.

Insert is now scoped the way migration 013 scoped reads: to the session you're actually in, which only the service key can set (010). `tasks_update` gets the same `WITH CHECK`, otherwise an existing personal task could simply be relabelled into a session you aren't in and achieve the same thing. Personal tasks (`room_code IS NULL`) are unaffected.

Also adds a 500-character `CHECK` on `content`, which had no server-side limit at all — the 120-char cap is a `maxLength` attribute on an input, which the REST API doesn't enforce.

### The client half

Both task hooks updated local state without checking what the write did. That was already wrong: an RLS refusal on update/delete isn't an error, it matches zero rows — so **ticking off a note you don't own appeared to work and silently reverted on the next fetch**. Migration 016 makes it matter more, since a shared insert can now fail for a real reason. Inserts check the returned row, updates/deletes ask for the affected ids back, and failures surface in a dismissible inline banner.

`clearCompleted` also stops being an N+1 delete loop — one `.in()` call instead of one request per task.

## Notes

- The `CHECK` is added `NOT VALID` and then validated separately, so an over-length legacy row surfaces as a validation failure rather than blocking the whole migration. The file includes the query to find such rows.
- **Migration 016 is NOT applied.** The Supabase MCP connection dropped partway through this session, so unlike 010–015 I couldn't apply or verify it against your project. Run it in the SQL editor — verification queries are at the bottom of the file — or reconnect the integration and I'll apply it.
- Ordering: the migration is safe to apply before this deploys. It only *narrows* writes the current client already performs correctly, and the client change is additive error handling.

## Test plan

- [x] Verified on Postgres 17 against migration 001's actual policies as the baseline: **3 assertions fail before, all 7 pass after**
  - blocked after: stranger injecting a shared note into a live session; stranger relabelling a personal task into someone else's session; a 600-character note
  - still working after: personal tasks, a participant writing a shared note in *their own* session, and ticking off your own task
- [x] Client lint, tsc, 12 tests, production build; 43 server tests
- [ ] Not applied to production, and not browser-verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)
