### PR TITLE
fix: sprite geometry — two pets walking on one leg, plus three reported defects that aren't real

### DIFF
--- a/client/src/components/PetCharacter.test.tsx
+++ b/client/src/components/PetCharacter.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, act } from "@testing-library/react";
+import PetCharacter from "./PetCharacter";
+import { PET_OPTIONS } from "@/lib/types";
+
+// A rect drawn outside the viewBox is silently clipped — it costs nothing at
+// runtime and produces no warning, so the cat and rabbit shipped with their
+// planted foot at y=10 inside a `0 0 10 10` viewBox and simply never drew it.
+// Reading the source can't catch that; comparing geometry to the viewBox can.
+
+type Box = { x: number; y: number; w: number; h: number };
+
+function spriteGeometry(el: HTMLElement) {
+  const svg = el.querySelector("svg");
+  if (!svg) throw new Error("no svg rendered");
+  const vb = (svg.getAttribute("viewBox") ?? "").split(/\s+/).map(Number);
+  const rects: Box[] = Array.from(svg.querySelectorAll("rect")).map((r) => ({
+    x: Number(r.getAttribute("x") ?? 0),
+    y: Number(r.getAttribute("y") ?? 0),
+    w: Number(r.getAttribute("width") ?? 0),
+    h: Number(r.getAttribute("height") ?? 0),
+  }));
+  return { minX: vb[0], minY: vb[1], width: vb[2], height: vb[3], rects };
+}
+
+const PETS = PET_OPTIONS.map((p) => p.type);
+
+describe("pet sprite geometry", () => {
+  afterEach(() => vi.useRealTimers());
+
+  // legUp flips on a 250ms interval while walking, and each frame draws a
+  // different pair of leg rows — so both frames have to be checked. frame 0 is
+  // legUp, frame 1 is its opposite.
+  for (const frame of [0, 1]) {
+    for (const type of PETS) {
+      it(`${type} draws entirely inside its viewBox (walk frame ${frame})`, () => {
+        vi.useFakeTimers();
+        const { container } = render(
+          <PetCharacter type={type} size={2} anim="walk" />,
+        );
+        if (frame === 1) {
+          act(() => void vi.advanceTimersByTime(250));
+        }
+        const { minX, minY, width, height, rects } = spriteGeometry(container);
+        expect(rects.length).toBeGreaterThan(0);
+        for (const r of rects) {
+          expect(r.x).toBeGreaterThanOrEqual(minX);
+          expect(r.y).toBeGreaterThanOrEqual(minY);
+          expect(r.x + r.w).toBeLessThanOrEqual(minX + width);
+          expect(r.y + r.h).toBeLessThanOrEqual(minY + height);
+        }
+      });
+    }
+  }
+
+  // The specific regression: two legs drawn, two legs visible.
+  for (const type of PETS) {
+    it(`${type} has a foot on its bottom row so it stands on the ground`, () => {
+      const { container } = render(<PetCharacter type={type} size={2} />);
+      const { minY, height, rects } = spriteGeometry(container);
+      const bottom = minY + height;
+      expect(rects.some((r) => r.y + r.h === bottom)).toBe(true);
+    });
+  }
+
+  it("renders every pet on the same grid, so they share one scale", () => {
+    const boxes = PETS.map((type) => {
+      const { container } = render(<PetCharacter type={type} size={2} />);
+      const { width, height } = spriteGeometry(container);
+      return `${width}x${height}`;
+    });
+    expect(new Set(boxes).size).toBe(1);
+  });
+});

--- a/client/src/components/PetCharacter.tsx
+++ b/client/src/components/PetCharacter.tsx
@@ -4,7 +4,7 @@ import type { AnimState } from "./PixelCharacter";
 import type { PetType } from "@/lib/types";
 
 // ─────────────────────────────────────────────────────────────────────────────
-// PetCharacter — tiny SVG pixel art pets (10×10 viewBox)
+// PetCharacter — tiny SVG pixel art pets (10×11 viewBox)
 // All pets match their owner's animation state.
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -15,7 +15,7 @@ interface PetCharacterProps {
   size?: number;
 }
 
-// Cat pixel art (10×10)
+// Cat pixel art (10×11)
 function CatPixels({ legUp }: { legUp: boolean }) {
   return (
     <>
@@ -45,7 +45,7 @@ function CatPixels({ legUp }: { legUp: boolean }) {
   );
 }
 
-// Dog pixel art (10×10)
+// Dog pixel art (10×11)
 function DogPixels({ legUp }: { legUp: boolean }) {
   return (
     <>
@@ -64,18 +64,18 @@ function DogPixels({ legUp }: { legUp: boolean }) {
       {/* Nose */}
       <rect x={4} y={4} width={2} height={1} fill="#2a1800" />
       {/* Body */}
-      <rect x={2} y={6} width={6} height={3} fill="#e8c99a" />
+      <rect x={2} y={6} width={6} height={4} fill="#e8c99a" />
       {/* Tail */}
       <rect x={8} y={5} width={1} height={2} fill="#c9a46e" />
       <rect x={9} y={4} width={1} height={2} fill="#c9a46e" />
       {/* Legs */}
-      <rect x={2} y={legUp ? 8 : 9} width={2} height={1} fill="#c9a46e" />
-      <rect x={6} y={legUp ? 9 : 8} width={2} height={1} fill="#c9a46e" />
+      <rect x={2} y={legUp ? 9 : 10} width={2} height={1} fill="#c9a46e" />
+      <rect x={6} y={legUp ? 10 : 9} width={2} height={1} fill="#c9a46e" />
     </>
   );
 }
 
-// Dragon pixel art (10×10) — premium
+// Dragon pixel art (10×11) — premium
 function DragonPixels({ legUp }: { legUp: boolean }) {
   return (
     <>
@@ -95,17 +95,17 @@ function DragonPixels({ legUp }: { legUp: boolean }) {
       <rect x={0} y={6} width={2} height={2} fill="#7c3aed" />
       <rect x={8} y={6} width={2} height={2} fill="#7c3aed" />
       {/* Body */}
-      <rect x={2} y={6} width={6} height={3} fill="#a78bfa" />
+      <rect x={2} y={6} width={6} height={4} fill="#a78bfa" />
       {/* Tail */}
       <rect x={8} y={8} width={2} height={1} fill="#7c3aed" />
       {/* Legs */}
-      <rect x={2} y={legUp ? 8 : 9} width={2} height={1} fill="#8b5cf6" />
-      <rect x={6} y={legUp ? 9 : 8} width={2} height={1} fill="#8b5cf6" />
+      <rect x={2} y={legUp ? 9 : 10} width={2} height={1} fill="#8b5cf6" />
+      <rect x={6} y={legUp ? 10 : 9} width={2} height={1} fill="#8b5cf6" />
     </>
   );
 }
 
-// Rabbit pixel art (10×10)
+// Rabbit pixel art (10×11)
 function RabbitPixels({ legUp }: { legUp: boolean }) {
   return (
     <>
@@ -169,10 +169,12 @@ export default function PetCharacter({
   }[type];
 
   return (
+    // 11 rows, not 10: the planted foot lives on row 10. Every pet shares the
+    // grid so they stay the same scale as each other.
     <svg
-      viewBox="0 0 10 10"
+      viewBox="0 0 10 11"
       width={10 * size}
-      height={10 * size}
+      height={11 * size}
       className={animClass}
       style={{
         shapeRendering: "crispEdges",

--- a/client/src/components/WorldDecorations.tsx
+++ b/client/src/components/WorldDecorations.tsx
@@ -257,7 +257,10 @@ const CUP: PixelMap = [
 const CUP_PALETTE: PixelPalette = {
   C: "#fdf6ec",
   k: "#6b4226",
-  H: "#fdf6ec",
+  // The handle had the same value as the cup wall, so defining a separate key
+  // for it achieved nothing — it just read as one column of extra width. Reuses
+  // the saucer's shade rather than introducing a colour.
+  H: "#d9c8a8",
   D: "#d9c8a8",
 };
 

--- a/client/src/lib/uiSprites.test.ts
+++ b/client/src/lib/uiSprites.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import * as sprites from "./uiSprites";
+import type { PixelMap } from "@/components/PixelSprite";
+
+// PixelSprite derives its viewBox width from the *longest* row and pads the
+// rest with transparency, so a map with one short row is not an error — it just
+// silently shifts that row's art relative to the others. Same for a stray
+// character with no palette entry: skipped, no warning. Both are the kind of
+// thing you only notice by looking, which is exactly what this repo can't
+// currently do in CI.
+
+const isPixelMap = (v: unknown): v is PixelMap =>
+  Array.isArray(v) && v.length > 0 && v.every((r) => typeof r === "string");
+
+const maps = Object.entries(sprites).filter(([, v]) => isPixelMap(v)) as [
+  string,
+  PixelMap,
+][];
+
+const paletteFor = (name: string): Record<string, string> | null => {
+  const direct = (sprites as Record<string, unknown>)[`${name}_PALETTE`];
+  return direct && typeof direct === "object"
+    ? (direct as Record<string, string>)
+    : null;
+};
+
+describe("ui sprite maps", () => {
+  it("finds the exported maps", () => {
+    expect(maps.length).toBeGreaterThan(0);
+  });
+
+  for (const [name, map] of maps) {
+    it(`${name} is rectangular`, () => {
+      const widths = new Set(map.map((r) => r.length));
+      expect([...widths]).toHaveLength(1);
+    });
+
+    it(`${name} has no row that is entirely padding`, () => {
+      // A fully-blank leading or trailing row inflates the sprite's box, so
+      // percentage positioning no longer means what it looks like.
+      const blank = (r: string) => /^[.\s]*$/.test(r);
+      expect(blank(map[0])).toBe(false);
+      expect(blank(map[map.length - 1])).toBe(false);
+    });
+
+    const palette = paletteFor(name);
+    if (palette) {
+      it(`${name} uses only characters its palette defines`, () => {
+        const unknown = new Set<string>();
+        for (const row of map) {
+          for (const ch of row) {
+            if (ch !== "." && ch !== " " && !palette[ch]) unknown.add(ch);
+          }
+        }
+        expect([...unknown]).toEqual([]);
+      });
+
+      it(`${name} defines no two palette keys with the same colour`, () => {
+        // This is the coffee-cup bug: H and C were both #fdf6ec, so the handle
+        // was indistinguishable from the cup wall.
+        const byColour = new Map<string, string[]>();
+        for (const [key, colour] of Object.entries(palette)) {
+          byColour.set(colour, [...(byColour.get(colour) ?? []), key]);
+        }
+        const dupes = [...byColour.entries()].filter(([, k]) => k.length > 1);
+        expect(dupes).toEqual([]);
+      });
+    }
+  }
+});


### PR DESCRIPTION
Item 7 from the roadmap — but only the half of it that can be verified. Read the last section before merging; the more useful outcome of this branch may be what it *didn't* find.

## Why this isn't all of item 7

Item 7 was "redraw the scale hierarchy and migrate characters onto `PixelSprite`". That is pixel-art work, and I have no browser or device here — I cannot look at the result. Redrawing sprites blind is the one task on the roadmap where I'd reliably produce plausible-looking code that renders badly, and you'd have no way to tell from the diff.

So this branch does the part that's objectively checkable against geometry, and leaves the aesthetic redraw for a pass where you can see it.

## The real bug: two pets were walking on one leg

The cat and rabbit both drew their legs at `y={legUp ? 9 : 10}` inside a `viewBox="0 0 10 10"`. Row 10 doesn't exist, so on **every** frame one of the two legs was silently clipped — each animal walked on a single leg, alternating which. SVG discards out-of-bounds geometry without a warning, so nothing ever surfaced it.

The dog and dragon show the pattern the other two were reaching for: planted foot one row below the body, lifted foot on the body's last row. Cat and rabbit wanted exactly that and ran out of grid.

Fixed by giving every pet an eleventh row. That leaves the cat and rabbit art **completely untouched** — it just becomes visible. Dog and dragon move to the same 9/10 rows with one extra body row so their lifted foot still meets the torso. That last part is a deliberate small change, made so all four share one grid rather than two pets standing a pixel taller than the others.

Also fixed: `CUP_PALETTE` defined `H` with the same value as `C`, so the coffee cup's handle rendered as one column of extra cup wall. Reuses the saucer's existing shade rather than introducing a colour, so it adds no decision to the palette work still ahead.

## Verification

`PetCharacter.test.tsx` compares every rect's geometry against the declared viewBox, on both walk frames. Against `main`:

```
× cat draws entirely inside its viewBox (walk frame 0)
✓ dog draws entirely inside its viewBox (walk frame 0)
✓ dragon draws entirely inside its viewBox (walk frame 0)
× rabbit draws entirely inside its viewBox (walk frame 0)
× cat draws entirely inside its viewBox (walk frame 1)
✓ dog ...   ✓ dragon ...
× rabbit draws entirely inside its viewBox (walk frame 1)
```

Four fail, and the two that were fine pass — the test discriminates rather than just going red. The "foot on the bottom row" and "same grid" cases pass either way; they're guards against a future redraw, not evidence about this bug.

`uiSprites.test.ts` guards the invariants `PixelSprite` fails silently on: ragged maps (it takes the viewBox width from the longest row and pads the rest), characters with no palette entry (skipped, no warning), and two palette keys with the same colour (the cup bug). All 13 pass as-is — guards, not findings.

60 client tests, 43 server, `tsc --noEmit`, lint, `next build` all clean.

## Three of the reported defects aren't real

I checked each claim from the audit against the source before fixing it, and three don't survive. I've corrected the local roadmap notes too.

- **"`anime` and `sleepy` eyes are half a pixel off-centre."** No. The head spans columns 3–12, centre 8. `anime` and `sleepy` eyes span `[4,7)` and `[9,12)` — midpoint `(4+12)/2 = 8`. `normal` spans `[4,6)` and `[10,12)`, also 8. All three are symmetric, and the blush at `[3,5)`/`[11,13)` independently confirms 8 is the axis. The original claim derived 7.5 from the same numbers, incorrectly.
- **"`long` hair is a character-for-character copy of `bob`, so users see no change."** The *front* layer is identical, but `HairBack` draws 9-row side drapes at columns 1–2 and 13–14 for `long` only. The two options are visibly different — same fringe, longer sides. That's a reasonable design, not a bug.
- **"The `PALM` crown sits ~2.5 pixels left of its trunk, so the tree looks about to topple."** The crown and the trunk's *top* are both centred on column 7. The trunk then leans right across rows 5–10 — which is what palm trunks do. The claim compares the crown to the trunk's *base* and reads the curve as an error.

Partially true: `MOON` has **2** always-empty trailing columns, not 3, so `right-[8%]` is off by ~10px at `scale={5}`. Left alone deliberately — trimming moves the moon, and I can't check where it lands. Its two different palettes are two worlds' moon tints (warm yellow, lavender), intentional rather than a duplication bug.

## What item 7 still needs from you

The aesthetic half. Concretely: a pine tree is currently shorter than a person and a mountain is 11% taller than one, and the two characters are ~90 hand-placed rects that can't be palette-swapped, outlined, or given a blink frame without editing coordinates by hand. I'd suggest doing roadmap item 3b (one canonical pixel unit) first, since the redraw's whole premise is that depth comes from sprite *dimensions* rather than from six different pixel densities — and then iterating on the redraw with you looking at it.
