### PR TITLE
fix: mobile viewport — unreachable session controls, safe-area insets, landscape HUD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ build
 .next
 .claude
 
+
+# Local planning notes, not for the repo
+*.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,17 @@ Note: `server/session.js` holds the pure session-state helpers (`createSessionSt
 - `lib/sounds.ts` owns audio *and* the mute flag. The flag is a module-level variable with its own listener set, not React state, because `playSound` is called from `useGameSession`'s socket handlers — outside the component tree, sometimes while nothing is mounted. `useSound` subscribes to it via `useSyncExternalStore`, so any number of `SoundToggle`s stay in agreement. Add new sounds to `FILES`; don't add a second playback path that bypasses the mute check.
 - Visuals: `GameWorld` renders the session scene; `PixelCharacter`/`PetCharacter`/`WorldDecorations` are hand-drawn SVG/CSS pixel art driven by `lib/avatarData.ts`. Note what the server actually validates: `sanitizeAvatar` whitelists `hairStyle` and `eyeStyle`, but checks colours with a plain `/^#[0-9a-fA-F]{6}$/` regex — so recolouring the palette is client-only, while adding a *style* also needs `VALID_HAIR_STYLES`/`VALID_EYE_STYLES`, and adding a *world* needs both `VALID_WORLDS` and the SQL `sessions_world_check` (migration 008).
 
+### Mobile / viewport conventions
+
+The game screen is a fixed app shell (`h-dvh` + `overflow-hidden`) with an internal scroll region, so layout mistakes there strand controls off-screen with no gesture to reach them rather than just looking cramped.
+
+- **Use `dvh`, never `vh`/`h-screen`.** On iOS Safari `100vh` is the *large* viewport — the height the page would have with the toolbar hidden — so a `vh`-sized shell is taller than what's visible, and anything at the bottom of an inner scroll region falls below the fold inside an `overflow-hidden` parent.
+- `layout.tsx` sets `viewportFit: "cover"`, so any element flush to a screen edge must account for `env(safe-area-inset-*)`. **Fold the inset into the element's existing padding** (`pt-[calc(0.625rem+env(safe-area-inset-top))]`) rather than adding a `.pt-safe` helper class — a plain CSS class declaring `padding-top` lands later in the cascade than Tailwind's `py-*` and replaces it instead of adding to it.
+- **Landscape phones need height queries, not width breakpoints.** A landscape phone is *wide*, so `sm:` fires exactly when vertical space has run out and makes things bigger. `globals.css` keys the HUD's compact form off `max-height: 520px`.
+- Overlay panels go `inset-x-2 sm:inset-x-auto` + `w-full sm:w-80` — `FriendsPanel`, `StatsPanel` and `StickyNote` all follow this; a bare `w-80` is 320px of a 360px screen.
+- Touch targets follow the `w-11 h-11 sm:w-7 sm:h-7` / `px-4 py-2.5 sm:px-0 sm:py-0` pattern already in `Button` and `AvatarCreator`.
+- Still outstanding: `GameWorld` has no responsive sprite scaling — characters are the same fixed CSS px on a 360px phone as on a desktop. That wants a single canonical pixel unit first (see the art notes), since scaling sprites by non-integer factors is what makes pixel art blur.
+
 ### Database conventions
 
 - `profiles` extends `auth.users`; usernames use Discord-style `username#discriminator` tags via the `claim_username` RPC (one-time change enforced in SQL, migration 005).

--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -87,6 +87,27 @@ body {
 }
 
 /* ─────────────────────────────────────────────────────────────────────────────
+   Short viewports (landscape phones)
+   The HUD card is taller than a landscape phone's viewport, so it covered the
+   scene entirely — the two characters are the whole point of the screen. Keyed
+   off height rather than a width breakpoint, because the thing that runs out
+   is vertical space: a small landscape phone is *wide*, so `sm:` makes it
+   worse, not better.
+───────────────────────────────────────────────────────────────────────────── */
+
+@media (max-height: 520px) {
+  .hud-card {
+    padding-top: 0.625rem;
+    padding-bottom: 0.625rem;
+    gap: 0.375rem;
+  }
+  .hud-timer {
+    font-size: 2.25rem;
+    line-height: 1;
+  }
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
    Pixel Art Utilities
 ───────────────────────────────────────────────────────────────────────────── */
 

--- a/client/src/components/DuoTimer.tsx
+++ b/client/src/components/DuoTimer.tsx
@@ -179,7 +179,7 @@ export default function DuoTimer() {
   // ── Loading ─────────────────────────────────────────────────────────────
   if (appStep === "loading") {
     return (
-      <div className="min-h-screen bg-bg flex items-center justify-center">
+      <div className="min-h-dvh bg-bg flex items-center justify-center">
         <div className="flex flex-col items-center gap-5">
           <div className="font-display text-4xl text-ink tracking-wide">
             Duodoro
@@ -213,7 +213,7 @@ export default function DuoTimer() {
   if (appStep === "avatar") {
     const isEditing = !!profile?.avatar_config;
     return (
-      <div className="min-h-screen bg-bg texture-dots flex items-center justify-center p-6">
+      <div className="min-h-dvh bg-bg texture-dots flex items-center justify-center p-6">
         <AvatarCreator
           initialConfig={myAvatar}
           initialDisplayName={profile?.display_name ?? ""}
@@ -336,7 +336,7 @@ export default function DuoTimer() {
   // ── Game Screen ─────────────────────────────────────────────────────────
   return (
     <div
-      className="h-screen bg-bg text-white relative overflow-hidden"
+      className="h-dvh bg-bg text-white relative overflow-hidden"
       onClick={() => setProfileMenuOpen(false)}
     >
       {/* ── Game World (full-screen background) ── */}

--- a/client/src/components/HomeDashboard.tsx
+++ b/client/src/components/HomeDashboard.tsx
@@ -123,7 +123,7 @@ export default function HomeDashboard({
 
   return (
     <div
-      className="min-h-screen bg-bg texture-dots flex flex-col"
+      className="min-h-dvh bg-bg texture-dots flex flex-col"
       onClick={() => setProfileMenuOpen(false)}
     >
       {/* Top bar */}

--- a/client/src/components/HomeDashboard.tsx
+++ b/client/src/components/HomeDashboard.tsx
@@ -296,7 +296,9 @@ export default function HomeDashboard({
             <h2 className="text-xs font-semibold text-faint uppercase tracking-wider mb-3">
               Choose a world
             </h2>
-            <div className="grid grid-cols-4 gap-2">
+            {/* Three across on a phone, not four: at four the thumbnails are 48px
+                  tall and the 10px labels are unreadable. */}
+            <div className="grid grid-cols-3 sm:grid-cols-4 gap-2">
               {WORLDS.map((w) => (
                 <button
                   key={w.id}
@@ -307,10 +309,10 @@ export default function HomeDashboard({
                       : "border-line bg-surface text-muted hover:border-faint"
                   }`}
                 >
-                  <div className="h-12 w-full">
+                  <div className="h-16 sm:h-12 w-full">
                     <WorldThumbnail worldId={w.id} />
                   </div>
-                  <span className="block py-1 text-[10px] font-medium">
+                  <span className="block py-1.5 sm:py-1 text-[11px] sm:text-[10px] font-medium">
                     {w.label}
                   </span>
                 </button>

--- a/client/src/components/HomeDashboard.tsx
+++ b/client/src/components/HomeDashboard.tsx
@@ -126,8 +126,8 @@ export default function HomeDashboard({
       className="min-h-dvh bg-bg texture-dots flex flex-col"
       onClick={() => setProfileMenuOpen(false)}
     >
-      {/* Top bar */}
-      <div className="flex items-center justify-between px-4 py-2.5 bg-surface/80 backdrop-blur border-b border-line">
+      {/* Top bar — safe-area insets folded into the padding, see SessionTopBar */}
+      <div className="flex items-center justify-between pb-2.5 pt-[calc(0.625rem+env(safe-area-inset-top))] pl-[calc(1rem+env(safe-area-inset-left))] pr-[calc(1rem+env(safe-area-inset-right))] bg-surface/80 backdrop-blur border-b border-line">
         <div className="flex items-center gap-2">
           <span className="font-display text-lg text-ink tracking-wide">
             Duodoro

--- a/client/src/components/LandingPage.tsx
+++ b/client/src/components/LandingPage.tsx
@@ -161,7 +161,7 @@ export default function LandingPage() {
   };
 
   return (
-    <div className="min-h-screen bg-bg texture-dots flex flex-col">
+    <div className="min-h-dvh bg-bg texture-dots flex flex-col">
       {/* Top bar */}
       <header className="flex items-center justify-between px-5 py-4 max-w-2xl w-full mx-auto">
         <span className="font-display text-xl text-ink tracking-wide">

--- a/client/src/components/SessionHUD.tsx
+++ b/client/src/components/SessionHUD.tsx
@@ -133,7 +133,7 @@ export default function SessionHUD({
     // controls ("end session" / "leave session") can scroll clear of the home
     // indicator instead of sitting under it.
     <div className="flex-1 flex items-start justify-center px-6 pt-4 pb-[calc(1rem+env(safe-area-inset-bottom))] overflow-y-auto">
-      <div className="bg-surface/85 backdrop-blur border border-line rounded-2xl px-8 py-5 flex flex-col items-center gap-3 shadow-xl mb-4">
+      <div className="hud-card bg-surface/85 backdrop-blur border border-line rounded-2xl px-6 sm:px-8 py-5 flex flex-col items-center gap-3 shadow-xl mb-4">
         <div className="font-display text-lg tracking-wide text-ink">
           {phaseLabel[phase](playerCount)}
         </div>
@@ -144,7 +144,7 @@ export default function SessionHUD({
         )}
 
         {showTimer && (
-          <div className="text-6xl font-mono font-bold tabular-nums flex flex-col items-center">
+          <div className="hud-timer text-5xl sm:text-6xl font-mono font-bold tabular-nums flex flex-col items-center">
             {phase === "focus" && serverMode === "flow" && (
               <span className="text-xs text-calm mb-1 tracking-widest font-bold uppercase">
                 Flow elapsed

--- a/client/src/components/SessionHUD.tsx
+++ b/client/src/components/SessionHUD.tsx
@@ -129,7 +129,10 @@ export default function SessionHUD({
   const canStop = sessionStarted && phase !== "waiting";
 
   return (
-    <div className="flex-1 flex items-start justify-center px-6 pt-4 overflow-y-auto">
+    // The bottom inset goes on the scroll container, not the card, so the last
+    // controls ("end session" / "leave session") can scroll clear of the home
+    // indicator instead of sitting under it.
+    <div className="flex-1 flex items-start justify-center px-6 pt-4 pb-[calc(1rem+env(safe-area-inset-bottom))] overflow-y-auto">
       <div className="bg-surface/85 backdrop-blur border border-line rounded-2xl px-8 py-5 flex flex-col items-center gap-3 shadow-xl mb-4">
         <div className="font-display text-lg tracking-wide text-ink">
           {phaseLabel[phase](playerCount)}

--- a/client/src/components/SessionHUD.tsx
+++ b/client/src/components/SessionHUD.tsx
@@ -269,17 +269,21 @@ export default function SessionHUD({
               Take break
             </Button>
           )}
+          {/* These are the two most consequential controls in the app and were
+              bare 12px text. Padded to a thumb-sized target on touch, back to
+              the tight original from sm up. Matches Button/AvatarCreator's
+              existing `w-11 h-11 sm:w-7 sm:h-7` pattern. */}
           {canStop && (
             <button
               onClick={onStop}
-              className="text-muted hover:text-danger text-xs transition-colors mt-2"
+              className="text-muted hover:text-danger text-xs transition-colors mt-2 px-4 py-2.5 sm:px-0 sm:py-0 rounded-lg"
             >
               end session
             </button>
           )}
           <button
             onClick={onLeave}
-            className="text-xs text-danger/60 hover:text-danger transition-colors mt-2"
+            className="text-xs text-danger/60 hover:text-danger transition-colors mt-2 px-4 py-2.5 sm:px-0 sm:py-0 rounded-lg"
           >
             {"←"} leave session
           </button>

--- a/client/src/components/SessionTopBar.tsx
+++ b/client/src/components/SessionTopBar.tsx
@@ -73,7 +73,11 @@ export default function SessionTopBar({
     }`;
 
   return (
-    <div className="grid grid-cols-[1fr_auto_1fr] items-center px-4 py-2.5 bg-surface/85 backdrop-blur border-b border-line z-10">
+    // Safe-area insets are folded into the base padding rather than added by a
+    // separate utility: layout.tsx sets viewportFit "cover", so without them the
+    // bar's contents sit under the notch in portrait and under the rounded
+    // corner in landscape. The bar's own background still extends underneath.
+    <div className="grid grid-cols-[1fr_auto_1fr] items-center pb-2.5 pt-[calc(0.625rem+env(safe-area-inset-top))] pl-[calc(1rem+env(safe-area-inset-left))] pr-[calc(1rem+env(safe-area-inset-right))] bg-surface/85 backdrop-blur border-b border-line z-10">
       {/* Left: Friends */}
       <div className="flex items-center justify-end pr-2">
         <button

--- a/client/src/components/StickyNote.tsx
+++ b/client/src/components/StickyNote.tsx
@@ -191,10 +191,13 @@ export default function StickyNote({
             exit={{ opacity: 0 }}
             onClick={onClose}
           />
-          {/* Vertically-centered panel on the right */}
-          <div className="fixed right-4 top-0 bottom-0 z-40 flex items-center pointer-events-none">
+          {/* Vertically-centered panel on the right. FriendsPanel and StatsPanel
+              already went full-width-with-side-inset below sm; this one was left
+              on a fixed w-80, which is 320px of a 360px screen pinned 16px from
+              the right edge. */}
+          <div className="fixed inset-x-2 sm:inset-x-auto sm:right-4 top-0 bottom-0 z-40 flex items-center pointer-events-none">
             <motion.div
-              className="pointer-events-auto w-80 flex flex-col rounded-2xl shadow-2xl overflow-hidden"
+              className="pointer-events-auto w-full sm:w-80 flex flex-col rounded-2xl shadow-2xl overflow-hidden"
               style={{
                 background: color.gradient,
                 maxHeight: "min(600px, 85vh)",


### PR DESCRIPTION
Item 5 from the roadmap. The game screen was not merely cramped on a phone — it stranded controls off-screen with no gesture that could reach them.

## The core bug

The game screen is `h-screen` + `overflow-hidden`, with the HUD in a `flex-1 overflow-y-auto` child. On iOS Safari `100vh` is the *large* viewport — the height the page would have if the browser toolbar were hidden — so the shell is taller than what you can see.

The HUD could always scroll. The problem is that its scroll region's height came from the oversized parent, so the bottom of it — **"end session" and "leave session"** — sat below the fold inside a container that refuses to scroll. There was no way to reach those two buttons on a phone.

`h-dvh` tracks the visible viewport, so the flex child is sized to what the user actually sees and its overflow becomes reachable. `dvh` and `vh` are identical on desktop.

## The rest

- **Safe-area insets.** `layout.tsx` has set `viewportFit: "cover"` all along, but there was not one reference to `env(safe-area-inset-*)` anywhere in `client/src`. Top bar contents ran under the status bar, HUD controls under the home indicator. Folded into each element's existing padding rather than added via a `.pt-safe` helper — a plain CSS class declaring `padding-top` lands later in the cascade than Tailwind's `py-2.5` and would silently *replace* it. Horizontal insets included too, since those are what bite in landscape.
- **Landscape.** The HUD card is taller than a landscape phone's viewport, so it covered the scene — the two characters being the entire point of that screen. Keyed off `max-height: 520px`, not a width breakpoint: a landscape phone is *wide*, so `sm:` fires exactly when vertical space has run out and makes the card bigger.
- **Touch targets.** "end session" and "leave session" were bare 12px text with no padding, directly above the home indicator. Padded on touch, tight original from `sm` up, matching the `w-11 h-11 sm:w-7 sm:h-7` pattern `Button` and `AvatarCreator` already use.
- **World picker.** 8 worlds in `grid-cols-4` gives a 48px-tall thumbnail with a 10px label on a 360px screen — the last thing you touch before starting a session. Three across on phones, four from `sm`.
- **Notes panel.** `FriendsPanel` and `StatsPanel` already used `inset-x-2 sm:inset-x-auto` + `w-full sm:w-80`; `StickyNote` was left on a bare `w-80`, i.e. 320px of a 360px screen. Now consistent with its siblings.

## Verification

**No phone, and no browser.** I have no device or browser automation here, so nothing below is a visual confirmation — read it as "the rules are live and correct", not "it looks right".

What I did verify, which is the failure mode I was actually worried about — Tailwind silently not generating arbitrary values containing nested `env()` calls, leaving the classes inert:

```
=== the padding rules in the emitted CSS bundle ===
padding-top:calc(.625rem + env(safe-area-inset-top))
padding-bottom:calc(1rem + env(safe-area-inset-bottom))
padding-left:calc(1rem + env(safe-area-inset-left))
padding-right:calc(1rem + env(safe-area-inset-right))
=== also present: 100dvh, max-height:520px, grid-template-columns:repeat(3
```

Then booted the production build and confirmed end-to-end: `200` on `/`, landing page renders with `min-h-dvh`, and the stylesheet actually served to the browser contains `env(safe-area-inset-top)` and `100dvh`.

Plus 28 client tests, 43 server tests, `tsc --noEmit`, lint and `next build` all clean.

## Deliberately not done

`GameWorld` has no responsive sprite scaling — characters are the same fixed CSS px on a 360px phone as on a desktop. That wants one canonical pixel unit first, because scaling pixel art by non-integer factors is what makes it blur, and it needs visual iteration I can't do from here. Noted in CLAUDE.md and the roadmap.

## Please check on an actual phone

1. Start a session, then reach **leave session** — that's the whole point of this PR.
2. Rotate to landscape mid-session; the characters should still be visible.
3. If you have a notched device, confirm the top bar clears the status bar.
