### PR TITLE
One ground line, one art pixel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ Note: `server/session.js` holds the pure session-state helpers (`createSessionSt
 - `useOnlineFriends` is a hybrid — the friend list comes from Supabase, the online/offline dots from the socket (`get_online_friends` + `presence_update`).
 - `public/sw.js` caches **nothing about the app** — only `/offline.html`, served as a fallback for failed *navigations*. Timer state is server-authoritative, so a stale socket.io or Supabase reply is worse than no reply; the fetch handler returns early for anything that isn't a navigation. Keep it that way. `offline.html` is standalone by necessity (no network means no hashed CSS bundle, no Google Fonts), so its theme tokens are a copy of `globals.css` — update both together.
 - `lib/sounds.ts` owns audio *and* the mute flag. The flag is a module-level variable with its own listener set, not React state, because `playSound` is called from `useGameSession`'s socket handlers — outside the component tree, sometimes while nothing is mounted. `useSound` subscribes to it via `useSyncExternalStore`, so any number of `SoundToggle`s stay in agreement. Add new sounds to `FILES`; don't add a second playback path that bypasses the mute check.
-- Visuals: `GameWorld` renders the session scene; `PixelCharacter`/`PetCharacter`/`WorldDecorations` are hand-drawn SVG/CSS pixel art driven by `lib/avatarData.ts`. Note what the server actually validates: `sanitizeAvatar` whitelists `hairStyle` and `eyeStyle`, but checks colours with a plain `/^#[0-9a-fA-F]{6}$/` regex — so recolouring the palette is client-only, while adding a *style* also needs `VALID_HAIR_STYLES`/`VALID_EYE_STYLES`, and adding a *world* needs both `VALID_WORLDS` and the SQL `sessions_world_check` (migration 008).
+- Visuals: `GameWorld` renders the session scene; `PixelCharacter`/`PetCharacter`/`WorldDecorations` are hand-drawn SVG/CSS pixel art driven by `lib/avatarData.ts`. `lib/scene.ts` holds the two numbers the scene has to agree on — `GROUND` (the ground plane's height, which everything standing is anchored to) and `ART_PX` (one art pixel in CSS px). Both were duplicated literals; `GROUND` appeared six times across three files. Note what the server actually validates: `sanitizeAvatar` whitelists `hairStyle` and `eyeStyle`, but checks colours with a plain `/^#[0-9a-fA-F]{6}$/` regex — so recolouring the palette is client-only, while adding a *style* also needs `VALID_HAIR_STYLES`/`VALID_EYE_STYLES`, and adding a *world* needs both `VALID_WORLDS` and the SQL `sessions_world_check` (migration 008).
 
 ### Mobile / viewport conventions
 
@@ -83,7 +83,7 @@ The game screen is a fixed app shell (`h-dvh` + `overflow-hidden`) with an inter
 - **Landscape phones need height queries, not width breakpoints.** A landscape phone is *wide*, so `sm:` fires exactly when vertical space has run out and makes things bigger. `globals.css` keys the HUD's compact form off `max-height: 520px`.
 - Overlay panels go `inset-x-2 sm:inset-x-auto` + `w-full sm:w-80` — `FriendsPanel`, `StatsPanel` and `StickyNote` all follow this; a bare `w-80` is 320px of a 360px screen.
 - Touch targets follow the `w-11 h-11 sm:w-7 sm:h-7` / `px-4 py-2.5 sm:px-0 sm:py-0` pattern already in `Button` and `AvatarCreator`.
-- Still outstanding: `GameWorld` has no responsive sprite scaling — characters are the same fixed CSS px on a 360px phone as on a desktop. That wants a single canonical pixel unit first (see the art notes), since scaling sprites by non-integer factors is what makes pixel art blur.
+- Still outstanding: `GameWorld` has no responsive sprite scaling — characters are the same fixed CSS px on a 360px phone as on a desktop. `ART_PX` is now the single knob for it, but it can only move in whole numbers: scaling sprites by non-integer factors is what makes pixel art blur, so the phone size is `ART_PX = 2`, not `ART_PX * 0.75`.
 
 ### Database conventions
 
@@ -176,6 +176,17 @@ SVGs, five of which are untouched Next.js starter files.
   fraction between them. See `useCharacterPosition`.
 - Squash-and-stretch is not available to this art: `scaleY(1.05)` of a 72px sprite is
   75.6px. Weight has to come from the arc, in whole pixels.
+- **One art pixel per scene.** `ART_PX` (`lib/scene.ts`) is it; the characters and pets
+  are on it. The scenery is not, and cannot be moved by editing its `scale` props: a
+  sprite's apparent pixel size *is* its scale, so a 16-cell map at `ART_PX` is a 48px
+  mountain, not a small-pixelled 128px one. Keeping current sizes at one density means
+  redrawing each map at more cells — `MOUNTAIN` needs 43×27 instead of 16×10. The full
+  cost is tabulated at the top of `WorldDecorations.tsx`. Never "fix" a density mismatch
+  by rescaling a small map up; that is the same picture with bigger pixels.
+- Anything that stands in the world anchors to `GROUND`, and its wrapper's bottom edge
+  must be the sprite's feet. A name tag or caption inside the wrapper silently becomes
+  the bottom edge and lifts the sprite off the ground — that is what `calc(19% - 4px)`
+  was compensating for.
 - To review sprite changes without a browser, render the component in jsdom and dump the
   SVG to a static HTML page — that is how the pet fix was reviewed. Screenshots and visual
   judgement still need the repo owner; say so instead of guessing.

--- a/client/src/components/AvatarCreator.tsx
+++ b/client/src/components/AvatarCreator.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState } from "react";
 import PixelCharacter from "./PixelCharacter";
+import { ART_PX } from "@/lib/scene";
 import {
   SKIN_COLORS,
   HAIR_COLORS,
@@ -139,7 +140,7 @@ export default function AvatarCreator({
               paddingBottom: 12,
             }}
           >
-            <PixelCharacter {...config} anim="idle" facing="right" size={3} />
+            <PixelCharacter {...config} anim="idle" facing="right" size={ART_PX} />
           </div>
         </div>
 

--- a/client/src/components/GameWorld.test.tsx
+++ b/client/src/components/GameWorld.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { render } from "@testing-library/react";
 import GameWorld, { type GamePhase } from "./GameWorld";
 import { DEFAULT_AVATAR } from "@/lib/avatarData";
+import { ART_PX, GROUND } from "@/lib/scene";
 
 // The scene used to place characters with `calc(41.7% + 8px)` on `left` and
 // spin the break-phase controller ±10°. Both put sprite edges between device
@@ -12,7 +13,12 @@ import { DEFAULT_AVATAR } from "@/lib/avatarData";
 const me = { id: "me", avatar: DEFAULT_AVATAR };
 const partner = { id: "them", avatar: DEFAULT_AVATAR };
 
-function renderScene(phase: GamePhase, focusProgress = 0, returning = 0) {
+function renderScene(
+  phase: GamePhase,
+  focusProgress = 0,
+  returning = 0,
+  pets = false,
+) {
   return render(
     <GameWorld
       worldId="forest"
@@ -21,6 +27,8 @@ function renderScene(phase: GamePhase, focusProgress = 0, returning = 0) {
       returningProgress={returning}
       me={me}
       partner={partner}
+      myPet={pets ? "cat" : null}
+      partnerPet={pets ? "dog" : null}
       myName="ME"
       partnerName="THEM"
     />,
@@ -78,5 +86,54 @@ describe("break overlay", () => {
     for (const el of container.querySelectorAll<HTMLElement>("*")) {
       expect(el.style.transform ?? "").not.toMatch(/rotate/);
     }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// One ground line, one art pixel.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("ground line", () => {
+  it("stands everything in the scene on the same line", () => {
+    const { container } = renderScene("waiting");
+    // Trees, hills and both characters are all anchored with an inline
+    // `bottom`. Any value that isn't GROUND is something standing off the
+    // horizon — which is what `calc(19% - 4px)` was.
+    const anchors = new Set(
+      Array.from(container.querySelectorAll<HTMLElement>("[style*='bottom']"))
+        .map((el) => el.style.bottom)
+        .filter(Boolean),
+    );
+    expect(anchors).toEqual(new Set([GROUND]));
+  });
+
+  it("anchors the character by its feet, not by its name tag", () => {
+    // The tag has to be out of flow. As an ordinary child it is the wrapper's
+    // bottom edge, so anchoring the wrapper to the ground lands the label on
+    // the ground and leaves the character a label's height in the air.
+    const { container } = renderScene("waiting");
+    for (const wrapper of characterWrappers(container)) {
+      const tag = wrapper.querySelector<HTMLElement>(".text-\\[10px\\]");
+      expect(tag, "no name tag rendered").toBeTruthy();
+      expect(tag!.className).toContain("absolute");
+    }
+  });
+});
+
+describe("one art pixel", () => {
+  /** CSS px per art pixel, read off a sprite's own SVG. */
+  function density(container: HTMLElement, viewBox: string) {
+    const svg = container.querySelector(`svg[viewBox="${viewBox}"]`);
+    expect(svg, `no sprite with viewBox "${viewBox}"`).toBeTruthy();
+    const cells = Number(viewBox.split(" ")[2]);
+    return Number(svg!.getAttribute("width")) / cells;
+  }
+
+  it("draws characters and their pets on the same pixel grid", () => {
+    const { container } = renderScene("waiting", 0, 0, true);
+    // The scenery is deliberately not here yet — see the deviation table in
+    // WorldDecorations. These two are what stand side by side in one frame.
+    expect(density(container, "0 0 16 24")).toBe(ART_PX);
+    expect(density(container, "0 0 10 11")).toBe(ART_PX);
   });
 });

--- a/client/src/components/GameWorld.tsx
+++ b/client/src/components/GameWorld.tsx
@@ -20,6 +20,7 @@ import {
   CONTROLLER_PALETTE,
 } from "@/lib/uiSprites";
 import { WorldDecor } from "./WorldDecorations";
+import { GROUND } from "@/lib/scene";
 
 export type GamePhase =
   | "waiting"
@@ -122,8 +123,6 @@ export default function GameWorld({
     sceneWidth,
   );
 
-  const GROUND_HEIGHT = "19%";
-
   return (
     <div ref={sceneRef} className="relative w-full h-full">
       {/* Sky */}
@@ -138,7 +137,7 @@ export default function GameWorld({
       <div
         className="absolute bottom-0 left-0 right-0"
         style={{
-          height: GROUND_HEIGHT,
+          height: GROUND,
           backgroundColor: world.groundColor,
         }}
       >
@@ -314,7 +313,10 @@ export default function GameWorld({
 
       {/* Waiting state — partner slot empty */}
       {!partner && phase === "waiting" && (
-        <div className="absolute right-4 bottom-[19%] flex flex-col items-center opacity-40">
+        <div
+          className="absolute right-4 flex flex-col items-center opacity-40"
+          style={{ bottom: GROUND }}
+        >
           <div className="w-12 h-12 rounded-full border-2 border-dashed border-white/50 flex items-center justify-center text-white text-lg">
             ?
           </div>

--- a/client/src/components/GameWorld.tsx
+++ b/client/src/components/GameWorld.tsx
@@ -20,7 +20,7 @@ import {
   CONTROLLER_PALETTE,
 } from "@/lib/uiSprites";
 import { WorldDecor } from "./WorldDecorations";
-import { GROUND } from "@/lib/scene";
+import { ART_PX, GROUND } from "@/lib/scene";
 
 export type GamePhase =
   | "waiting"
@@ -229,13 +229,18 @@ export default function GameWorld({
       >
         <div className="flex items-end gap-1">
           {myPet && (
-            <PetCharacter type={myPet} anim={myAnim} facing="right" size={2} />
+            <PetCharacter
+              type={myPet}
+              anim={myAnim}
+              facing="right"
+              size={ART_PX}
+            />
           )}
           <PixelCharacter
             {...me.avatar}
             anim={myAnim}
             facing="right"
-            size={3}
+            size={ART_PX}
           />
         </div>
         <div className="absolute top-full inset-x-0 mt-1 text-[10px] text-center font-bold text-white bg-black/50 rounded px-1 font-mono truncate max-w-[80px]">
@@ -259,14 +264,14 @@ export default function GameWorld({
               {...partner.avatar}
               anim={partnerDisconnected ? "idle" : partnerAnim}
               facing="left"
-              size={3}
+              size={ART_PX}
             />
             {partnerPet && (
               <PetCharacter
                 type={partnerPet}
                 anim={partnerDisconnected ? "idle" : partnerAnim}
                 facing="left"
-                size={2}
+                size={ART_PX}
               />
             )}
           </div>

--- a/client/src/components/GameWorld.tsx
+++ b/client/src/components/GameWorld.tsx
@@ -219,20 +219,17 @@ export default function GameWorld({
       </div>
 
       {/* Me (left side, walks right) */}
+      {/* The name tag is out of flow on purpose: as an ordinary child it was
+          the wrapper's bottom edge, so anchoring the wrapper to the ground put
+          the label on the ground and held the character a label's height above
+          it. That is what the `- 4px` was nudging at. */}
       <motion.div
         className="absolute z-20"
-        style={{ bottom: "calc(19% - 4px)", left: 0, x: myX }}
+        style={{ bottom: GROUND, left: 0, x: myX }}
       >
         <div className="flex items-end gap-1">
           {myPet && (
-            <div className="mb-1">
-              <PetCharacter
-                type={myPet}
-                anim={myAnim}
-                facing="right"
-                size={2}
-              />
-            </div>
+            <PetCharacter type={myPet} anim={myAnim} facing="right" size={2} />
           )}
           <PixelCharacter
             {...me.avatar}
@@ -241,7 +238,7 @@ export default function GameWorld({
             size={3}
           />
         </div>
-        <div className="text-[10px] text-center mt-1 font-bold text-white bg-black/50 rounded px-1 font-mono truncate max-w-[80px]">
+        <div className="absolute top-full inset-x-0 mt-1 text-[10px] text-center font-bold text-white bg-black/50 rounded px-1 font-mono truncate max-w-[80px]">
           {myName ?? "YOU"}
         </div>
       </motion.div>
@@ -251,7 +248,7 @@ export default function GameWorld({
         <motion.div
           key={partner.id}
           className="absolute z-20"
-          style={{ bottom: "calc(19% - 4px)", right: 0, x: partnerX }}
+          style={{ bottom: GROUND, right: 0, x: partnerX }}
         >
           <div
             className={`flex items-end gap-1 transition-opacity duration-500 ${
@@ -265,17 +262,15 @@ export default function GameWorld({
               size={3}
             />
             {partnerPet && (
-              <div className="mb-1">
-                <PetCharacter
-                  type={partnerPet}
-                  anim={partnerDisconnected ? "idle" : partnerAnim}
-                  facing="left"
-                  size={2}
-                />
-              </div>
+              <PetCharacter
+                type={partnerPet}
+                anim={partnerDisconnected ? "idle" : partnerAnim}
+                facing="left"
+                size={2}
+              />
             )}
           </div>
-          <div className="text-[10px] text-center mt-1 font-bold text-white bg-black/50 rounded px-1 font-mono truncate max-w-[80px]">
+          <div className="absolute top-full inset-x-0 mt-1 text-[10px] text-center font-bold text-white bg-black/50 rounded px-1 font-mono truncate max-w-[80px]">
             {partnerDisconnected ? (
               <span className="animate-pulse">RECONNECTING…</span>
             ) : (

--- a/client/src/components/LandingPage.tsx
+++ b/client/src/components/LandingPage.tsx
@@ -8,7 +8,7 @@ import { WorldDecor } from "./WorldDecorations";
 import { signInWithProvider } from "@/lib/supabase";
 import { DEFAULT_AVATAR, WORLDS } from "@/lib/avatarData";
 import { HEART, HEART_PALETTE } from "@/lib/uiSprites";
-import { GROUND } from "@/lib/scene";
+import { ART_PX, GROUND } from "@/lib/scene";
 
 // Two sample characters walking toward each other on the landing page
 const LEFT_CHAR = { ...DEFAULT_AVATAR, outfitColor: "#3B5BDB" };
@@ -128,7 +128,7 @@ function HeroScene() {
           ease: "linear",
         }}
       >
-        <PixelCharacter {...LEFT_CHAR} anim="walk" facing="right" size={3} />
+        <PixelCharacter {...LEFT_CHAR} anim="walk" facing="right" size={ART_PX} />
       </motion.div>
       <motion.div
         className="absolute bottom-[17%]"
@@ -140,7 +140,7 @@ function HeroScene() {
           ease: "linear",
         }}
       >
-        <PixelCharacter {...RIGHT_CHAR} anim="walk" facing="left" size={3} />
+        <PixelCharacter {...RIGHT_CHAR} anim="walk" facing="left" size={ART_PX} />
       </motion.div>
     </div>
   );

--- a/client/src/components/LandingPage.tsx
+++ b/client/src/components/LandingPage.tsx
@@ -8,6 +8,7 @@ import { WorldDecor } from "./WorldDecorations";
 import { signInWithProvider } from "@/lib/supabase";
 import { DEFAULT_AVATAR, WORLDS } from "@/lib/avatarData";
 import { HEART, HEART_PALETTE } from "@/lib/uiSprites";
+import { GROUND } from "@/lib/scene";
 
 // Two sample characters walking toward each other on the landing page
 const LEFT_CHAR = { ...DEFAULT_AVATAR, outfitColor: "#3B5BDB" };
@@ -92,7 +93,7 @@ function HeroScene() {
           </div>
           <div
             className="absolute bottom-0 left-0 right-0"
-            style={{ height: "19%", backgroundColor: world.groundColor }}
+            style={{ height: GROUND, backgroundColor: world.groundColor }}
           >
             <div
               className="absolute top-0 left-0 right-0 h-1.5"

--- a/client/src/components/PetCharacter.tsx
+++ b/client/src/components/PetCharacter.tsx
@@ -2,10 +2,18 @@
 import { useEffect, useState } from "react";
 import type { AnimState } from "./PixelCharacter";
 import type { PetType } from "@/lib/types";
+import { ART_PX } from "@/lib/scene";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PetCharacter — tiny SVG pixel art pets (10×11 viewBox)
 // All pets match their owner's animation state.
+//
+// `size` is one art pixel in CSS px, the same unit the character uses. Pets
+// used to render at 2 while the character rendered at 3, which is a different
+// pixel grid in the same frame. On ART_PX they are 30×33 rather than 20×22 —
+// correct density, but large next to a 48×72 person. Keeping the old apparent
+// size at one density means redrawing the maps at roughly 7×7 cells, which is
+// the item 7b redraw.
 // ─────────────────────────────────────────────────────────────────────────────
 
 interface PetCharacterProps {
@@ -140,7 +148,7 @@ export default function PetCharacter({
   type,
   anim = "idle",
   facing = "right",
-  size = 3,
+  size = ART_PX,
 }: PetCharacterProps) {
   const [walkFrame, setWalkFrame] = useState(0);
 

--- a/client/src/components/PixelCharacter.tsx
+++ b/client/src/components/PixelCharacter.tsx
@@ -1,12 +1,17 @@
 "use client";
 import { useEffect, useState } from "react";
 import type { AvatarConfig, HairStyle, EyeStyle } from "@/lib/avatarData";
+import { ART_PX } from "@/lib/scene";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PixelCharacter — SVG-based 8-bit character renderer
 //
 // ViewBox: 0 0 16 24  (16 × 24 "pixels")
-// Displayed at: size * 16 × size * 24  (default size=4 → 64×96px)
+// Displayed at: size * 16 × size * 24  (ART_PX → 48×72px)
+//
+// `size` is one art pixel in CSS px. It defaults to ART_PX and every call site
+// passes ART_PX — a character rendering at a different pixel size to the scene
+// around it is the thing ART_PX exists to prevent, not a knob.
 //
 // Layout:
 //   y=0–3   Hair top
@@ -170,7 +175,7 @@ export default function PixelCharacter({
   outfitColor,
   anim = "idle",
   facing = "right",
-  size = 4,
+  size = ART_PX,
   className,
 }: PixelCharacterProps) {
   const [walkFrame, setWalkFrame] = useState(0);

--- a/client/src/components/WorldDecorations.tsx
+++ b/client/src/components/WorldDecorations.tsx
@@ -2,18 +2,17 @@
 import { useMemo } from "react";
 import PixelSprite, { type PixelMap, type PixelPalette } from "./PixelSprite";
 import { getWorld, type WorldId } from "@/lib/avatarData";
+import { GROUND } from "@/lib/scene";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // World Decorations — pixel-art scenery for each world.
 //
 // Every prop-less component here renders inside GameWorld's sky container
-// (absolute inset-0, overflow-hidden). The ground plane starts at bottom: 19%,
-// so anything "standing" is anchored there. Scenes are built from three
-// layers for depth: far silhouettes → mid sprites → near sprites, plus slow
-// ambient motion (drifting clouds, twinkling stars, rising steam).
+// (absolute inset-0, overflow-hidden). The ground plane is GROUND tall
+// (lib/scene.ts), so anything "standing" is anchored there. Scenes are built
+// from three layers for depth: far silhouettes → mid sprites → near sprites,
+// plus slow ambient motion (drifting clouds, twinkling stars, rising steam).
 // ─────────────────────────────────────────────────────────────────────────────
-
-const GROUND = "19%";
 
 // ── Sprite maps ─────────────────────────────────────────────────────────────
 

--- a/client/src/components/WorldDecorations.tsx
+++ b/client/src/components/WorldDecorations.tsx
@@ -14,6 +14,31 @@ import { GROUND } from "@/lib/scene";
 // plus slow ambient motion (drifting clouds, twinkling stars, rising steam).
 // ─────────────────────────────────────────────────────────────────────────────
 
+// ── Scale deviations ────────────────────────────────────────────────────────
+//
+// None of the scenery is on ART_PX yet, and it cannot get there by editing the
+// numbers below: a sprite's apparent pixel size *is* its scale, so a 16-cell
+// map rendered at 3px is a 48px mountain, not a small-pixelled 128px one.
+// Keeping the current on-screen size means redrawing each map at more cells.
+// The cost, so the redraw (roadmap 7b) can be planned rather than discovered:
+//
+//   sprite          map      scale(s)      on-screen        cells @ ART_PX
+//   MOUNTAIN        16x10    5, 6, 7, 8    80..128 wide     27x17 .. 43x27
+//   BOOKSHELF       14x17    4             56x68            19x23
+//   PALM            14x11    4             56x44            19x15
+//   UMBRELLA        12x9     4             48x36            16x12
+//   PINE            12x14    2, 3, 4       24..48 wide      8x9 .. 16x19
+//   SUN             9x9      3, 4, 5       27..45           9x9 .. 15x15
+//   MOON            8x8      4, 5          32..40           11x11 .. 13x13
+//   PLANET          16x9     2, 4          32..64 wide      11x6 .. 21x12
+//   CLOUD           12x4     2, 3          24..36 wide      8x3 .. 12x4
+//   BUILDING_*      -        2, 3          -                already at/near 3
+//   LAMP, TABLE     -        3             -                already at ART_PX
+//
+// MountainDecor alone renders at 5, 6, 7 and 8 in a single frame, with the
+// character beside it at 3. Mismatched pixel density is the clearest tell of
+// amateur pixel art, so this list is the debt, not the design.
+//
 // ── Sprite maps ─────────────────────────────────────────────────────────────
 
 const CLOUD: PixelMap = [

--- a/client/src/lib/scene.ts
+++ b/client/src/lib/scene.ts
@@ -1,0 +1,29 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Scene constants — the two numbers every piece of world art has to agree on.
+//
+// Both used to be duplicated literals. GROUND was written out three times
+// (WorldDecorations, GameWorld, LandingPage) and kept in step by hand, and the
+// art pixel was whatever number each call site passed to `scale`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Height of the ground plane, as a fraction of the scene box. Anything
+ * standing in the world is anchored to it: the plane itself is this tall, and
+ * a sprite's feet sit exactly on top of it.
+ */
+export const GROUND = "19%";
+
+/**
+ * One art pixel, in CSS px. A pixel-art scene has exactly one of these — a
+ * sprite rendering its pixels bigger than its neighbour's is the single
+ * clearest tell of amateur pixel art, and it is not fixable by rescaling
+ * later, because a sprite's apparent pixel size *is* its scale.
+ *
+ * The characters and pets are on it. The scenery is not yet: `MountainDecor`
+ * alone renders at 5, 6, 7 and 8, and moving it to ART_PX today would shrink
+ * the front range from 128px wide to 48px. Keeping its on-screen size means
+ * redrawing the map at 43x27 cells instead of 16x10 — that is the redraw in
+ * roadmap item 7b, not a constant swap. The deviations are catalogued in
+ * WorldDecorations; do not "fix" them by scaling a small map up.
+ */
+export const ART_PX = 3;


### PR DESCRIPTION
Roadmap item 3b, scoped as we agreed: the mechanical half now, the density collapse
deferred to the 7b redraw with its cost written down.

**Stacked on #35** — base is `art/de-blur-pixel-transforms`, so merge that one first and
this retargets to `main` automatically. 5 commits.

### What's here

`lib/scene.ts` holds the two numbers the scene has to agree on.

**`GROUND`** was written out six times across three files — `WorldDecorations`,
`GameWorld` (its own constant, *plus* `bottom-[19%]` on the waiting slot, *plus*
`calc(19% - 4px)` on both characters) and `LandingPage`. Trees, waves, skylines and the
ground plane itself all anchor to it, so one of them drifting detaches the scenery from
the horizon.

**`ART_PX`** is one art pixel in CSS px. Characters were `3` and pets were `2`, which is
two pixel grids in the same frame — the clearest tell of amateur pixel art, and invisible
in a diff while both numbers live at call sites. Both are on `ART_PX` now, including the
component defaults so `3` and `4` stop looking like tunable choices.

### The `- 4px` was compensating for the wrong thing

`bottom` positions the wrapper, and the wrapper's bottom edge was the **name tag**, not
the character's feet. So anchoring to the ground put the label near the horizon and held
the character a label's height above it — while every tree in the same scene stands
exactly on `GROUND`, because `Grounded` has no label inside it. The gap is roughly five
times the 4px that was papering over it.

The tag moves out of flow (`absolute top-full`), so the wrapper's bottom edge is the feet
and the anchor is plain `GROUND`. The pet loses `mb-1` for the same reason — with
`items-end` it was floating 4px above its owner's foot line.

This is part of why characters read as hovering. The missing contact shadow (roadmap item
4) is the other part and is not touched here.

### Deliberately not done

The scenery stays on its own scales, and **cannot** be moved by editing the numbers: a
sprite's apparent pixel size *is* its scale, so a 16-cell map at `ART_PX` is a 48px
mountain, not a small-pixelled 128px one. Keeping current sizes at one density means
redrawing each map at more cells. The full bill is tabulated at the top of
`WorldDecorations.tsx` so 7b can be planned rather than discovered:

| sprite | map | scale(s) | on-screen | cells @ ART_PX |
|---|---|---|---|---|
| MOUNTAIN | 16×10 | 5, 6, 7, 8 | 80–128 wide | 27×17 – **43×27** |
| BOOKSHELF | 14×17 | 4 | 56×68 | 19×23 |
| PALM | 14×11 | 4 | 56×44 | 19×15 |
| PINE | 12×14 | 2, 3, 4 | 24–48 wide | 8×9 – 16×19 |
| LAMP, TABLE | — | 3 | — | already at ART_PX |

### A/B

All three new assertions fail against the pre-3b commit, and #35's six still pass:

```
× stands everything in the scene on the same line
    AssertionError: expected Set{ '19%', 'calc(19% - 4px)' } to deeply equal Set{ '19%' }
× anchors the character by its feet, not by its name tag
    AssertionError: expected 'text-[10px] text-center mt-1 font-bol…' to contain 'absolute'
× draws characters and their pets on the same pixel grid
    AssertionError: expected 2 to be 3
```

That last one is the mismatched density expressed as a single number, which it never
could be while the two values lived at separate call sites.

### Verified / not verified

Green locally: `tsc --noEmit`, `npm run lint`, 88 tests, `next build` with the CI dummy env.

**Not browser-tested.** Review page at
`…/scratchpad/ground-line-review.html` — before/after scenes rendered against the **real
compiled Tailwind bundle**, so the layout is the real layout, with a red rule overlaid at
`bottom: 19%` to make "on the line or not" checkable rather than a vibe. Three rows:
feet-on-ground, pets, and a second world.

One judgment call I'd like your eye on: **pets grow from 20×22 to 30×33.** That is
correct density, but it makes a cat about 0.46× a person's height where a real one is
~0.25×. If it looks wrong, the fix is redrawing the pet maps at roughly 7×7 cells in 7b —
not sending `size` back to `2`, which reintroduces the second pixel grid.