### PR TITLE
Server-set rotating world themes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-Duodoro is a collaborative pomodoro web app for long-distance couples/friends. Users sign in (Google/Discord OAuth via Supabase), create a pixel-art avatar, pick a themed "world", and run synchronized focus/break sessions together in real time. Friends, invites, presence, sticky-note tasks, and session stats are layered on top.
+Duodoro is a collaborative pomodoro web app for long-distance couples/friends. Users sign in (Google/Discord OAuth via Supabase), create a pixel-art avatar, and run synchronized focus/break sessions together in real time, in whichever themed "world" the clock is on. Friends, invites, presence, sticky-note tasks, and session stats are layered on top.
 
 ## Repo layout
 
@@ -28,7 +28,7 @@ Client (`cd client`):
 
 Server (`cd server`):
 - `npm start` — runs on port 3001 (or `npx nodemon index.js` for reload)
-- `npm run test:run` — vitest once
+- `npm run test:run` — vitest once. Most of the suite is pure helpers, but `createSession.test.js` spawns the real server as a child process with `PORT=0` and talks to it over a real socket (`socket.io-client`, a devDependency) — so that run binds an ephemeral port and scrapes the boot log for it
 - Without `SUPABASE_URL`/`SUPABASE_SERVICE_KEY` set, the server runs in dev mode: JWT verification and all persistence are skipped. In production those vars are required (it exits otherwise).
 
 Local dev needs both processes running. Client env: `NEXT_PUBLIC_SOCKET_URL`, `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`. Server env: see `server/.env.example`.
@@ -40,6 +40,7 @@ Local dev needs both processes running. Client env: `NEXT_PUBLIC_SOCKET_URL`, `N
 - **Socket.IO server** (`server/index.js`) is the source of truth for live session state: phases, timers, players, presence, invites. All session state is **in-memory** (the `sessions` map plus the presence registry in `server/presence.js`) — it does not survive a server restart, and nothing live is read back from the DB.
 - **Supabase** handles auth (JWT), and persistence: profiles, friendships, tasks/sticky notes, and *completed* session history (`sessions` + `session_participants` rows written by the server with the service-role key, bypassing RLS). The client talks to Supabase directly (anon key + RLS) for friends, tasks, and stats.
 - **Client** never trusts its own clock for the timer: the server broadcasts `phase_change` with `phaseStartTime` and durations; the client renders countdowns from `Date.now() - phaseStartTime`.
+- **The world is not client input.** There is one world at a time, the same for everybody, derived from the wall clock — see the rotation section below.
 
 ### Server session lifecycle
 
@@ -50,9 +51,22 @@ Two timer modes: `pomodoro` (fixed durations, server auto-advances) and `flow` (
 
 A dropped socket doesn't eject its player immediately: authenticated players keep their slot for a reconnect grace window (`RECONNECT_GRACE_MS`, default 60 s), and `join_session` from the same `userId` re-keys the existing slot to the new socket instead of duplicating the player. The client mirrors the active session id into `sessionStorage` and auto-rejoins after a page reload.
 
+### The world rotation
+
+`create_session` assigns `worldAt()` (`server/rotation.js`) — one world, everybody, changing on the **:30** of every hour, anchored to UTC. Nobody picks a world; there is no picker. Rules that keep it working:
+
+- **Derived, never stored.** No row, no timer, no broadcast. Live session state is already in-memory and dies with the process, so a persisted rotation would be one more thing to resync after a restart and one more thing two instances can disagree about. Anything that needs to know the world computes it.
+- **A session keeps the world it started in.** Rotation applies to new sessions only — swapping the scene 20 minutes into a focus block is worse than a slightly stale theme, and it would make the `sessions.world` history row ambiguous. `sync_state` carries the session's world; the client mirrors it and does not re-derive.
+- **Two copies, one schedule.** `client/` and `server/` can't import each other, so the derivation is duplicated in `server/rotation.js` and `client/src/lib/rotation.ts`. What keeps them honest is that both test suites pin the **same table of timestamps** — edit one implementation and the *other* package's suite fails. Change both, or neither.
+- **Integer hash, never `Math.sin`.** The per-cycle shuffle uses `Math.imul` + xor-shift. `lib/terrain.ts` and `lib/interior.ts` seed with `Math.sin`, which is fine when a 1-ULP difference between engines moves a rock; here it would put the client and the server in *different worlds*. ECMA-262 doesn't require transcendentals to be bit-identical across implementations. Anything two packages must agree on exactly stays in integer arithmetic.
+- **The order reshuffles every cycle** (8 slots = every world once). A fixed order would be an 8-hour loop, and 8 divides 24, so a 9am regular would get the same world every day forever. A fix-up stops a cycle opening on the world the last one closed with.
+- **`create_session` ignores an unknown `world` field rather than rejecting it**, so an older client still gets a session instead of an error. That is the general shape for removing a field from an event.
+
+Adding a world now needs `ROTATION_WORLDS` (**both** copies), the client's `WorldId` and `WORLDS` in `lib/avatarData.ts`, and the SQL `sessions_world_check` (migration 008, last edited by 019). A world missing from the rotation is unreachable — there is no picker left to select it with, which is why `rotation.test.ts` asserts the two lists match.
+
 Security conventions in the socket layer (preserve these when adding events):
 - `io.use()` middleware verifies the Supabase JWT and sets `socket.userId` — **never trust a client-sent userId**.
-- Every inbound payload is validated/sanitized (`sanitizeAvatar`, `VALID_WORLDS`, name length caps, duration clamps `MAX_FOCUS`/`MAX_BREAK`).
+- Every inbound payload is validated/sanitized (`sanitizeAvatar`, `VALID_PETS`, name length caps, duration clamps `MAX_FOCUS`/`MAX_BREAK`). The stronger move, where it's available, is not to take the field at all — that is what happened to `world`.
 - Mutating events check the socket is actually a player in the session; create/join/invite are rate-limited per socket.
 - Knowing a session id is not permission to use it: `join_session` requires an existing slot, an invite, or friendship with someone already in the session, and `send_invite` is friends-only. Server-side ids are read from `socketToSession`, never taken from the payload.
 
@@ -65,14 +79,15 @@ Note: `server/session.js` holds the pure session-state helpers (`createSessionSt
 `DuoTimer.tsx` is the top-level orchestrator: it composes two hooks and switches screens on `appStep` (`loading → landing → avatar → home → game`, defined in `lib/sessionTypes.ts`).
 
 - `hooks/useAuth.ts` — Supabase auth, profile load/save, drives `appStep`.
-- `hooks/useGameSession.ts` — owns the Socket.IO connection (auth token in handshake, retries on token expiry), all session/phase/player state, invites, resume-after-tab-sleep resync (`request_sync`), and the `sessionStorage` mirror that drives rejoin-after-reload. This is the file to touch for any realtime behavior. It also exposes `connectionState`, which `ConnectionBanner` renders as a "reconnecting / connection lost" banner while you're in a session.
+- `hooks/useGameSession.ts` — owns the Socket.IO connection (auth token in handshake, retries on token expiry), all session/phase/player state, invites, resume-after-tab-sleep resync (`request_sync`), and the `sessionStorage` mirror that drives rejoin-after-reload. This is the file to touch for any realtime behavior. It also exposes `connectionState`, which `ConnectionBanner` renders as a "reconnecting / connection lost" banner while you're in a session. `myWorld` is read-only to callers — it mirrors the server's answer, and a setter would be a supported way to put the client back in charge of it.
+- **Never read `Date.now()` during render.** `"use client"` marks a component as interactive; Next still renders it on the server, where "now" is a different number, so anything clock-derived in the first pass is a hydration mismatch. Start at `null` and fill in from an effect — `useRotatingWorld` is the pattern, and `WorldNowCard.test.tsx` checks it with `renderToStaticMarkup`, because testing-library's `render()` flushes effects and so can't see the first pass at all. Then *re-read* the clock each tick rather than decrementing a stored value: background tabs get their timers throttled, and a countdown that decrements drifts by however long the tab slept.
 - `lib/supabase.ts` — browser Supabase singleton (PKCE flow, localStorage sessions — deliberately not cookie/SSR-based; `app/auth/callback/route.ts` exists for the OAuth redirect).
 - Direct-to-Supabase data hooks: `useFriendsList`, `useFriendSearch`, `useTasks`, `useStickyNotes`, `lib/useStats.ts`. In these, **check `error` on reads as well as writes** — `if (data) setX(data)` leaves the list at its old value and renders the empty state, which makes a hard failure indistinguishable from "you have nothing yet". That is exactly how the `42P17` outage fixed in migration 018 hid: every task read was erroring and the UI said "No tasks yet". Likewise, RLS refusing an UPDATE or DELETE is not an error — it matches zero rows — so those need `.select()` and a row-count check.
 - **An empty result and a failed request must never render the same way.** Zeros and "nothing here yet" are claims about the user's data; making them on a failed fetch tells someone their history is gone. Where a hook can return legitimately-empty data, expose a *loaded* flag alongside `error` — `useStats` does — and gate the empty state on it, because `personalStats === null` covers both "new account" and "never loaded". `StatsErrorState` is the shared "couldn't load, nothing was lost, retry" panel.
 - `useOnlineFriends` is a hybrid — the friend list comes from Supabase, the online/offline dots from the socket (`get_online_friends` + `presence_update`).
 - `public/sw.js` caches **nothing about the app** — only `/offline.html`, served as a fallback for failed *navigations*. Timer state is server-authoritative, so a stale socket.io or Supabase reply is worse than no reply; the fetch handler returns early for anything that isn't a navigation. Keep it that way. `offline.html` is standalone by necessity (no network means no hashed CSS bundle, no Google Fonts), so its theme tokens are a copy of `globals.css` — update both together.
 - `lib/sounds.ts` owns audio *and* the mute flag. The flag is a module-level variable with its own listener set, not React state, because `playSound` is called from `useGameSession`'s socket handlers — outside the component tree, sometimes while nothing is mounted. `useSound` subscribes to it via `useSyncExternalStore`, so any number of `SoundToggle`s stay in agreement. Add new sounds to `FILES`; don't add a second playback path that bypasses the mute check.
-- Visuals: `GameWorld` renders the session scene; `PixelCharacter`/`PetCharacter`/`WorldDecorations` are hand-drawn SVG/CSS pixel art driven by `lib/avatarData.ts`. `lib/scene.ts` holds the two numbers the scene has to agree on — `GROUND` (the ground plane's height, which everything standing is anchored to) and `ART_PX` (one art pixel in CSS px). Both were duplicated literals; `GROUND` appeared six times across three files. Note what the server actually validates: `sanitizeAvatar` whitelists `hairStyle` and `eyeStyle`, but checks colours with a plain `/^#[0-9a-fA-F]{6}$/` regex — so recolouring the palette is client-only, while adding a *style* also needs `VALID_HAIR_STYLES`/`VALID_EYE_STYLES`, and adding a *world* needs both `VALID_WORLDS` and the SQL `sessions_world_check` (migration 008).
+- Visuals: `GameWorld` renders the session scene; `PixelCharacter`/`PetCharacter`/`WorldDecorations` are hand-drawn SVG/CSS pixel art driven by `lib/avatarData.ts`. `lib/scene.ts` holds the two numbers the scene has to agree on — `GROUND` (the ground plane's height, which everything standing is anchored to) and `ART_PX` (one art pixel in CSS px). Both were duplicated literals; `GROUND` appeared six times across three files. Note what the server actually validates: `sanitizeAvatar` whitelists `hairStyle` and `eyeStyle`, but checks colours with a plain `/^#[0-9a-fA-F]{6}$/` regex — so recolouring the palette is client-only, while adding a *style* also needs `VALID_HAIR_STYLES`/`VALID_EYE_STYLES`. Adding a *world* is a separate checklist — see the rotation section; `VALID_WORLDS` no longer exists.
 
 ### Mobile / viewport conventions
 
@@ -139,10 +154,15 @@ The repo owner has settled on these; follow them without being asked.
   duplicate `long` hair, palm misalignment) turned out not to exist on inspection. Check
   the source, then fix.
 
-`ROADMAP.local.md` in the repo root is the prioritised backlog — gitignored via
-`*.local.md`, so it is local-only and safe to edit freely. It carries file:line references,
+`ROADMAP.md` in the repo root is the prioritised backlog. It carries file:line references,
 a corrections section for debunked findings, and the recommended order of work. Read it
 before proposing what to do next, and tick items off as they ship.
+
+It used to be `ROADMAP.local.md`, gitignored via `*.local.md`. It is tracked now, which
+changes how to edit it: it lands in PR diffs, so update it **in the PR that does the work**
+rather than as a separate pass, and keep the file:line references honest — a stale line
+number in a tracked file is worse than one in a scratch file, because the next person
+believes it.
 
 ## Pixel art conventions
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,423 @@
+# Duodoro — what to work on next
+
+The prioritised backlog. Tick items off as they ship; update this in the PR
+that does the work, not afterwards. Ordered by value; each line names the real
+files. Was `ROADMAP.local.md` and gitignored until PR #38 — it is tracked now,
+so the file:line references land in diffs and want keeping honest.
+
+Last updated: 2026-08-13. PRs #35, #36 and #37 merged — 24 commits on main.
+PR #38 (rotating themes, 7 commits) open on `feat/rotating-themes`.
+Migrations 016–019 are applied to Supabase (019 verified in production: the
+CHECK now lists 'grocery' and keeps 'lofi' for history).
+
+~~Open infra issue: `ALLOWED_ORIGIN` missing the www host~~ — **fixed
+2026-08-12.** Verified: both `https://duodoro.live` and
+`https://www.duodoro.live` now get a matching ACAO from Render.
+
+---
+
+## Done
+
+- [x] **5. Mobile game screen** — PR #31, merged
+- [x] **6. Silent failures read as data loss** — PR #32, merged
+- [x] **7a. Sprite geometry** — PR #33, merged. The objectively-checkable half of 7.
+- [x] **1. De-blur** — PR #35, **merged** (rebase, 7 commits on main).
+      Whole-pixel transforms everywhere; the rule is in CLAUDE.md and enforced
+      by `app/pixelMotion.test.ts`. Confirmed by eye on localhost: characters
+      no longer float, walk reads clean.
+- [x] **3b. GROUND + ART_PX** — PR #36, **merged** (rebase, 5 commits).
+      The mechanical half. The density collapse moved into 7b — see below.
+
+## Next up (recommended order)
+
+- [x] **7b-bg. Backgrounds** — PR #37, **merged** (rebase, 12 commits).
+      All eight worlds redrawn; every one renders at exactly one art pixel and
+      the "known backlog" guard now asserts an empty list. Root cause was not
+      draughtsmanship: the hill bands were `preserveAspectRatio="none"` on a
+      `w-full` SVG, i.e. *stretched* to ~45x10 per pixel, and MountainDecor
+      drew one map at scale 5/6/7/8 in one frame. lofi retired for grocery
+      (migration 019). Owner reviewed on localhost: "acceptable".
+- [x] **11. Server-set rotating themes** — PR #38, 6 commits. Hourly on the
+      :30, derived from the clock in `server/rotation.js` +
+      `client/src/lib/rotation.ts`, order reshuffled every 8 slots. The open
+      question below is **answered**: kept at one hour (the owner's spec) and
+      fixed the daily repeat with the per-cycle shuffle instead of changing the
+      interval. Home's picker is now `WorldNowCard`.
+- [ ] **7b-char. Characters + pets onto `PixelSprite`** — the deferred half.
+      Now the least detailed thing on screen; the backgrounds overtook them.
+- [ ] **2. Premium button on home is a no-op** — under an hour. "Unlock all
+      world themes" already removed by #38 (nothing left to gate); the other
+      three claims on that list are still fiction and still this item's job.
+
+## ⚠️ Corrections to this file
+
+Three "defects" originally listed under item 7 were checked against the source
+and are **not real**. They have been struck out below. Verify before fixing:
+
+- **Eye centring** — claimed `anime`/`sleepy` centre on 7.5. They don't. The head
+  spans columns 3–12 (centre 8); `anime` and `sleepy` eyes span [4,7) and [9,12),
+  midpoint (4+12)/2 = **8**. `normal` spans [4,6) and [10,12), also 8. All three
+  are symmetric, and the blush at [3,5)/[11,13) confirms 8 is the axis.
+- **"long" hair identical to "bob"** — the *front* layer is identical, but
+  `HairBack` draws 9-row side drapes at columns 1–2 and 13–14 for `long` only
+  (`PixelCharacter.tsx:41-53`). The two options are visibly different; same
+  fringe, longer sides. Reasonable design, not a bug.
+- **PALM crown misaligned** — the crown and the trunk's *top* are both centred on
+  column 7. The trunk then leans right by design over rows 5–10, which is what
+  palm trunks do. Comparing the crown to the trunk's base and calling the
+  difference an error mistakes the curve for a defect.
+
+Partially true: **MOON** has **2** always-empty trailing columns, not 3. Cosmetic
+bounding-box looseness — `right-[8%]` is off by ~10px at `scale={5}`. Left alone
+deliberately; trimming moves the moon and there's no way to check the result
+without looking. MOON's *two different palettes* are two different worlds' moon
+tints (warm yellow vs lavender) — intentional, not a duplication bug.
+
+---
+
+## 1. De-blur the pixel art  ·  ~30 lines, mechanical, one sitting
+
+Non-integer rotation and sub-pixel positioning resample hard edges into grey
+fringe. This is why sprites look blurry **despite** `shapeRendering: crispEdges`
+— the renderer is fine, the transforms aren't.
+
+- `client/src/app/globals.css:112-133` — remove the ±1° `rotate()` from the
+  character keyframes and the fractional `scaleY(1.05 / 0.92 / 0.96)`. Replace
+  squash-and-stretch with integer `translateY` steps.
+- `client/src/components/GameWorld.tsx:87` — the ±10° controller swing. Use a
+  1-pixel horizontal shuffle or `scaleX(-1)` instead.
+- `client/src/hooks/useCharacterPosition.ts:31` — returns
+  `calc(${focusProgress * 42}% + 8px)`, animated on `left`, so the sprite sits
+  on a fractional pixel and shimmers for the whole focus phase. Move to
+  `transform: translateX()` on rounded integer px.
+- `client/src/components/GameWorld.tsx:216,249` — `bottom: "calc(19% - 4px)"`,
+  also fractional.
+- Delete the dead `.pixel-sprite` class (`globals.css:93-96`, zero usages) and
+  the no-op `imageRendering: "pixelated"` on `<svg>` elements
+  (`PixelCharacter.tsx:220`, `PetCharacter.tsx:179` — it only affects rasters).
+
+**Highest visual-impact-per-line in the codebase.** Do this first.
+
+---
+
+## 2. Premium button on the home screen is a no-op  ·  under an hour
+
+- `client/src/components/HomeDashboard.tsx:212-219` —
+  `onClick={() => setProfileMenuOpen(false)}`. Closes the menu, does nothing
+  else. `HomeDashboard`'s props (`:23-40`) have no premium callback at all;
+  `DuoTimer` never passes one.
+- `client/src/components/SessionTopBar.tsx:43,152-159` — wires it correctly.
+  So the in-session path works and the *home* path silently dies. Home is the
+  primary monetization surface.
+- `client/src/components/PremiumModal.tsx:11-17` — the feature list is fiction.
+  "Unlock all world themes" while `HomeDashboard.tsx:297-315` lets everyone pick
+  all 8. "Focus stats & session history" while `StatsPanel`/`StatsScreen` are
+  open to all. "Friend session notifications" while the Notification API appears
+  nowhere in the codebase. Only pets are actually gated
+  (`PetPicker.tsx:20,34`).
+
+Thread `onOpenPremium` through (the plumbing exists in `DuoTimer`), then either
+trim the list to what's real or actually gate worlds. Gating worlds needs a
+server check too — `server/index.js:463,492` accepts any valid world from any
+user regardless of premium status.
+
+---
+
+## 3. One palette + one pixel unit  ·  mechanical, one taste call
+
+**146 hardcoded hex literals** in `client/src` against 17 theme tokens, drawn
+from three different published design systems:
+
+- `PetCharacter.tsx:23-37` — the most-copied Coolors palette, verbatim.
+- `lib/uiSprites.ts:16,25` — a *different* Coolors set.
+- `WorldDecorations.tsx` — 77 of the 146. Tailwind defaults (`#c084fc`
+  purple-400 `:92`, `#f1f5f9` slate-100 `:121`) mixed with Material Design 800s
+  for the bookshelf (`:226-231`) and Material browns (`:224,245`).
+- `client/src/app/globals.css:10-49` — the app's own 17 warm-paper/charcoal
+  tokens, used by **none** of the art.
+
+**3a (mechanical):** create `client/src/lib/palette.ts` from a published Lospec
+ramp — Sweetie-16 (forgiving) or Apollo (46 colours, richer for 8 worlds) — as
+named ramps (`SKIN[0..5]`, `FOLIAGE`, `STONE`, `NIGHT`, `WARM`, `METAL`), then
+migrate component palettes onto it.
+
+*Caveat:* existing users have literal hexes in `profiles.avatar_config`, so
+changing `SKIN_COLORS`/`HAIR_COLORS`/`OUTFIT_COLORS` leaves them permanently
+off-palette without a nearest-colour snap on load or a one-time SQL update.
+
+**3b — DONE in PR #36, but only half of what this said.** `lib/scene.ts` now
+exports `GROUND` and `ART_PX`; characters and pets are on `ART_PX`; `GROUND`
+was six literals across three files, not two.
+
+**The density collapse is not mechanical and has moved to 7b.** A sprite's
+apparent pixel size *is* its scale, so a 16-cell map at `ART_PX` is a 48px
+mountain, not a small-pixelled 128px one. Collapsing the scenery onto one unit
+either shrinks it by half to two-thirds, or means redrawing every map at more
+cells. Cost table is at the top of `WorldDecorations.tsx`; the worst is
+`MOUNTAIN` at 43×27 cells instead of 16×10.
+
+Also corrected while doing it: the `calc(19% - 4px)` was not "people stand 4px
+into the dirt". `bottom` positions the wrapper, and the wrapper's bottom edge
+was the *name tag* — so characters floated a label's height **above** the
+horizon while trees stood on it. Fixed by taking the tag out of flow. This is
+part of item 4's "everyone appears to hover"; the contact shadow is the rest.
+
+---
+
+## 4. Outline + contact shadow  ·  ~40 lines
+
+Nothing in `PixelCharacter.tsx` or `PetCharacter.tsx` draws a dark border, and
+nothing draws a shadow under a grounded sprite. On the Space world
+(`sky #04001A`, `ground #1e0f4a`, `avatarData.ts:96-98`) a dark-haired character
+dissolves into the background, and everyone appears to hover rather than stand.
+
+Add an optional auto-outline pass to `PixelSprite`: for each transparent cell
+orthogonally adjacent to a filled cell, emit a rect in an outline colour. ~15
+lines inside the existing run-merging loop, and every string-map sprite gets a
+1-pixel border for free. Then a shared `<ContactShadow>` — one art-pixel-tall
+dark rect at ~35% opacity — under every `Grounded` sprite and both characters.
+
+Characters won't benefit until item 7 migrates them onto `PixelSprite`.
+
+---
+
+## 5. Mobile game screen  ·  SHIPPED — PR #31
+
+- `client/src/components/DuoTimer.tsx:339` — game screen is `h-screen` +
+  `overflow-hidden`. On iOS Safari `100vh` exceeds the visible viewport, so the
+  bottom of the HUD — including **end session** and **leave session**
+  (`SessionHUD.tsx:269-282`) — sits under the browser toolbar, and
+  `overflow-hidden` means you cannot scroll to reach it.
+- `client/src/app/layout.tsx:48` — `viewportFit: "cover"` is set but there is
+  **not one** `env(safe-area-inset-*)` anywhere in `client/src`. Top bar runs
+  under the notch, bottom under the home indicator.
+- In landscape the HUD card is taller than the viewport and covers the scene
+  entirely.
+- `client/src/components/GameWorld.tsx` — zero responsive breakpoints, sprites
+  at fixed CSS px, so characters are the same 48px on a 360px phone as on a 27"
+  monitor. The responsive-sprite half wants item 3b done first.
+- `client/src/components/HomeDashboard.tsx:297` — 8 worlds in `grid-cols-4`
+  gives 48px-tall thumbnails on a phone.
+
+`Button.tsx` and `AvatarCreator.tsx` already show the touch-target pattern
+(`w-11 h-11 sm:w-7 sm:h-7`) — extend it to the HUD.
+
+---
+
+## 6. Silent failures read as data loss
+
+- `client/src/lib/useStats.ts:118-120` — catches every RPC failure into
+  `console.error` and leaves the snapshot `EMPTY`.
+  `HomeDashboard.tsx:264-270` then renders "Total 0m / This Week 0m / Streak 0d"
+  — pixel-identical to a brand-new account. A returning user with a 40-day
+  streak and one failed request sees their whole history apparently erased, with
+  no error anywhere. `fetchStats(true)` already supports forcing, so a retry is
+  cheap.
+- `client/src/hooks/useAuth.ts:201-209` — `saveAvatar` never checks the update
+  result, yet still calls `setMyAvatar`, caches to localStorage and advances to
+  home. A failed write looks like success until you open another device.
+- `client/src/components/DuoTimer.tsx:245-248` — the `display_name` update
+  ignores `error` entirely. Contrast `:225-241`, which handles `claim_username`
+  errors properly — the pattern is known, just not applied.
+- `client/public/sw.js:1-16` — a deliberate no-op passthrough with no app-shell
+  cache. An **installed** PWA with no network shows the browser's offline error
+  page rather than a Duodoro screen. Cache a minimal shell; never cache socket
+  or RPC responses.
+
+Related convention already in CLAUDE.md as of #29: check `error` on reads, not
+just writes. This item is the rest of that sweep.
+
+---
+
+## 7. Redraw the scale hierarchy + characters onto `PixelSprite`
+
+The genuine art labour. Deliberately last so it lands on a finished system.
+
+**Scale (judgment):** 3b did not enforce one density on the scenery — it could
+not, see above — so 7b now owns both the redraw *and* the collapse. Depth has
+to come from sprite *dimensions in art pixels*, not px-per-pixel. Character is
+16×24 at `ART_PX` = 48×72px, therefore today:
+
+- a pine tree (`PINE` 12×14 @ scale 4, `WorldDecorations.tsx:463`) is 56px —
+  **shorter than a person**, with 33% bigger pixels
+- a skyscraper (`BUILDING_TALL` 9×16 @ scale 3, `:597`) is 48px — two-thirds a
+  person's height
+- a mountain (`MOUNTAIN` 16×10 @ scale 8, `:635`) is 80px — **11% taller than a
+  human**
+- ~~pets are 20px with pixels ⅔ the character's~~ — **density fixed in PR #36**,
+  pets are on `ART_PX`. But they are now 30×33, i.e. a cat 0.46× a person's
+  height where a real one is ~0.25×. Redraw the pet maps at about 7×7 cells;
+  do **not** put `size` back to 2
+
+A 16-px-tall person needs a ~28px tree, ~60px tower, ~40px mountain range, plus
+explicit far/mid/near variants differing by *value*, not scale.
+
+**Characters (judgment):** `PixelCharacter.tsx` (338 lines) and
+`PetCharacter.tsx` (187 lines) are ~90 literal `<rect x= y=>` elements with
+inline coordinates — they do **not** use `PixelSprite`. So the two sprites users
+look at most can't be palette-swapped, outlined, blinked or given a second idle
+frame without editing numbers by hand. Rewrite as layered string maps (`base`,
+`hair-back`, `hair-front`, `eyes-open`, `eyes-shut`, `outfit`).
+
+Latent bugs to fix while redrawing:
+
+- ~~`PetCharacter.tsx` cat/rabbit clipped foot~~ — **fixed in PR #33.** Both drew
+  a leg at row 10 inside a 10-row viewBox, so each walked on one leg, alternating
+  which. All four pets now share an 11-row grid.
+- ~~eye centring~~ — **not a real defect.** See corrections at the top.
+- ~~`long` hair identical to `bob`~~ — **not a real defect.** See corrections.
+- `PixelCharacter.tsx:325` — `darken(skinColor, 0.08)` is a naive RGB multiply;
+  on the two darkest skins (`avatarData.ts:25-26`) it shifts value by ~6/255,
+  i.e. invisibly. Meanwhile blush is a fixed `#F4A0A0` at 0.6 opacity
+  (`:331-332`), which on `#4A2518` reads as two bright pink stripes. Derive
+  shading by hue-shift; scale blush opacity to skin luminance.
+- ~~`CUP_PALETTE` H identical to C~~ — **fixed in PR #33**, handle now uses the
+  saucer shade.
+- ~~`PALM` crown misaligned~~ — **not a real defect.** See corrections.
+- `MOON` — 2 always-empty trailing columns. Cosmetic; see corrections.
+
+Then add a blink frame every 4–6s and a 2-frame idle. Today `pixel-idle`
+(`globals.css:107-109`) translates the whole sprite up 3px; no sprite's own
+pixels ever change, so scenes read as posed dolls.
+
+---
+
+## 8. Emoji purge  ·  ~20 lines, disproportionately visible
+
+`lib/uiSprites.ts:3` says sprites exist for "anywhere an emoji would break the
+pixel-art look" and `Icons.tsx:1` says the set "replaces emoji in UI chrome" —
+yet:
+
+- `PetPicker.tsx:40` renders 🐱🐶🐉🐰/🔒 while `PetCharacter` can draw the pets
+- `FriendsPanel.tsx:56` and `FriendsOnlineSection.tsx:59` render world emoji
+  while `WorldThumbnail` (`WorldDecorations.tsx:787`) exists
+- `PremiumModal.tsx:12-16,72` is all emoji
+
+The replacements already exist and are simply unused in these spots.
+
+---
+
+## 9. Pixel-ify the chrome  ·  after 3
+
+The app loads the pixel typeface Pixelify Sans (`app/layout.tsx:17`) and then
+renders **the timer — the largest element in the product — in Geist Mono**
+(`SessionHUD.tsx:144`). Elsewhere: `rounded-2xl backdrop-blur shadow-xl`
+(`SessionHUD.tsx:133`), `rounded-full` status dots, Feather-style stroke icons
+with `strokeLinecap: "round"` (`Icons.tsx:8-16`), and a waiting slot that is a
+dashed **circle** with a text "?" (`GameWorld.tsx:313-322`). Soft-SaaS chrome
+wrapped around a game.
+
+`Button.tsx:29-33` already gestures at the right idiom with `border-b-4`.
+
+---
+
+## 10. Launch surface  ·  cheap, do before showing anyone
+
+- no `openGraph.images` and no `metadataBase` → every shared link renders a
+  blank card
+- `app/layout.tsx:40` — typo: `"Focus together, anywhere.."`
+- `public/icon.svg` is a placeholder: two white circles on emerald `#10b981`, a
+  colour that appears nowhere else in the app
+- `manifest.webmanifest` sets `theme_color: "#111827"`, matching neither theme
+  (`#f3ede1` / `#171411`), so the install splash flashes the wrong colour
+
+---
+
+## 11. Server-set rotating themes  ·  SHIPPED — PR #38
+
+The owner's call, 2026-08-12: model the theme the way PEAK models its mountain
+— one world, chosen by the server, the same for everybody, rotating on a clock.
+Home loses its world picker entirely; you press **Focus** and the theme is
+whatever the world is currently on.
+
+**Rotation:** every hour, on the **:30**. Not on the hour — the offset is the
+point, so the change doesn't land at the same moment as everyone's o'clock
+pomodoro boundary.
+
+**Derive it, don't store it.** The active world must be a pure function of wall
+clock, so every server instance, every client and every late joiner agree
+without coordination and without a round trip:
+
+    index = floor((Date.now() - THIRTY_MIN) / ONE_HOUR) % VALID_WORLDS.length
+
+No DB row, no timer, no broadcast needed to *know* the theme. Nothing to drift,
+nothing to resync after a restart — which matters because all session state is
+already in memory and dies with the process.
+
+**A session keeps the theme it started with.** Rotation applies to *new*
+sessions only. Swapping the scene under two people 20 minutes into a focus
+block is a worse experience than a slightly stale theme, and it would also make
+`sessions.world_id` ambiguous for the history rows.
+
+Changes this needs:
+
+- `server/index.js:463,492` — `create_session` currently takes `world` from the
+  client and validates it against `VALID_WORLDS`. It should stop accepting the
+  field and assign the derived one. The validation disappears with the input.
+- `client/src/components/HomeDashboard.tsx:297-315` — the 8-world `grid-cols-4`
+  picker goes. Replaced by one Focus button; showing "next theme in MM:SS"
+  is free, since the client can derive it with the same function.
+- Put the derivation in one shared place. It cannot be imported across the two
+  packages (`client/` and `server/` are independent npm packages with their own
+  lockfiles) so it will be duplicated — keep both copies next to a comment
+  naming the other, and cover both with the same table of timestamps.
+- `sessions.world_id` and `sessions_world_check` (migration 008) are unaffected;
+  the value is still one of the eight. `profiles.current_world_id` likewise.
+- Item 2's `PremiumModal` copy must lose "unlock all world themes" — with
+  server-set themes there is no per-user world choice left to gate.
+
+~~**Open question for the owner:** eight worlds at one hour each is an
+eight-hour cycle, so someone who always focuses at 9am sees the same world
+every day.~~ **Answered in #38.** Kept the hour and the :30 as specified, and
+shuffled the *order* per cycle instead of changing the interval. A cycle is
+still all eight worlds, so the "see everything in eight hours" property holds,
+but which eight-hour permutation you get depends on the cycle number — so 9am
+moves. A fix-up stops a cycle opening on the world the last one closed with.
+Verified uniform across positions over 80k cycles (±2% of 1/8) with zero
+boundary repeats.
+
+**What actually shipped, beyond the design above:**
+
+- The shuffle uses an integer hash (`Math.imul` + xor-shift), *not* the
+  `Math.sin` seeding in `lib/terrain.ts`. ECMA-262 doesn't require
+  transcendentals to be bit-identical across engines; a 1-ULP difference moves
+  a rock in the scenery but would put the client and server in different
+  worlds.
+- `send_invite` also stopped trusting a client-sent `worldId` — the server
+  reads it off the session. It was relaying an attacker-controlled world label
+  into a full-screen popup on someone else's machine.
+- `VALID_WORLDS` is gone from `server/index.js`; `ROTATION_WORLDS` is the one
+  list.
+- `server/createSession.test.js` is the package's first handler-level test —
+  boots the real server on an ephemeral port over a real socket. `PORT=0` works
+  now because the boot log prints the *bound* port.
+
+**Not verified:** nothing here has been looked at in a browser. Worth checking
+by eye — the countdown ticking on home, and that a session left open across a
+:30 keeps its own world rather than swapping under you.
+
+---
+
+## Also worth knowing
+
+- **Free assets:** palettes yes, sprites no. A Lospec ramp is zero bytes, no
+  licence risk (CC0 needs no attribution), and hands you the hardest thing to do
+  without training. CC0 sprite tilesets are cheap and tiny too, but the avatar
+  recolours at runtime from user-chosen hex, which a flat PNG can't do without
+  canvas tinting — and dropping an asset artist's characters next to hand-coded
+  scenery trades "inconsistent within one style" for "two styles".
+- **There are no image assets at all.** `client/public/` holds six SVGs, five of
+  which are untouched Next.js starter files (`file.svg`, `globe.svg`,
+  `next.svg`, `vercel.svg`, `window.svg`). Every pixel is generated at runtime.
+  Nothing mangled the art — there was never an art *system*.
+- **Accessibility:** 12 `aria-*` attributes total across ~85 buttons, with
+  icon-only controls unlabelled.
+- **Test coverage:** `useAuth.ts` is 234 lines gating every screen transition
+  and has no tests.
+- **Unverified in the browser:** everything from PRs #26–#30. #35/#36 were
+  checked by hand on localhost 2026-08-12 — characters no longer float, walk
+  reads clean; pets and the jump/float/controller keyframes were *not* looked
+  at (pets are premium-locked, the rest need a two-account session). Still
+  worth checking: tick a partner's shared goal and confirm the "✓ by" byline
+  sticks; mute mid-jingle then reload; background a session tab 90s and
+  confirm you're still in it.

--- a/client/src/components/DuoTimer.tsx
+++ b/client/src/components/DuoTimer.tsx
@@ -44,8 +44,8 @@ export default function DuoTimer() {
   const initial = displayName.charAt(0).toUpperCase();
 
   // ── Wrappers that bridge auth + game ────────────────────────────────────
-  const handleCreateSession = (world: Parameters<typeof game.createSession>[0]) => {
-    game.createSession(world, myAvatar);
+  const handleCreateSession = () => {
+    game.createSession(myAvatar);
     setAppStep("game");
   };
 
@@ -281,8 +281,6 @@ export default function DuoTimer() {
           activeSessionId={game.sessionId || undefined}
           socketRef={game.socketRef}
           onFocus={handleCreateSession}
-          selectedWorld={game.myWorld}
-          onSelectWorld={game.setMyWorld}
           onRejoinSession={() => setAppStep("game")}
           onJoinSession={handleJoinSession}
           onInvite={handleSendInvite}

--- a/client/src/components/HomeDashboard.test.tsx
+++ b/client/src/components/HomeDashboard.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import HomeDashboard from "./HomeDashboard";
+import { WORLDS } from "@/lib/avatarData";
+import { worldAt } from "@/lib/rotation";
+import type { Profile } from "@/lib/types";
+
+// Home used to open with an eight-thumbnail world picker and hand the choice
+// to onFocus. With the rotation the choice doesn't exist: there is one world,
+// the server picks it, and pressing Focus takes whatever is up.
+
+vi.mock("@/lib/useStats", () => ({
+  useStats: () => ({
+    personalStats: null,
+    duoStats: null,
+    recentSessions: [],
+    dailyFocus: [],
+    loading: false,
+    error: null,
+    loaded: true,
+    retry: vi.fn(),
+    fetchStats: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useTasks", () => ({
+  useTasks: () => ({
+    tasks: [],
+    newTask: "",
+    setNewTask: vi.fn(),
+    addTask: vi.fn(),
+    toggleTask: vi.fn(),
+    deleteTask: vi.fn(),
+    pendingTasks: [],
+    completedTasks: [],
+    clearCompleted: vi.fn(),
+    error: null,
+    clearError: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useOnlineFriends", () => ({
+  useOnlineFriends: () => ({ friends: [], onlineFriendIds: [] }),
+}));
+
+const profile: Profile = {
+  id: "user-1",
+  username: "jorge",
+  discriminator: "0001",
+  username_changed: false,
+  display_name: "Jorge",
+  display_name_changed_at: null,
+  avatar_config: null,
+  is_premium: false,
+  current_room: null,
+  current_session_id: null,
+  current_world_id: null,
+  updated_at: "2026-08-12T00:00:00Z",
+};
+
+function renderHome(onFocus = vi.fn()) {
+  const utils = render(
+    <HomeDashboard
+      profile={profile}
+      socketRef={{ current: null }}
+      onFocus={onFocus}
+      onRejoinSession={vi.fn()}
+      onJoinSession={vi.fn()}
+      onInvite={vi.fn()}
+      onEditAvatar={vi.fn()}
+      onChangeUsername={vi.fn()}
+      onChangeDisplayName={vi.fn()}
+      onSignOut={vi.fn()}
+      onOpenFriends={vi.fn()}
+      onOpenStats={vi.fn()}
+    />,
+  );
+  return { ...utils, onFocus };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.setSystemTime(Date.parse("2026-08-12T09:07:30Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("HomeDashboard world rotation", () => {
+  it("offers no world to choose", () => {
+    renderHome();
+    expect(screen.queryByText("Choose a world")).not.toBeInTheDocument();
+    // Every world but the current one should be absent. Naming them
+    // individually rather than counting buttons, so this still fails if the
+    // picker comes back in a different shape.
+    const current = worldAt(Date.now());
+    for (const world of WORLDS) {
+      if (world.id === current) continue;
+      expect(screen.queryByText(world.label)).not.toBeInTheDocument();
+    }
+  });
+
+  it("shows the world the rotation is on", () => {
+    renderHome();
+    const current = WORLDS.find((w) => w.id === worldAt(Date.now()))!;
+    expect(screen.getByText("Everyone's world")).toBeInTheDocument();
+    expect(screen.getByText(current.label)).toBeInTheDocument();
+    expect(screen.getByText("22:30")).toBeInTheDocument();
+  });
+
+  it("starts a session without being told where", () => {
+    const { onFocus } = renderHome();
+    fireEvent.click(screen.getByRole("button", { name: "Focus" }));
+    expect(onFocus).toHaveBeenCalledTimes(1);
+    // Previously this was onFocus(selectedWorld). Nothing may be passed now —
+    // an argument here would mean the client still believes it decides.
+    expect(onFocus).toHaveBeenCalledWith();
+  });
+});

--- a/client/src/components/HomeDashboard.tsx
+++ b/client/src/components/HomeDashboard.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
 import { useStats } from "@/lib/useStats";
-import { WORLDS, type WorldId } from "@/lib/avatarData";
 import { formatDuration, formatTag } from "@/lib/format";
 import { useTasks } from "@/hooks/useTasks";
 import { useOnlineFriends } from "@/hooks/useOnlineFriends";
@@ -9,7 +8,7 @@ import TaskSection from "./TaskSection";
 import FriendsOnlineSection from "./FriendsOnlineSection";
 import ThemeToggle from "./ThemeToggle";
 import SoundToggle from "./SoundToggle";
-import { WorldThumbnail } from "./WorldDecorations";
+import WorldNowCard from "./WorldNowCard";
 import Button from "./Button";
 import {
   UsersIcon,
@@ -25,10 +24,8 @@ interface Props {
   profile: Profile;
   activeSessionId?: string;
   socketRef: { current: Socket | null };
-  onFocus: (world: WorldId) => void;
-  /** Controlled by DuoTimer so the invite path sees the same choice */
-  selectedWorld: WorldId;
-  onSelectWorld: (world: WorldId) => void;
+  /** Starts a session in whatever world the rotation is on — see WorldNowCard. */
+  onFocus: () => void;
   onRejoinSession: () => void;
   onJoinSession: (sessionId: string) => void;
   onInvite: (friendId: string) => void;
@@ -70,8 +67,6 @@ export default function HomeDashboard({
   activeSessionId,
   socketRef,
   onFocus,
-  selectedWorld,
-  onSelectWorld,
   onRejoinSession,
   onJoinSession,
   onInvite,
@@ -322,33 +317,7 @@ export default function HomeDashboard({
             onInvite={onInvite}
           />
 
-          <div>
-            <h2 className="text-xs font-semibold text-faint uppercase tracking-wider mb-3">
-              Choose a world
-            </h2>
-            {/* Three across on a phone, not four: at four the thumbnails are 48px
-                  tall and the 10px labels are unreadable. */}
-            <div className="grid grid-cols-3 sm:grid-cols-4 gap-2">
-              {WORLDS.map((w) => (
-                <button
-                  key={w.id}
-                  onClick={() => onSelectWorld(w.id)}
-                  className={`rounded-xl border overflow-hidden transition-all text-center ${
-                    selectedWorld === w.id
-                      ? "border-accent ring-2 ring-accent/40 text-ink shadow-sm"
-                      : "border-line bg-surface text-muted hover:border-faint"
-                  }`}
-                >
-                  <div className="h-16 sm:h-12 w-full">
-                    <WorldThumbnail worldId={w.id} />
-                  </div>
-                  <span className="block py-1.5 sm:py-1 text-[11px] sm:text-[10px] font-medium">
-                    {w.label}
-                  </span>
-                </button>
-              ))}
-            </div>
-          </div>
+          <WorldNowCard />
 
           <div className="space-y-2 pt-2">
             {activeSessionId && (
@@ -360,7 +329,7 @@ export default function HomeDashboard({
               variant={activeSessionId ? "surface" : "accent"}
               size={activeSessionId ? "md" : "lg"}
               fullWidth
-              onClick={() => onFocus(selectedWorld)}
+              onClick={() => onFocus()}
             >
               {activeSessionId ? "New session" : "Focus"}
             </Button>

--- a/client/src/components/PremiumModal.tsx
+++ b/client/src/components/PremiumModal.tsx
@@ -8,11 +8,15 @@ interface Props {
   onClose: () => void;
 }
 
+// "Unlock all world themes" was here. It was already untrue — everyone could
+// pick all eight — and the rotation makes it unsellable: there is no per-user
+// world choice left to gate. The rest of this list is still ahead of the
+// product (stats and history are open to all, and nothing in the codebase
+// sends a notification); that is roadmap item 2's to settle, not this PR's.
 const FEATURES = [
   { icon: "🐾", label: "Companion pets that walk with you" },
   { icon: "🎨", label: "Exclusive premium character skins" },
   { icon: "📊", label: "Focus stats & session history" },
-  { icon: "🌍", label: "Unlock all world themes" },
   { icon: "🔔", label: "Friend session notifications" },
 ];
 

--- a/client/src/components/WorldNowCard.test.tsx
+++ b/client/src/components/WorldNowCard.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { renderToStaticMarkup } from "react-dom/server";
+import WorldNowCard from "./WorldNowCard";
+import { worldAt, nextRotationAt, ROTATION_MS } from "@/lib/rotation";
+import { getWorld } from "@/lib/avatarData";
+
+// The card is a readout of the server's rotation, so what it has to get right
+// is agreement with the clock — including *after* a boundary passes with the
+// page still open.
+
+const label = (t: number) => getWorld(worldAt(t)).label;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("WorldNowCard", () => {
+  it("names the world the rotation is on", () => {
+    const now = Date.parse("2026-08-12T09:07:30Z");
+    vi.setSystemTime(now);
+    render(<WorldNowCard />);
+    act(() => void vi.advanceTimersByTime(0));
+    expect(screen.getByText(label(now))).toBeInTheDocument();
+  });
+
+  it("counts down to the changeover", () => {
+    const now = Date.parse("2026-08-12T09:07:30Z");
+    vi.setSystemTime(now);
+    render(<WorldNowCard />);
+    act(() => void vi.advanceTimersByTime(0));
+    // 09:07:30 -> 09:30:00 is 22:30.
+    expect(screen.getByText("22:30")).toBeInTheDocument();
+
+    act(() => void vi.advanceTimersByTime(90_000));
+    expect(screen.getByText("21:00")).toBeInTheDocument();
+  });
+
+  it("changes world when the boundary passes with the page open", () => {
+    // A tab left open across a rotation must not keep advertising the old
+    // world; someone reading it would press Focus and land somewhere else.
+    const now = Date.parse("2026-08-12T09:07:30Z");
+    vi.setSystemTime(now);
+    render(<WorldNowCard />);
+    act(() => void vi.advanceTimersByTime(0));
+    const before = label(now);
+    expect(screen.getByText(before)).toBeInTheDocument();
+
+    const after = nextRotationAt(now) + 1000;
+    act(() => {
+      vi.setSystemTime(after);
+      vi.advanceTimersByTime(1000);
+    });
+    expect(screen.queryByText(before)).not.toBeInTheDocument();
+    expect(screen.getByText(label(after))).toBeInTheDocument();
+  });
+
+  it("re-reads the clock rather than decrementing", () => {
+    // Background tabs get their intervals throttled. Counting down from a
+    // stored value drifts by however long the tab was asleep; re-reading
+    // recovers on the next tick. Simulated here by moving the clock further
+    // than the timers.
+    const now = Date.parse("2026-08-12T09:00:00Z");
+    vi.setSystemTime(now);
+    render(<WorldNowCard />);
+    act(() => void vi.advanceTimersByTime(0));
+
+    act(() => {
+      // The wall clock moves ten minutes; the timer queue only advances by one
+      // tick, which is what a throttled background tab looks like.
+      vi.setSystemTime(now + 10 * 60_000 - 1000);
+      vi.advanceTimersByTime(1000);
+    });
+    expect(screen.getByText("20:00")).toBeInTheDocument();
+  });
+
+  it("shows one world, not a gallery of them", () => {
+    // Guard on the premise: the picker is gone because there is nothing to
+    // pick. A second world on this screen would put the choice back.
+    vi.setSystemTime(Date.parse("2026-08-12T09:00:00Z"));
+    const { container } = render(<WorldNowCard />);
+    act(() => void vi.advanceTimersByTime(0));
+    expect(container.querySelectorAll("svg").length).toBe(1);
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
+  });
+
+  it("puts nothing time-derived in the server-rendered markup", () => {
+    // Next renders this on the server, where "now" is a different number than
+    // it is at hydration. Anything clock-derived in the first pass is a
+    // guaranteed mismatch, which is why the hook starts at null and fills in
+    // from an effect. renderToStaticMarkup is that first pass exactly —
+    // testing-library's render() already flushes effects, so it cannot show
+    // this.
+    vi.setSystemTime(Date.parse("2026-08-12T09:00:00Z"));
+    const markup = renderToStaticMarkup(<WorldNowCard />);
+    expect(markup).not.toMatch(/Changes in/);
+    expect(markup).not.toMatch(/\d\d:\d\d/);
+  });
+
+  it("agrees with the schedule for a full cycle", () => {
+    const start = Date.parse("2026-08-12T00:30:00Z");
+    const seen: string[] = [];
+    for (let i = 0; i < 8; i++) {
+      const t = start + i * ROTATION_MS;
+      vi.setSystemTime(t);
+      const { unmount } = render(<WorldNowCard />);
+      act(() => void vi.advanceTimersByTime(0));
+      seen.push(screen.getByText(label(t)).textContent!);
+      unmount();
+    }
+    expect(new Set(seen).size).toBe(8);
+  });
+});

--- a/client/src/components/WorldNowCard.tsx
+++ b/client/src/components/WorldNowCard.tsx
@@ -1,0 +1,53 @@
+"use client";
+import { getWorld } from "@/lib/avatarData";
+import { formatTime } from "@/lib/format";
+import { WorldThumbnail } from "./WorldDecorations";
+import { useRotatingWorld } from "@/hooks/useRotatingWorld";
+
+/**
+ * The world everyone is in, and how long it has left.
+ *
+ * Replaces the eight-thumbnail picker. Nobody chooses a world any more — the
+ * server puts everyone in the same one and changes it on the :30 — so this is
+ * a readout, not a control, and it deliberately doesn't look like a button.
+ *
+ * The countdown is what makes the rotation legible instead of arbitrary: a
+ * world that swaps without warning reads as a glitch, one with a timer on it
+ * reads as a schedule.
+ */
+export default function WorldNowCard() {
+  const rotation = useRotatingWorld();
+  const world = rotation ? getWorld(rotation.world) : null;
+
+  return (
+    <div>
+      <h2 className="text-xs font-semibold text-faint uppercase tracking-wider mb-3">
+        Everyone&apos;s world
+      </h2>
+      <div className="rounded-xl border border-line bg-surface overflow-hidden">
+        {/* Taller than the old thumbnails were: there is one of these now, not
+            eight in a grid, so it can be looked at rather than scanned. */}
+        <div className="h-28 sm:h-24 w-full">
+          {world && <WorldThumbnail worldId={world.id} />}
+        </div>
+        <div className="flex items-baseline justify-between gap-3 px-3 py-2.5">
+          <span className="text-sm font-semibold text-ink">
+            {world ? world.label : "—"}
+          </span>
+          <span className="text-[11px] text-muted">
+            {rotation ? (
+              <>
+                Changes in{" "}
+                <span className="font-mono tabular-nums text-ink">
+                  {formatTime(rotation.msLeft / 1000)}
+                </span>
+              </>
+            ) : (
+              " "
+            )}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/hooks/useGameSession.ts
+++ b/client/src/hooks/useGameSession.ts
@@ -565,9 +565,9 @@ export function useGameSession(profile: Profile | null) {
   const dismissInvite = useCallback(() => setPendingInvite(null), []);
 
   return {
-    // World & pet
+    // World & pet. myWorld is read-only to callers: the world is the server's,
+    // and a setter here is a way to put the client back in charge of it.
     myWorld,
-    setMyWorld,
     myPet,
     setMyPet,
     // Session config

--- a/client/src/hooks/useGameSession.ts
+++ b/client/src/hooks/useGameSession.ts
@@ -11,6 +11,7 @@ import type {
   InviteData,
 } from "@/lib/sessionTypes";
 import { playSound } from "@/lib/sounds";
+import { worldAt } from "@/lib/rotation";
 import { getSupabase } from "@/lib/supabase";
 
 const SOCKET_URL =
@@ -24,18 +25,20 @@ export type { InviteData };
 
 export function useGameSession(profile: Profile | null) {
   // ── Avatar & world ──────────────────────────────────────────────────────
+  // myWorld is a mirror of the server's answer, not a choice: createSession
+  // seeds it from the rotation so the scene doesn't flash forest, and
+  // sync_state overwrites it with the authoritative value. Kept as a plain
+  // literal rather than worldAt() so nothing reads the clock during render —
+  // Next renders this component on the server too, where "now" is a different
+  // number.
   const [myWorld, setMyWorld] = useState<WorldId>("forest");
   const [myPet, setMyPetState] = useState<PetType | null>(null);
   // Ref mirrors so the socket handlers — registered once with [] deps — read
-  // current values instead of whatever was captured at mount. Without these,
-  // an invite sent before a session exists is relayed by the session_created
-  // handler using profile=null ("Someone") and the default world ("forest").
+  // current values instead of whatever was captured at mount. Without this, an
+  // invite sent before a session exists is relayed by the session_created
+  // handler using profile=null, i.e. from "Someone".
   const myPetRef = useRef<PetType | null>(null);
-  const myWorldRef = useRef<WorldId>("forest");
   const profileRef = useRef<Profile | null>(null);
-  useEffect(() => {
-    myWorldRef.current = myWorld;
-  }, [myWorld]);
   useEffect(() => {
     profileRef.current = profile;
   }, [profile]);
@@ -183,7 +186,6 @@ export function useGameSession(profile: Profile | null) {
             socket.emit("send_invite", {
               targetUserId: target,
               sessionId: sid,
-              worldId: myWorldRef.current,
               fromName: inviterName(),
             });
           }
@@ -445,7 +447,7 @@ export function useGameSession(profile: Profile | null) {
 
   // ── Session actions ─────────────────────────────────────────────────────
   const createSession = useCallback(
-    (world: WorldId, avatar: AvatarConfig) => {
+    (avatar: AvatarConfig) => {
       const socket = socketRef.current;
       if (!socket) return;
       if (sessionId) {
@@ -455,13 +457,16 @@ export function useGameSession(profile: Profile | null) {
         setPlayers({});
         setSessionId("");
       }
-      setMyWorld(world);
+      // Optimistic, so the scene doesn't flash forest while sync_state is in
+      // flight. The server assigns the real one from the same clock and it
+      // arrives moments later; the only way the two disagree is a create that
+      // straddles a rotation boundary, and then the server's answer wins.
+      setMyWorld(worldAt());
       const displayName = profile?.display_name ?? profile?.username ?? "Player";
       lastAvatarRef.current = avatar;
       lastDisplayNameRef.current = displayName;
       socket.emit("create_session", {
         avatar,
-        world,
         displayName,
         pet: myPetRef.current,
       });
@@ -538,23 +543,23 @@ export function useGameSession(profile: Profile | null) {
       setTimeout(() => setInviteSentName(null), 2500);
 
       if (sessionId) {
+        // No worldId: the server reads it off the session it's inviting to.
         socket.emit("send_invite", {
           targetUserId,
           sessionId,
-          worldId: myWorld,
           fromName: profile?.display_name ?? profile?.username ?? "Someone",
         });
       } else {
         pendingOutboundInvite.current = targetUserId;
+        setMyWorld(worldAt());
         socket.emit("create_session", {
           avatar,
-          world: myWorld,
           displayName: profile?.display_name ?? profile?.username ?? "Player",
           pet: myPetRef.current,
         });
       }
     },
-    [sessionId, myWorld, profile],
+    [sessionId, profile],
   );
 
   const dismissInvite = useCallback(() => setPendingInvite(null), []);

--- a/client/src/hooks/useRotatingWorld.ts
+++ b/client/src/hooks/useRotatingWorld.ts
@@ -1,0 +1,41 @@
+"use client";
+import { useEffect, useState } from "react";
+import { worldAt, msUntilRotation } from "@/lib/rotation";
+import type { WorldId } from "@/lib/avatarData";
+
+export interface RotationState {
+  world: WorldId;
+  /** Milliseconds until the world changes. */
+  msLeft: number;
+}
+
+/**
+ * The world currently in play, and how long it has left.
+ *
+ * Starts as `null` and fills in from an effect rather than reading the clock
+ * during render. The home screen is inside a client component but Next still
+ * renders it on the server, and `Date.now()` is a different number there — a
+ * countdown computed during render is a guaranteed hydration mismatch. `null`
+ * means "not known yet", which the caller renders as a placeholder for one
+ * frame.
+ *
+ * Ticks every second. The clock is read fresh each tick instead of counting
+ * down from a stored value, so a backgrounded tab that gets its timers
+ * throttled catches up on the next tick rather than drifting — the same reason
+ * the session timer renders from `phaseStartTime` instead of decrementing.
+ */
+export function useRotatingWorld(): RotationState | null {
+  const [state, setState] = useState<RotationState | null>(null);
+
+  useEffect(() => {
+    const tick = () => {
+      const now = Date.now();
+      setState({ world: worldAt(now), msLeft: msUntilRotation(now) });
+    };
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return state;
+}

--- a/client/src/lib/rotation.test.ts
+++ b/client/src/lib/rotation.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import {
+  ROTATION_WORLDS,
+  ROTATION_MS,
+  CYCLE_LENGTH,
+  slotAt,
+  orderForCycle,
+  worldAt,
+  nextRotationAt,
+  msUntilRotation,
+} from "./rotation";
+import { WORLDS } from "./avatarData";
+
+const at = (iso: string) => Date.parse(iso);
+
+/**
+ * The cross-package pin.
+ *
+ * Byte-identical to the table in `server/rotation.test.js`. These are recorded
+ * outputs, not independently-derived expectations — the properties below are
+ * what check the design. What this table is for is *agreement*: edit one
+ * implementation's schedule and the other package's suite fails. Two people
+ * looking at two different worlds is invisible from inside either half alone.
+ */
+const PINNED = [
+  ["2026-08-12T00:00:00Z", "cafe"],
+  ["2026-08-12T00:29:59Z", "cafe"],
+  ["2026-08-12T00:30:00Z", "mountain"],
+  ["2026-08-12T01:29:59Z", "mountain"],
+  ["2026-08-12T01:30:00Z", "cafe"],
+  ["2026-08-12T09:00:00Z", "cafe"],
+  ["2026-08-12T12:30:00Z", "beach"],
+  ["2026-08-12T23:45:00Z", "mountain"],
+  ["2026-08-13T09:00:00Z", "space"],
+  ["2026-08-14T09:00:00Z", "beach"],
+  ["2026-08-15T09:00:00Z", "cafe"],
+  ["2027-01-01T00:30:00Z", "city"],
+];
+
+describe("rotation schedule", () => {
+  it("changes on the :30, not the hour", () => {
+    expect(worldAt(at("2026-08-12T00:29:59.999Z"))).toBe(
+      worldAt(at("2026-08-12T00:00:00Z")),
+    );
+    expect(worldAt(at("2026-08-12T00:30:00Z"))).not.toBe(
+      worldAt(at("2026-08-12T00:29:59.999Z")),
+    );
+  });
+
+  it("holds one world for exactly an hour", () => {
+    const start = at("2026-08-12T00:30:00Z");
+    const world = worldAt(start);
+    expect(worldAt(start + ROTATION_MS - 1)).toBe(world);
+    expect(worldAt(start + ROTATION_MS)).not.toBe(world);
+  });
+
+  it("advances one slot per hour", () => {
+    const t = at("2026-08-12T09:00:00Z");
+    expect(slotAt(t + ROTATION_MS) - slotAt(t)).toBe(1);
+  });
+
+  it("reports when the next changeover lands", () => {
+    const t = at("2026-08-12T09:07:30Z");
+    expect(new Date(nextRotationAt(t)).toISOString()).toBe(
+      "2026-08-12T09:30:00.000Z",
+    );
+    expect(msUntilRotation(t)).toBe(22 * 60 * 1000 + 30 * 1000);
+    expect(worldAt(nextRotationAt(t))).not.toBe(worldAt(t));
+  });
+});
+
+describe("rotation order", () => {
+  it("shows every world once per cycle", () => {
+    for (let cycle = 0; cycle < 2000; cycle++) {
+      expect(new Set(orderForCycle(cycle)).size).toBe(CYCLE_LENGTH);
+    }
+  });
+
+  it("never repeats a world across a cycle boundary", () => {
+    for (let cycle = 1; cycle < 2000; cycle++) {
+      const previous = orderForCycle(cycle - 1);
+      expect(orderForCycle(cycle)[0]).not.toBe(previous[CYCLE_LENGTH - 1]);
+    }
+  });
+
+  it("gives someone who always focuses at 9am a different world each day", () => {
+    const nine = (day: number) => worldAt(at(`2026-08-${day}T09:00:00Z`));
+    const week = [12, 13, 14, 15, 16, 17, 18].map(nine);
+    expect(new Set(week).size).toBeGreaterThan(1);
+  });
+
+  it("is uniform across positions", () => {
+    const counts = new Map(ROTATION_WORLDS.map((w) => [w, 0]));
+    const cycles = 8000;
+    for (let cycle = 0; cycle < cycles; cycle++) {
+      const world = orderForCycle(cycle)[0];
+      counts.set(world, (counts.get(world) ?? 0) + 1);
+    }
+    const expected = cycles / CYCLE_LENGTH;
+    for (const count of counts.values()) {
+      expect(count).toBeGreaterThan(expected * 0.85);
+      expect(count).toBeLessThan(expected * 1.15);
+    }
+  });
+});
+
+describe("rotation is a pure function of the clock", () => {
+  it("matches the pinned schedule shared with the server", () => {
+    for (const [iso, world] of PINNED) {
+      expect(`${iso} -> ${worldAt(at(iso))}`).toBe(`${iso} -> ${world}`);
+    }
+  });
+
+  it("only ever returns a valid world", () => {
+    for (const t of [0, -1, at("1969-01-01T00:00:00Z"), at("2099-12-31T23:59:59Z")]) {
+      expect(ROTATION_WORLDS).toContain(worldAt(t));
+    }
+  });
+
+  it("rotates through exactly the worlds the app can draw", () => {
+    // Adding a world to avatarData without adding it here would make it
+    // unreachable — there is no picker left to select it with.
+    expect([...ROTATION_WORLDS].sort()).toEqual(WORLDS.map((w) => w.id).sort());
+  });
+});

--- a/client/src/lib/rotation.ts
+++ b/client/src/lib/rotation.ts
@@ -1,0 +1,145 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Rotating world themes — derived from the wall clock, never stored.
+//
+// One world at a time, the same for everybody, changing on the :30 of every
+// hour. Modelled on PEAK: you don't pick a mountain, you climb whichever one
+// the game is on right now.
+//
+// **Derived, not stored**, deliberately. Session state already lives only in
+// the server's memory and dies with the process, so anything persisted about
+// the rotation would be one more thing to resync after a restart — and one
+// more thing that can disagree between two instances. A pure function of the
+// clock needs no coordination at all: every server, every browser tab and
+// every late joiner reach the same answer with no round trip.
+//
+// **This file is duplicated at `server/rotation.js`.** `client/` and `server/`
+// are independent npm packages with separate lockfiles and cannot import each
+// other. Both copies are pinned to the same table of timestamps in their tests
+// (`rotation.test.ts` / `rotation.test.js`), so editing one and not the other
+// fails the other package's suite rather than silently showing two people two
+// different worlds.
+//
+// The server is still the authority. This copy exists so the home screen can
+// show what's up next without a round trip, and so a session doesn't flash
+// forest before `sync_state` lands. Where they disagree — only possible if a
+// create lands across a boundary — the server's answer is the one that sticks.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import type { WorldId } from "./avatarData";
+
+/**
+ * The rotation.
+ *
+ * 'lofi' was retired in favour of 'grocery' and is absent, so nothing new can
+ * be created in it; migration 019 keeps it legal in the `sessions` CHECK so
+ * existing history rows stay valid.
+ */
+export const ROTATION_WORLDS: readonly WorldId[] = [
+  "forest",
+  "space",
+  "beach",
+  "city",
+  "mountain",
+  "library",
+  "cafe",
+  "grocery",
+];
+
+/** How long one world is up. */
+export const ROTATION_MS = 60 * 60 * 1000;
+
+/**
+ * How far the boundary sits from the top of the hour.
+ *
+ * The offset is the point: a theme change landing exactly on the hour would
+ * land on the same tick as everybody's o'clock pomodoro boundary, so the two
+ * events would compete. Anchored in UTC, because the whole product premise is
+ * that two people in different timezones see the same world.
+ */
+export const ROTATION_OFFSET_MS = 30 * 60 * 1000;
+
+/** Slots per cycle — one cycle is every world, once. */
+export const CYCLE_LENGTH = ROTATION_WORLDS.length;
+
+/**
+ * Integer hash. No `Math.sin`, no floats.
+ *
+ * The scenery generators seed themselves with `Math.sin`, which is fine when a
+ * one-ULP difference between engines moves a rock. Here the client and the
+ * server have to reach *the same world*, and this half runs on whatever engine
+ * the user brought. ECMA-262 does not require transcendental functions to be
+ * bit-identical between implementations; integer ops are.
+ */
+function hash32(n: number): number {
+  let x = n | 0;
+  x = Math.imul(x ^ (x >>> 16), 0x45d9f3b);
+  x = Math.imul(x ^ (x >>> 16), 0x45d9f3b);
+  return (x ^ (x >>> 16)) >>> 0;
+}
+
+/** Which rotation slot a moment falls in. Slot 0 began at 00:30 on 1 Jan 1970. */
+export function slotAt(now: number): number {
+  return Math.floor((now - ROTATION_OFFSET_MS) / ROTATION_MS);
+}
+
+/**
+ * The order the worlds come up in during one cycle of eight slots.
+ *
+ * Shuffled per cycle rather than fixed. Eight worlds at an hour each is an
+ * eight-hour loop, and eight divides twenty-four — so with a fixed order,
+ * somebody who always focuses at 9am would get the same world every single
+ * day, forever. Re-shuffling each cycle keeps the guarantee that you see all
+ * eight in eight hours while making the daily sequence different.
+ */
+function rawOrderForCycle(cycle: number): WorldId[] {
+  const order = ROTATION_WORLDS.slice();
+  // Fisher–Yates, drawing from the integer hash rather than a PRNG object so
+  // the same cycle always produces the same order on any engine.
+  for (let i = order.length - 1; i > 0; i--) {
+    const j = hash32(Math.imul(cycle, 0x9e3779b1) + i) % (i + 1);
+    const swap = order[i];
+    order[i] = order[j];
+    order[j] = swap;
+  }
+  return order;
+}
+
+/**
+ * As above, but never opening on the world the previous cycle closed with —
+ * that would show the same scene for two hours running and read as a bug.
+ *
+ * Comparing against the *raw* previous order is safe and keeps this
+ * non-recursive: the fix only ever touches positions 0 and 1, and the position
+ * being compared is the last one.
+ */
+export function orderForCycle(cycle: number): WorldId[] {
+  const order = rawOrderForCycle(cycle);
+  const previous = rawOrderForCycle(cycle - 1);
+  if (order.length > 1 && order[0] === previous[previous.length - 1]) {
+    const swap = order[0];
+    order[0] = order[1];
+    order[1] = swap;
+  }
+  return order;
+}
+
+/** The world in play at `now` (defaults to this instant). */
+export function worldAt(now: number = Date.now()): WorldId {
+  const slot = slotAt(now);
+  // `%` keeps the sign of the dividend in JS, and slots before 1970 are
+  // negative. Nothing sane hits this, but a negative index returns undefined
+  // and would leave the app in no world at all.
+  const cycle = Math.floor(slot / CYCLE_LENGTH);
+  const position = ((slot % CYCLE_LENGTH) + CYCLE_LENGTH) % CYCLE_LENGTH;
+  return orderForCycle(cycle)[position];
+}
+
+/** Epoch ms of the next changeover. */
+export function nextRotationAt(now: number = Date.now()): number {
+  return (slotAt(now) + 1) * ROTATION_MS + ROTATION_OFFSET_MS;
+}
+
+/** How long the current world has left, in ms. */
+export function msUntilRotation(now: number = Date.now()): number {
+  return nextRotationAt(now) - now;
+}

--- a/server/createSession.test.js
+++ b/server/createSession.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawn } from "node:child_process";
+import { io as connect } from "socket.io-client";
+import { ROTATION_WORLDS, worldAt } from "./rotation.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The world is the server's to decide.
+//
+// Every other socket test in this package covers the pure helpers in
+// session.js, which is enough for state transitions but cannot show what a
+// *handler* does with a payload. The claim here — "a client-sent world is
+// ignored" — is only true at the handler, so this boots the real server and
+// talks to it over a real socket.
+//
+// Run against the previous commit, `world: <injected>` comes back as the
+// session's world and these fail.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const AVATAR = {
+  skinColor: "#F1C27D",
+  hairStyle: "bob",
+  hairColor: "#3B2314",
+  eyeStyle: "normal",
+  outfitColor: "#4A6FA5",
+};
+
+// The auth middleware needs *a* token. Without SUPABASE_URL the server skips
+// verification but still decodes the sub claim, so this is a syntactically
+// real JWT with a fixed subject and nothing else.
+function fakeToken(sub) {
+  const b64 = (o) => Buffer.from(JSON.stringify(o)).toString("base64url");
+  return `${b64({ alg: "none", typ: "JWT" })}.${b64({ sub })}.`;
+}
+
+let child;
+let url;
+
+beforeAll(async () => {
+  child = spawn("node", ["index.js"], {
+    cwd: import.meta.dirname,
+    env: {
+      ...process.env,
+      PORT: "0",
+      // Empty rather than deleted: dotenv only fills keys that are absent, so
+      // a developer's own .env would otherwise point this at real Supabase.
+      SUPABASE_URL: "",
+      SUPABASE_SERVICE_KEY: "",
+      NODE_ENV: "test",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  url = await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("server did not start")), 15_000);
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      const match = /Server running on port (\d+)/.exec(chunk);
+      if (match) {
+        clearTimeout(timer);
+        resolve(`http://localhost:${match[1]}`);
+      }
+    });
+    child.on("exit", (code) => reject(new Error(`server exited early (${code})`)));
+  });
+}, 20_000);
+
+afterAll(() => {
+  child?.kill("SIGKILL");
+});
+
+/** Create a session with the given payload; resolve with the sync_state world. */
+function createSession(payload, sub) {
+  return new Promise((resolve, reject) => {
+    const socket = connect(url, {
+      auth: { token: fakeToken(sub) },
+      transports: ["websocket"],
+    });
+    const timer = setTimeout(() => {
+      socket.close();
+      reject(new Error("no sync_state"));
+    }, 10_000);
+    socket.on("connect_error", (err) => {
+      clearTimeout(timer);
+      socket.close();
+      reject(err);
+    });
+    socket.on("sync_state", (state) => {
+      clearTimeout(timer);
+      socket.close();
+      resolve(state.world);
+    });
+    socket.on("connect", () => {
+      socket.emit("create_session", { avatar: AVATAR, displayName: "Tester", ...payload });
+    });
+  });
+}
+
+describe("create_session assigns the rotating world", () => {
+  it("ignores a world sent by the client", async () => {
+    const before = Date.now();
+    // Bracket the round trip so a rotation landing mid-test can't decide the
+    // result: the answer must be one of the two worlds in play, and the
+    // injected value is chosen to be neither.
+    const plausible = new Set([worldAt(before), worldAt(before + 60_000)]);
+    const injected = ROTATION_WORLDS.find((w) => !plausible.has(w));
+
+    const world = await createSession({ world: injected }, "11111111-1111-4111-8111-111111111111");
+
+    expect(world).not.toBe(injected);
+    expect([...plausible, worldAt(Date.now())]).toContain(world);
+  });
+
+  it("assigns the same world regardless of what two clients ask for", async () => {
+    const [a, b] = await Promise.all([
+      createSession({ world: "space" }, "22222222-2222-4222-8222-222222222222"),
+      createSession({ world: "beach" }, "33333333-3333-4333-8333-333333333333"),
+    ]);
+    expect(a).toBe(b);
+  });
+
+  it("still creates a session when no world is sent at all", async () => {
+    // Guard, not an A/B: this passed before the change too, because the old
+    // handler fell back to 'forest'. It is here so "ignored, not required"
+    // stays true — an older client must not start getting errors.
+    const world = await createSession({}, "44444444-4444-4444-8444-444444444444");
+    expect(ROTATION_WORLDS).toContain(world);
+  });
+});

--- a/server/index.js
+++ b/server/index.js
@@ -18,6 +18,7 @@ const {
   findUserSessions,
   buildSyncPayload,
 } = require('./session');
+const { worldAt } = require('./rotation');
 require('dotenv').config();
 
 const supabase = (process.env.SUPABASE_URL && process.env.SUPABASE_SERVICE_KEY)
@@ -51,10 +52,6 @@ const io = new Server(server, {
 });
 
 // ── Auth middleware — verify Supabase JWT on every connection ─────────────
-// 'lofi' was retired in favour of 'grocery'. It stays out of this list so no
-// new session can be created in it, but migration 019 keeps it legal in the
-// sessions CHECK so existing history rows remain valid.
-const VALID_WORLDS = ['forest', 'space', 'beach', 'city', 'mountain', 'library', 'cafe', 'grocery'];
 const MAX_DISPLAY_NAME = 50;
 const MAX_FOCUS = 120 * 60;   // 2 hours in seconds
 const MAX_BREAK = 60 * 60;    // 1 hour in seconds
@@ -435,7 +432,7 @@ io.on('connection', (socket) => {
   });
 
   // ── Invite relay ────────────────────────────────────────────────────────
-  socket.on('send_invite', async ({ targetUserId, sessionId, worldId, fromName }) => {
+  socket.on('send_invite', async ({ targetUserId, sessionId, fromName }) => {
     if (!rateLimits.sendInvite(socket.id)) {
       socket.emit('invite_error', { message: 'Too many invites, slow down' });
       return;
@@ -463,7 +460,13 @@ io.on('connection', (socket) => {
     // Use verified userId, not client-sent
     const fromUserId = socket.userId || null;
     const safeName = (typeof fromName === 'string' ? fromName : 'Someone').slice(0, MAX_DISPLAY_NAME);
-    const safeWorld = VALID_WORLDS.includes(worldId) ? worldId : null;
+    // The world a session is in is server state, so read it from there rather
+    // than validating a client-sent copy. The invite popup shows this; taking
+    // the sender's word for it let them advertise a session as somewhere it
+    // isn't. It also can't go stale now that the rotation moves.
+    const safeWorld = (typeof sessionId === 'string' && sessions[sessionId])
+      ? sessions[sessionId].world
+      : null;
 
     // Allowlist the invitee so the join gate lets them in
     if (typeof sessionId === 'string' && sessions[sessionId]) {
@@ -482,17 +485,23 @@ io.on('connection', (socket) => {
     console.log(`[invite] ${safeName} invited ${targetUserId}`);
   });
 
-  // create_session: { avatar, world, displayName, pet }
+  // create_session: { avatar, displayName, pet }
   // Creates a new session with a UUID, user becomes host.
   // userId comes from verified socket.userId (auth middleware).
-  socket.on('create_session', ({ avatar, world, displayName, pet }) => {
+  //
+  // The world is NOT a parameter. It is whatever the rotation is on right now
+  // (server/rotation.js) — one world, everybody, changing on the :30. A `world`
+  // field in the payload is ignored rather than rejected, so an older client
+  // still gets a session instead of an error. There is nothing left to validate
+  // here because there is nothing left to trust.
+  socket.on('create_session', ({ avatar, displayName, pet }) => {
     if (!rateLimits.createSession(socket.id)) {
       socket.emit('session_error', { message: 'Too many requests, slow down' });
       return;
     }
     // Input validation
     const safeName = (typeof displayName === 'string' ? displayName : 'Player').slice(0, MAX_DISPLAY_NAME);
-    const safeWorld = VALID_WORLDS.includes(world) ? world : 'forest';
+    const safeWorld = worldAt();
     const safeAvatar = sanitizeAvatar(avatar);
     if (!safeAvatar) {
       socket.emit('session_error', { message: 'Invalid avatar' });
@@ -792,7 +801,10 @@ async function clearAllPresence(reason) {
 
 const PORT = process.env.PORT || 3001;
 server.listen(PORT, async () => {
-  console.log(`Server running on port ${PORT}`);
+  // The bound port, not the requested one — PORT=0 means "pick a free one",
+  // which is how createSession.test.js gets an instance without fighting a dev
+  // server for 3001.
+  console.log(`Server running on port ${server.address().port}`);
   console.log(`Allowed origins: ${allowedOrigins.join(', ')}`);
   await clearAllPresence('boot');
 });

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "nodemon": "^3.1.14",
+        "socket.io-client": "^4.8.3",
         "vitest": "^4.0.18"
       }
     },
@@ -1418,6 +1419,42 @@
         "node": ">=10.2.0"
       }
     },
+    "node_modules/engine.io-client": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
+      "integrity": "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.21.0",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/engine.io-parser": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
@@ -2532,6 +2569,22 @@
         "ws": "~8.18.3"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/socket.io-parser": {
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.5.tgz",
@@ -3031,6 +3084,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     }
   }

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "nodemon": "^3.1.14",
+    "socket.io-client": "^4.8.3",
     "vitest": "^4.0.18"
   }
 }

--- a/server/rotation.js
+++ b/server/rotation.js
@@ -1,0 +1,151 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Rotating world themes — derived from the wall clock, never stored.
+//
+// One world at a time, the same for everybody, changing on the :30 of every
+// hour. Modelled on PEAK: you don't pick a mountain, you climb whichever one
+// the game is on right now.
+//
+// **Derived, not stored**, deliberately. Session state already lives only in
+// memory and dies with the process, so anything persisted about the rotation
+// would be one more thing to resync after a restart — and one more thing that
+// can disagree between two instances. A pure function of the clock needs no
+// coordination at all: every server, every browser tab and every late joiner
+// reach the same answer with no round trip and nothing to drift.
+//
+// **This file is duplicated at `client/src/lib/rotation.ts`.** `client/` and
+// `server/` are independent npm packages with separate lockfiles and cannot
+// import each other. Both copies are pinned to the same table of timestamps in
+// their tests (`rotation.test.js` / `rotation.test.ts`), so editing one and not
+// the other fails the other package's suite rather than silently showing two
+// people two different worlds.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The rotation, and the only list of valid worlds left on the server.
+ *
+ * 'lofi' was retired in favour of 'grocery' and is absent here, so nothing new
+ * can be created in it; migration 019 keeps it legal in the `sessions` CHECK so
+ * existing history rows stay valid. Adding a world means this list, the client's
+ * `WorldId`, and the SQL CHECK — see CLAUDE.md.
+ */
+const ROTATION_WORLDS = [
+  'forest',
+  'space',
+  'beach',
+  'city',
+  'mountain',
+  'library',
+  'cafe',
+  'grocery',
+];
+
+/** How long one world is up. */
+const ROTATION_MS = 60 * 60 * 1000;
+
+/**
+ * How far the boundary sits from the top of the hour.
+ *
+ * The offset is the point: a theme change landing exactly on the hour would
+ * land on the same tick as everybody's o'clock pomodoro boundary, so the two
+ * events would compete. Anchored in UTC, because the whole product premise is
+ * that two people in different timezones see the same world.
+ */
+const ROTATION_OFFSET_MS = 30 * 60 * 1000;
+
+/** Slots per cycle — one cycle is every world, once. */
+const CYCLE_LENGTH = ROTATION_WORLDS.length;
+
+/**
+ * Integer hash. No `Math.sin`, no floats.
+ *
+ * The scenery generators seed themselves with `Math.sin`, which is fine when a
+ * one-ULP difference between engines moves a rock. Here the client and the
+ * server have to reach *the same world*, and the client runs on engines this
+ * code has never been tested against. ECMA-262 does not require transcendental
+ * functions to be bit-identical between implementations; integer ops are.
+ */
+function hash32(n) {
+  let x = n | 0;
+  x = Math.imul(x ^ (x >>> 16), 0x45d9f3b);
+  x = Math.imul(x ^ (x >>> 16), 0x45d9f3b);
+  return (x ^ (x >>> 16)) >>> 0;
+}
+
+/** Which rotation slot a moment falls in. Slot 0 began at 00:30 on 1 Jan 1970. */
+function slotAt(now) {
+  return Math.floor((now - ROTATION_OFFSET_MS) / ROTATION_MS);
+}
+
+/**
+ * The order the worlds come up in during one cycle of eight slots.
+ *
+ * Shuffled per cycle rather than fixed. Eight worlds at an hour each is an
+ * eight-hour loop, and eight divides twenty-four — so with a fixed order,
+ * somebody who always focuses at 9am would get the same world every single
+ * day, forever. Re-shuffling each cycle keeps the guarantee that you see all
+ * eight in eight hours while making the daily sequence different.
+ */
+function rawOrderForCycle(cycle) {
+  const order = ROTATION_WORLDS.slice();
+  // Fisher–Yates, drawing from the integer hash rather than a PRNG object so
+  // the same cycle always produces the same order on any engine.
+  for (let i = order.length - 1; i > 0; i--) {
+    const j = hash32(Math.imul(cycle, 0x9e3779b1) + i) % (i + 1);
+    const swap = order[i];
+    order[i] = order[j];
+    order[j] = swap;
+  }
+  return order;
+}
+
+/**
+ * As above, but never opening on the world the previous cycle closed with —
+ * that would show the same scene for two hours running and read as a bug.
+ *
+ * Comparing against the *raw* previous order is safe and keeps this
+ * non-recursive: the fix only ever touches positions 0 and 1, and the position
+ * being compared is the last one.
+ */
+function orderForCycle(cycle) {
+  const order = rawOrderForCycle(cycle);
+  const previous = rawOrderForCycle(cycle - 1);
+  if (order.length > 1 && order[0] === previous[previous.length - 1]) {
+    const swap = order[0];
+    order[0] = order[1];
+    order[1] = swap;
+  }
+  return order;
+}
+
+/** The world in play at `now` (defaults to this instant). */
+function worldAt(now = Date.now()) {
+  const slot = slotAt(now);
+  // `%` keeps the sign of the dividend in JS, and slots before 1970 are
+  // negative. Nothing sane hits this, but a negative index returns undefined
+  // and would put the server in no world at all.
+  const cycle = Math.floor(slot / CYCLE_LENGTH);
+  const position = ((slot % CYCLE_LENGTH) + CYCLE_LENGTH) % CYCLE_LENGTH;
+  return orderForCycle(cycle)[position];
+}
+
+/** Epoch ms of the next changeover. */
+function nextRotationAt(now = Date.now()) {
+  return (slotAt(now) + 1) * ROTATION_MS + ROTATION_OFFSET_MS;
+}
+
+/** How long the current world has left, in ms. */
+function msUntilRotation(now = Date.now()) {
+  return nextRotationAt(now) - now;
+}
+
+module.exports = {
+  ROTATION_WORLDS,
+  ROTATION_MS,
+  ROTATION_OFFSET_MS,
+  CYCLE_LENGTH,
+  slotAt,
+  orderForCycle,
+  worldAt,
+  nextRotationAt,
+  msUntilRotation,
+};

--- a/server/rotation.test.js
+++ b/server/rotation.test.js
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import {
+  ROTATION_WORLDS,
+  ROTATION_MS,
+  CYCLE_LENGTH,
+  slotAt,
+  orderForCycle,
+  worldAt,
+  nextRotationAt,
+  msUntilRotation,
+} from "./rotation.js";
+
+const at = (iso) => Date.parse(iso);
+
+/**
+ * The cross-package pin.
+ *
+ * These are recorded outputs, not independently-derived expectations — the
+ * properties below are what actually check the design. What this table is for
+ * is agreement: `client/src/lib/rotation.ts` has a byte-identical copy, so any
+ * edit to one implementation that changes the schedule fails the *other*
+ * package's suite. Two people looking at two different worlds is the failure
+ * this exists to catch, and it is invisible on either side alone.
+ */
+const PINNED = [
+  ['2026-08-12T00:00:00Z', 'cafe'],
+  ['2026-08-12T00:29:59Z', 'cafe'],
+  ['2026-08-12T00:30:00Z', 'mountain'],
+  ['2026-08-12T01:29:59Z', 'mountain'],
+  ['2026-08-12T01:30:00Z', 'cafe'],
+  ['2026-08-12T09:00:00Z', 'cafe'],
+  ['2026-08-12T12:30:00Z', 'beach'],
+  ['2026-08-12T23:45:00Z', 'mountain'],
+  ['2026-08-13T09:00:00Z', 'space'],
+  ['2026-08-14T09:00:00Z', 'beach'],
+  ['2026-08-15T09:00:00Z', 'cafe'],
+  ['2027-01-01T00:30:00Z', 'city'],
+];
+
+describe('rotation schedule', () => {
+  it('changes on the :30, not the hour', () => {
+    // The offset is the whole reason it isn't `% 3600000`.
+    expect(worldAt(at('2026-08-12T00:29:59.999Z'))).toBe(
+      worldAt(at('2026-08-12T00:00:00Z')),
+    );
+    expect(worldAt(at('2026-08-12T00:30:00Z'))).not.toBe(
+      worldAt(at('2026-08-12T00:29:59.999Z')),
+    );
+  });
+
+  it('holds one world for exactly an hour', () => {
+    const start = at('2026-08-12T00:30:00Z');
+    const world = worldAt(start);
+    expect(worldAt(start + ROTATION_MS - 1)).toBe(world);
+    expect(worldAt(start + ROTATION_MS)).not.toBe(world);
+  });
+
+  it('advances one slot per hour', () => {
+    const t = at('2026-08-12T09:00:00Z');
+    expect(slotAt(t + ROTATION_MS) - slotAt(t)).toBe(1);
+  });
+
+  it('reports when the next changeover lands', () => {
+    const t = at('2026-08-12T09:07:30Z');
+    expect(new Date(nextRotationAt(t)).toISOString()).toBe(
+      '2026-08-12T09:30:00.000Z',
+    );
+    expect(msUntilRotation(t)).toBe(22 * 60 * 1000 + 30 * 1000);
+    // The world at the boundary is the *next* one, never the current one.
+    expect(worldAt(nextRotationAt(t))).not.toBe(worldAt(t));
+  });
+});
+
+describe('rotation order', () => {
+  it('shows every world once per cycle', () => {
+    for (let cycle = 0; cycle < 2000; cycle++) {
+      expect(new Set(orderForCycle(cycle)).size).toBe(CYCLE_LENGTH);
+    }
+  });
+
+  it('never repeats a world across a cycle boundary', () => {
+    // Without the fix-up in orderForCycle this happens about 1 cycle in 8, and
+    // shows the same scene for two hours running.
+    for (let cycle = 1; cycle < 2000; cycle++) {
+      const previous = orderForCycle(cycle - 1);
+      expect(orderForCycle(cycle)[0]).not.toBe(previous[CYCLE_LENGTH - 1]);
+    }
+  });
+
+  it('gives someone who always focuses at 9am a different world each day', () => {
+    // The reason the order is shuffled per cycle at all: eight worlds at an
+    // hour each divides evenly into a day, so a fixed order pins every
+    // wall-clock time to one world for good.
+    const nine = (day) => worldAt(at(`2026-08-${day}T09:00:00Z`));
+    const week = [12, 13, 14, 15, 16, 17, 18].map(nine);
+    expect(new Set(week).size).toBeGreaterThan(1);
+  });
+
+  it('is deterministic', () => {
+    const t = at('2026-08-12T09:00:00Z');
+    expect(worldAt(t)).toBe(worldAt(t));
+    expect(orderForCycle(1234)).toEqual(orderForCycle(1234));
+  });
+
+  it('is uniform across positions', () => {
+    // A shuffle that favours a position would park one world at, say, every
+    // 09:30 — the same defect the shuffle exists to prevent, just subtler.
+    const counts = new Map(ROTATION_WORLDS.map((w) => [w, 0]));
+    const cycles = 8000;
+    for (let cycle = 0; cycle < cycles; cycle++) {
+      const world = orderForCycle(cycle)[0];
+      counts.set(world, counts.get(world) + 1);
+    }
+    const expected = cycles / CYCLE_LENGTH;
+    for (const count of counts.values()) {
+      expect(count).toBeGreaterThan(expected * 0.85);
+      expect(count).toBeLessThan(expected * 1.15);
+    }
+  });
+});
+
+describe('rotation is a pure function of the clock', () => {
+  it('matches the pinned schedule shared with the client', () => {
+    for (const [iso, world] of PINNED) {
+      expect(`${iso} -> ${worldAt(at(iso))}`).toBe(`${iso} -> ${world}`);
+    }
+  });
+
+  it('only ever returns a valid world', () => {
+    // Including before the epoch, where `%` on a negative slot would otherwise
+    // index off the front of the array and put the server in no world at all.
+    for (const t of [0, -1, at('1969-01-01T00:00:00Z'), at('2099-12-31T23:59:59Z')]) {
+      expect(ROTATION_WORLDS).toContain(worldAt(t));
+    }
+    for (let i = 0; i < 500; i++) {
+      expect(ROTATION_WORLDS).toContain(worldAt(at('2026-08-12T00:30:00Z') + i * ROTATION_MS));
+    }
+  });
+
+  it('no longer offers the retired lofi world', () => {
+    expect(ROTATION_WORLDS).not.toContain('lofi');
+  });
+});


### PR DESCRIPTION
Roadmap item 11. The PEAK model: you don't pick a mountain, you climb whichever
one the game is on. One world at a time, the same for everybody, changing on the
**:30** of every hour.

Home's eight-thumbnail picker is gone. In its place is a card naming the world
that's up and counting down to the next one.

## Design decisions worth reviewing

**Derived, never stored.** `worldAt(now)` is a pure function of the wall clock —
no DB row, no timer, no broadcast. Live session state is already in-memory and
dies with the process, so a persisted rotation would be one more thing to resync
after a restart and one more thing two instances could disagree about.

**The order reshuffles every cycle.** This is the answer to the open question in
the roadmap. Eight worlds at an hour each is an eight-hour loop, and 8 divides
24 — so with a fixed order, someone who always focuses at 9am would get the same
world every day, forever. Rather than change the interval (you asked for hourly
on the :30, and that's a better rhythm), the *order* is reshuffled per cycle. A
cycle is still all eight worlds, so "see everything in eight hours" holds, but
which permutation you get depends on the cycle. A fix-up stops a cycle opening on
the world the last one closed with.

Verified over 80k cycles: uniform across positions (±2% of 1/8), zero boundary
repeats, no cycle missing a world.

**Integer hash, not `Math.sin`.** The terrain and shelving generators seed with
`Math.sin`, which is fine when a 1-ULP difference between engines moves a rock.
Here the client and server must reach *the same world*, and the client runs on
engines this code has never been tested against. ECMA-262 doesn't require
transcendentals to be bit-identical across implementations, so the shuffle uses
`Math.imul` + xor-shift and touches no floats.

**Duplicated, deliberately.** `client/` and `server/` are independent npm
packages and can't import each other, so the derivation exists twice. What keeps
them honest: both suites pin the **same table of timestamps**, so editing one
implementation's schedule fails the *other* package's suite. Two people looking
at two different worlds is invisible from inside either half alone.

**A session keeps the world it started in.** Rotation applies to new sessions
only. Swapping the scene 20 minutes into a focus block is worse than a slightly
stale theme, and it would make the `sessions.world` history row ambiguous.

## A/B

Both halves have tests that fail against the previous commit.

**Server** — `createSession.test.js`, run against the commit before the handler
change:

```
× ignores a world sent by the client
  AssertionError: expected 'forest' not to be 'forest'
× assigns the same world regardless of what two clients ask for
  AssertionError: expected 'space' to be 'beach'
✓ still creates a session when no world is sent at all
```

The third passes both ways — the old handler fell back to `forest`. It's
labelled a guard in the file, not presented as evidence.

**Client** — `HomeDashboard.test.tsx`, against the previous `HomeDashboard`: all
three fail. The picker heading is still in the document, "Everyone's world" is
not, and `Focus` is still called with an argument.

`WorldNowCard.test.tsx` and `rotation.test.*` are new-surface coverage rather
than A/B — there was no previous behaviour to fail. The cases worth having are
the boundary crossing with the page open, and the throttled-background-tab
catch-up.

## Also in here

- **`send_invite` stopped trusting a client-sent `worldId`.** It was relaying an
  attacker-controlled world label into a full-screen popup on someone else's
  machine — same class as the `fromName` cap. The server now reads the world off
  the session, which also can't go stale as the rotation moves.
- **`VALID_WORLDS` deleted.** No callers left; `ROTATION_WORLDS` is the one list
  and carries the note about `lofi` and migration 019.
- **`setMyWorld` unexported** from `useGameSession`. Nothing called it, and it
  was a supported way for a component to overrule the server locally.
- **"Unlock all world themes" removed from `PremiumModal`.** It was already
  untrue; the rotation makes it unsellable. The other three claims on that list
  are still fiction — roadmap item 2's job, not this PR's.
- **`onClick={onFocus}`** was passing the click event straight into the
  session-creating callback. Harmless today.
- **First handler-level test in `server/`.** Boots the real server as a child
  process on an ephemeral port and talks to it over a real socket. `PORT=0` works
  now because the boot log prints the *bound* port. Adds `socket.io-client` as a
  server devDependency.

## The roadmap is now tracked

`ROADMAP.local.md` → `ROADMAP.md`. It was gitignored on the grounds that it was
scratch, but it's become the actual record of what was tried and what was
debunked — including the corrections section that exists so nobody re-fixes
three sprite defects that were never real. The trade is that it lands in diffs,
so it has to be updated in the PR that does the work; that's noted in both it
and CLAUDE.md.

## Not verified

**Nothing here has been looked at in a browser.** No agent in this repo has
browser-tested anything. Worth checking by eye:

- the countdown ticking on home, and that it reads right at a :30 boundary
- a session left open across a :30 keeps its own world rather than swapping
- two accounts landing in the same world

No migration needed — the value is still one of the eight `sessions_world_check`
already allows.

## Commits

7, rebase-merge as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)