### PR TITLE
Characters and pets onto PixelSprite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,9 +170,31 @@ The art is generated at runtime — there are no image assets. `client/public/` 
 SVGs, five of which are untouched Next.js starter files.
 
 - `PixelSprite` (string map + palette → merged `<rect>`s, `shapeRendering: crispEdges`) is
-  the right primitive. `PixelCharacter` and `PetCharacter` do **not** use it — they are ~90
-  hand-placed `<rect x= y=>` elements, which is why they can't be palette-swapped,
-  outlined or given a blink frame without editing coordinates by hand.
+  the right primitive, and everything now uses it. The avatar and the pets are string maps
+  in `lib/characterMaps.ts` and `lib/petMaps.ts`; they were ~90 hand-placed `<rect x= y=>`
+  elements until PR #39, which is why they were the two sprites that couldn't be
+  palette-swapped, outlined or blinked.
+- **Multi-layer sprites composite into one map before rendering** (`lib/pixelMap.ts`),
+  never into stacked `<svg>` elements — separate SVGs put each layer's edges on their own
+  rounding and the parts of one shape pick up seams. Layers share one key alphabet, so
+  compositing is "last non-transparent wins" and no two layers can disagree about what a
+  key means. `place()` **throws** on a block that overruns the canvas or a row of the wrong
+  width: `PixelSprite`'s forgiveness is right for a standalone sprite and wrong for a
+  layer, where a padded row lands on top of what the layer was supposed to let through.
+- **Derive shading, never hand-pick it, and never scale RGB channels.** `shade()` and
+  `flush()` in `lib/palette.ts` are the only shading in the art. A per-channel multiply
+  moves a colour by an amount that depends on how bright it already is — the old
+  `darken(skin, 0.08)` shifted the deepest skin by 0.016 lightness and the palest by 0.071,
+  so the chin shadow was invisible on two of the six skins. Two obvious rewrites each fix
+  half: blending toward a fixed dark tone leaves near-black *lighter* than its own shadow,
+  and holding HSL saturation while dropping lightness turns pale colours vivid. `shade()`
+  drops lightness by a fixed amount while holding chroma, with a cap. Both failure modes
+  are regression tests in `lib/palette.test.ts`.
+- **A sprite should change its own pixels.** `pixel-idle` translates the whole sprite up
+  three px, which is motion *of* a drawing rather than motion *in* one, and a scene of
+  those reads as posed dolls. The avatar blinks (4–6.5 s, jittered — a fixed interval reads
+  as a tic — and off under `prefers-reduced-motion`). Walk cycles are separate maps, not
+  transformed copies.
 - **`PixelSprite` fails silently in three ways**, all covered by `lib/uiSprites.test.ts`:
   a short row is padded rather than rejected (the viewBox takes the *longest* row), a
   character with no palette entry is skipped, and two palette keys with the same colour

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,8 +5,9 @@ that does the work, not afterwards. Ordered by value; each line names the real
 files. Was `ROADMAP.local.md` and gitignored until PR #38 — it is tracked now,
 so the file:line references land in diffs and want keeping honest.
 
-Last updated: 2026-08-13. PRs #35, #36 and #37 merged — 24 commits on main.
-PR #38 (rotating themes, 7 commits) open on `feat/rotating-themes`.
+Last updated: 2026-08-13. PRs #35–#38 merged — 31 commits on main.
+PR #39 (characters + pets onto PixelSprite, 5 commits) open on
+`art/characters-on-pixelsprite`.
 Migrations 016–019 are applied to Supabase (019 verified in production: the
 CHECK now lists 'grocery' and keeps 'lofi' for history).
 
@@ -43,8 +44,12 @@ CHECK now lists 'grocery' and keeps 'lofi' for history).
       question below is **answered**: kept at one hour (the owner's spec) and
       fixed the daily repeat with the per-cycle shuffle instead of changing the
       interval. Home's picker is now `WorldNowCard`.
-- [ ] **7b-char. Characters + pets onto `PixelSprite`** — the deferred half.
-      Now the least detailed thing on screen; the backgrounds overtook them.
+- [x] **7b-char. Characters + pets onto `PixelSprite`** — PR #39, 5 commits.
+      Both sprites are layered string maps now (`lib/characterMaps.ts`,
+      `lib/petMaps.ts`) composited by `lib/pixelMap.ts`. The avatar blinks;
+      pets went 10×11 → 9×7 (0.46× a person → 0.29×). `darken()` is gone —
+      see below. Outlines are one prop away but **not turned on**, which is
+      the rest of item 4.
 - [ ] **2. Premium button on home is a no-op** — under an hour. "Unlock all
       world themes" already removed by #38 (nothing left to gate); the other
       three claims on that list are still fiction and still this item's job.
@@ -54,14 +59,15 @@ CHECK now lists 'grocery' and keeps 'lofi' for history).
 Three "defects" originally listed under item 7 were checked against the source
 and are **not real**. They have been struck out below. Verify before fixing:
 
-- **Eye centring** — claimed `anime`/`sleepy` centre on 7.5. They don't. The head
-  spans columns 3–12 (centre 8); `anime` and `sleepy` eyes span [4,7) and [9,12),
-  midpoint (4+12)/2 = **8**. `normal` spans [4,6) and [10,12), also 8. All three
-  are symmetric, and the blush at [3,5)/[11,13) confirms 8 is the axis.
-- **"long" hair identical to "bob"** — the *front* layer is identical, but
-  `HairBack` draws 9-row side drapes at columns 1–2 and 13–14 for `long` only
-  (`PixelCharacter.tsx:41-53`). The two options are visibly different; same
-  fringe, longer sides. Reasonable design, not a bug.
+- **Eye centring** — claimed `anime`/`sleepy` centre on 7.5. They don't: the head
+  spans columns 3–12, so the axis is 8, and all three styles sit on it. **Now
+  enforced** rather than argued — `characterMaps.test.ts` asserts the eye
+  midpoint is 8 and that rows 3–11 are shape-symmetric, for every style.
+- **"long" hair identical to "bob"** — the *front* layer is identical, but the
+  back layer draws side drapes for `long` only (`lib/characterMaps.ts`,
+  `HAIR_BACK`). Same fringe, longer sides: reasonable design, not a bug. Also
+  enforced now — `characterMaps.test.ts` asserts the two share a fringe and
+  differ overall.
 - **PALM crown misaligned** — the crown and the trunk's *top* are both centred on
   column 7. The trunk then leans right by design over rows 5–10, which is what
   palm trunks do. Comparing the crown to the trunk's base and calling the
@@ -109,17 +115,17 @@ fringe. This is why sprites look blurry **despite** `shapeRendering: crispEdges`
 - `client/src/components/SessionTopBar.tsx:43,152-159` — wires it correctly.
   So the in-session path works and the *home* path silently dies. Home is the
   primary monetization surface.
-- `client/src/components/PremiumModal.tsx:11-17` — the feature list is fiction.
-  "Unlock all world themes" while `HomeDashboard.tsx:297-315` lets everyone pick
-  all 8. "Focus stats & session history" while `StatsPanel`/`StatsScreen` are
-  open to all. "Friend session notifications" while the Notification API appears
-  nowhere in the codebase. Only pets are actually gated
+- `client/src/components/PremiumModal.tsx` — the feature list is still mostly
+  fiction. "Unlock all world themes" was removed in PR #38 (the rotation left
+  nothing to gate). Remaining: "Focus stats & session history" while
+  `StatsPanel`/`StatsScreen` are open to all; "Friend session notifications"
+  while the Notification API appears nowhere in the codebase; "Exclusive
+  premium character skins" while there are none. Only pets are actually gated
   (`PetPicker.tsx:20,34`).
 
-Thread `onOpenPremium` through (the plumbing exists in `DuoTimer`), then either
-trim the list to what's real or actually gate worlds. Gating worlds needs a
-server check too — `server/index.js:463,492` accepts any valid world from any
-user regardless of premium status.
+Thread `onOpenPremium` through (the plumbing exists in `DuoTimer`), then trim
+the list to what's real. Gating worlds is no longer an option — after PR #38
+the server assigns the world from the clock and there is no per-user choice.
 
 ---
 
@@ -128,7 +134,10 @@ user regardless of premium status.
 **146 hardcoded hex literals** in `client/src` against 17 theme tokens, drawn
 from three different published design systems:
 
-- `PetCharacter.tsx:23-37` — the most-copied Coolors palette, verbatim.
+- ~~`PetCharacter.tsx:23-37` — the most-copied Coolors palette, verbatim~~ —
+  **gone in PR #39.** Pet colours are one base per animal with `shade()`
+  deriving the rest, in `lib/petMaps.ts`. Characters likewise: `palette.ts`
+  now owns every shadow either sprite uses.
 - `lib/uiSprites.ts:16,25` — a *different* Coolors set.
 - `WorldDecorations.tsx` — 77 of the 146. Tailwind defaults (`#c084fc`
   purple-400 `:92`, `#f1f5f9` slate-100 `:121`) mixed with Material Design 800s
@@ -245,9 +254,9 @@ to come from sprite *dimensions in art pixels*, not px-per-pixel. Character is
 - a mountain (`MOUNTAIN` 16×10 @ scale 8, `:635`) is 80px — **11% taller than a
   human**
 - ~~pets are 20px with pixels ⅔ the character's~~ — **density fixed in PR #36**,
-  pets are on `ART_PX`. But they are now 30×33, i.e. a cat 0.46× a person's
-  height where a real one is ~0.25×. Redraw the pet maps at about 7×7 cells;
-  do **not** put `size` back to 2
+  ~~but they are now 30×33, i.e. a cat 0.46× a person's height~~ — **size fixed
+  in PR #39**: redrawn at 9×7, so 27×21 px, 0.29× a person. `size` stayed at
+  `ART_PX`
 
 A 16-px-tall person needs a ~28px tree, ~60px tower, ~40px mountain range, plus
 explicit far/mid/near variants differing by *value*, not scale.
@@ -266,19 +275,27 @@ Latent bugs to fix while redrawing:
   which. All four pets now share an 11-row grid.
 - ~~eye centring~~ — **not a real defect.** See corrections at the top.
 - ~~`long` hair identical to `bob`~~ — **not a real defect.** See corrections.
-- `PixelCharacter.tsx:325` — `darken(skinColor, 0.08)` is a naive RGB multiply;
-  on the two darkest skins (`avatarData.ts:25-26`) it shifts value by ~6/255,
-  i.e. invisibly. Meanwhile blush is a fixed `#F4A0A0` at 0.6 opacity
-  (`:331-332`), which on `#4A2518` reads as two bright pink stripes. Derive
-  shading by hue-shift; scale blush opacity to skin luminance.
+- ~~`darken(skinColor, 0.08)` is a naive RGB multiply~~ — **fixed in PR #39.**
+  Confirmed: it shifted the deepest skin by 0.016 lightness against 0.071 for
+  the palest. `shade()` in `palette.ts` drops lightness by a fixed amount while
+  holding chroma; `flush()` derives blush from the skin. Two earlier
+  implementations each fixed half of it — blending toward a fixed dark tone
+  leaves near-black hair *lighter* than its shadow, and holding HSL saturation
+  turns pale skin pink. Both are regression tests now.
 - ~~`CUP_PALETTE` H identical to C~~ — **fixed in PR #33**, handle now uses the
   saucer shade.
 - ~~`PALM` crown misaligned~~ — **not a real defect.** See corrections.
 - `MOON` — 2 always-empty trailing columns. Cosmetic; see corrections.
 
-Then add a blink frame every 4–6s and a 2-frame idle. Today `pixel-idle`
-(`globals.css:107-109`) translates the whole sprite up 3px; no sprite's own
-pixels ever change, so scenes read as posed dolls.
+~~Then add a blink frame every 4–6s and a 2-frame idle.~~ **Blink shipped in
+PR #39** (4–6.5s, jittered, 130ms, off under `prefers-reduced-motion`). The
+2-frame idle did *not*: `pixel-idle` still carries the whole motion, and a
+second body frame on top of it looked busy in the static dump. Worth trying
+once someone has watched the current version move.
+
+Also still open from this item: `PixelCharacter` accepts an `outline` prop and
+nothing passes one. Turning it on is the remaining half of item 4, and it is a
+visual call — the dump shows a fairly heavy keyline at `ART_PX`.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,8 +6,8 @@ files. Was `ROADMAP.local.md` and gitignored until PR #38 — it is tracked now,
 so the file:line references land in diffs and want keeping honest.
 
 Last updated: 2026-08-13. PRs #35–#38 merged — 31 commits on main.
-PR #39 (characters + pets onto PixelSprite, 5 commits) open on
-`art/characters-on-pixelsprite`.
+PR #39 (characters + pets onto PixelSprite, 7 commits) reviewed and approved on
+localhost, merging.
 Migrations 016–019 are applied to Supabase (019 verified in production: the
 CHECK now lists 'grocery' and keeps 'lofi' for history).
 
@@ -44,7 +44,8 @@ CHECK now lists 'grocery' and keeps 'lofi' for history).
       question below is **answered**: kept at one hour (the owner's spec) and
       fixed the daily repeat with the per-cycle shuffle instead of changing the
       interval. Home's picker is now `WorldNowCard`.
-- [x] **7b-char. Characters + pets onto `PixelSprite`** — PR #39, 5 commits.
+- [x] **7b-char. Characters + pets onto `PixelSprite`** — PR #39, 6 commits.
+      Owner reviewed on localhost: pets, walk and sitting all approved.
       Both sprites are layered string maps now (`lib/characterMaps.ts`,
       `lib/petMaps.ts`) composited by `lib/pixelMap.ts`. The avatar blinks;
       pets went 10×11 → 9×7 (0.46× a person → 0.29×). `darken()` is gone —
@@ -53,6 +54,10 @@ CHECK now lists 'grocery' and keeps 'lofi' for history).
 - [ ] **2. Premium button on home is a no-op** — under an hour. "Unlock all
       world themes" already removed by #38 (nothing left to gate); the other
       three claims on that list are still fiction and still this item's job.
+      Note item 12 makes pets the one premium feature with real depth.
+- [ ] **12. Pets level up and grow** — owner's idea, 2026-08-13. Written up
+      below. Mostly drawing: growth has to be maps with more cells, never a
+      bigger `size`. Levels want deriving from focus history, not storing.
 
 ## ⚠️ Corrections to this file
 
@@ -412,6 +417,61 @@ boundary repeats.
 **Not verified:** nothing here has been looked at in a browser. Worth checking
 by eye — the countdown ticking on home, and that a session left open across a
 :30 keeps its own world rather than swapping under you.
+
+---
+
+## 12. Pets level up and grow  ·  owner's idea, 2026-08-13, not started
+
+The owner's call after previewing #39: pets earn levels and get **bigger** as
+they level. A companion that visibly changes because of hours you actually put
+in is the first thing in the product that rewards returning, and it lands on a
+pet system that is now cheap to extend.
+
+**Growth is redrawn maps, not a scale multiplier.** This is the whole design
+constraint and it is not negotiable — it is the same lesson as the density
+collapse in 3b/7b. A sprite's apparent pixel size *is* its scale, so rendering
+the 9×7 cat at `size={4}` is not a bigger cat, it is the same cat with bigger
+pixels next to a person whose pixels didn't change. Growth means a map with
+*more cells* at the same `ART_PX`. Budget three sizes:
+
+| stage | cells | px at ART_PX | vs. a person |
+|---|---|---|---|
+| young | 7×5 | 21×15 | 0.21× |
+| grown (today's art) | 9×7 | 27×21 | 0.29× |
+| full | 11×9 | 33×27 | 0.38× |
+
+Three maps per pet × four pets = twelve, plus two walk frames each. That is the
+real cost of this feature and it is mostly drawing. Stop at 0.38×: a companion
+taller than half its owner stops reading as a pet.
+
+**Derive the level, don't store it.** Same instinct as the rotation (item 11)
+and for the same reason — a stored counter is a thing to migrate, resync and
+reconcile, and it can disagree with the history it is supposed to summarise.
+Total focus minutes already exist in `sessions`/`session_participants`, and
+`lib/useStats.ts` already reads them. `level = f(totalFocusMinutes)` needs no
+new column, cannot drift, and is automatically right for existing users on the
+day it ships — everyone's back catalogue counts.
+
+Open questions worth settling before drawing anything:
+
+- **Per user or per pet type?** Per user is one number and reuses the stats
+  that exist. Per pet type means a real table and makes switching pets cost
+  progress, which is either the point or a punishment depending on taste.
+- **Does your partner see your pet's level?** They see the pet already
+  (`pet_changed` relays the type). If growth is only local, two people in the
+  same room see different animals, which is the same class of bug the world
+  rotation exists to prevent. So the level has to travel with the pet in
+  session state, which means the server derives it too — and the server has the
+  service key and the same rows, so that is cheap.
+- **What are the thresholds?** Wants to be slow enough to mean something and
+  fast enough that a new user sees one change. First growth inside a week of
+  ordinary use is a reasonable target.
+- **Does it interact with premium?** Pets are the one thing actually gated
+  today (`PetPicker.tsx:20,34`), so levelling is currently a premium-only
+  feature by accident. Worth deciding deliberately — see item 2.
+
+Prerequisite: none. #39 put both sprites on string maps, so adding sizes is
+adding maps to `lib/petMaps.ts` and a selector, not touching a component.
 
 ---
 

--- a/client/src/components/GameWorld.test.tsx
+++ b/client/src/components/GameWorld.test.tsx
@@ -3,6 +3,8 @@ import { render } from "@testing-library/react";
 import GameWorld, { type GamePhase } from "./GameWorld";
 import { DEFAULT_AVATAR } from "@/lib/avatarData";
 import { ART_PX, GROUND } from "@/lib/scene";
+import { CHAR_W, CHAR_H } from "@/lib/characterMaps";
+import { PET_W, PET_H } from "@/lib/petMaps";
 
 // The scene used to place characters with `calc(41.7% + 8px)` on `left` and
 // spin the break-phase controller ±10°. Both put sprite edges between device
@@ -135,9 +137,23 @@ describe("one art pixel", () => {
 
   it("draws characters and their pets on the same pixel grid", () => {
     const { container } = renderScene("waiting", 0, 0, true);
-    // The scenery is deliberately not here yet — see the deviation table in
-    // WorldDecorations. These two are what stand side by side in one frame.
-    expect(density(container, "0 0 16 24")).toBe(ART_PX);
-    expect(density(container, "0 0 10 11")).toBe(ART_PX);
+    // Read the grids from the art rather than writing them out here — this
+    // test hardcoded "0 0 10 11" and had to be edited when the pets were
+    // redrawn, which is the kind of edit that quietly turns a check into a
+    // restatement of whatever the code now does.
+    expect(density(container, `0 0 ${CHAR_W} ${CHAR_H}`)).toBe(ART_PX);
+    expect(density(container, `0 0 ${PET_W} ${PET_H}`)).toBe(ART_PX);
+  });
+
+  it("keeps pets to something like an animal's share of a person's height", () => {
+    // Pets were 10x11 against a 16x24 person: 0.46x a human, where a cat is
+    // about 0.25x. They only looked right while they were rendering at a
+    // smaller pixel than the character, which is the mismatch ART_PX removed.
+    //
+    // A guard, not an A/B — it reads the constants the art declares, so it
+    // holds whatever the components do. The test above is the one that fails
+    // against the previous commit.
+    expect(PET_H / CHAR_H).toBeLessThan(0.35);
+    expect(PET_H / CHAR_H).toBeGreaterThan(0.2);
   });
 });

--- a/client/src/components/PetCharacter.tsx
+++ b/client/src/components/PetCharacter.tsx
@@ -3,17 +3,15 @@ import { useEffect, useState } from "react";
 import type { AnimState } from "./PixelCharacter";
 import type { PetType } from "@/lib/types";
 import { ART_PX } from "@/lib/scene";
+import { PET_ART } from "@/lib/petMaps";
+import PixelSprite from "./PixelSprite";
 
 // ─────────────────────────────────────────────────────────────────────────────
-// PetCharacter — tiny SVG pixel art pets (10×11 viewBox)
-// All pets match their owner's animation state.
+// PetCharacter — the companion that walks with you.
 //
-// `size` is one art pixel in CSS px, the same unit the character uses. Pets
-// used to render at 2 while the character rendered at 3, which is a different
-// pixel grid in the same frame. On ART_PX they are 30×33 rather than 20×22 —
-// correct density, but large next to a 48×72 person. Keeping the old apparent
-// size at one density means redrawing the maps at roughly 7×7 cells, which is
-// the item 7b redraw.
+// The art is in `lib/petMaps.ts`. `size` is one art pixel in CSS px, the same
+// unit the character uses — pets used to render at 2 while the character
+// rendered at 3, which is two pixel grids in one frame.
 // ─────────────────────────────────────────────────────────────────────────────
 
 interface PetCharacterProps {
@@ -21,134 +19,17 @@ interface PetCharacterProps {
   anim?: AnimState;
   facing?: "right" | "left";
   size?: number;
+  outline?: string;
 }
 
-// Cat pixel art (10×11)
-function CatPixels({ legUp }: { legUp: boolean }) {
-  return (
-    <>
-      {/* Ears */}
-      <rect x={1} y={0} width={2} height={2} fill="#d4a373" />
-      <rect x={7} y={0} width={2} height={2} fill="#d4a373" />
-      <rect x={2} y={0} width={1} height={1} fill="#f4a261" />
-      <rect x={7} y={0} width={1} height={1} fill="#f4a261" />
-      {/* Head */}
-      <rect x={1} y={2} width={8} height={5} fill="#e9c46a" />
-      {/* Eyes */}
-      <rect x={2} y={3} width={2} height={2} fill="#2d6a4f" />
-      <rect x={6} y={3} width={2} height={2} fill="#2d6a4f" />
-      <rect x={2} y={3} width={1} height={1} fill="white" />
-      <rect x={6} y={3} width={1} height={1} fill="white" />
-      {/* Nose */}
-      <rect x={4} y={5} width={2} height={1} fill="#e76f51" />
-      {/* Body */}
-      <rect x={2} y={7} width={6} height={3} fill="#e9c46a" />
-      {/* Tail */}
-      <rect x={8} y={6} width={2} height={1} fill="#d4a373" />
-      <rect x={9} y={5} width={1} height={2} fill="#d4a373" />
-      {/* Legs */}
-      <rect x={2} y={legUp ? 9 : 10} width={2} height={1} fill="#d4a373" />
-      <rect x={6} y={legUp ? 10 : 9} width={2} height={1} fill="#d4a373" />
-    </>
-  );
-}
-
-// Dog pixel art (10×11)
-function DogPixels({ legUp }: { legUp: boolean }) {
-  return (
-    <>
-      {/* Ears (floppy) */}
-      <rect x={0} y={2} width={2} height={3} fill="#c9a46e" />
-      <rect x={8} y={2} width={2} height={3} fill="#c9a46e" />
-      {/* Head */}
-      <rect x={1} y={1} width={8} height={5} fill="#e8c99a" />
-      {/* Snout */}
-      <rect x={3} y={4} width={4} height={2} fill="#d4a373" />
-      {/* Eyes */}
-      <rect x={2} y={2} width={2} height={2} fill="#4a2800" />
-      <rect x={6} y={2} width={2} height={2} fill="#4a2800" />
-      <rect x={2} y={2} width={1} height={1} fill="white" />
-      <rect x={6} y={2} width={1} height={1} fill="white" />
-      {/* Nose */}
-      <rect x={4} y={4} width={2} height={1} fill="#2a1800" />
-      {/* Body */}
-      <rect x={2} y={6} width={6} height={4} fill="#e8c99a" />
-      {/* Tail */}
-      <rect x={8} y={5} width={1} height={2} fill="#c9a46e" />
-      <rect x={9} y={4} width={1} height={2} fill="#c9a46e" />
-      {/* Legs */}
-      <rect x={2} y={legUp ? 9 : 10} width={2} height={1} fill="#c9a46e" />
-      <rect x={6} y={legUp ? 10 : 9} width={2} height={1} fill="#c9a46e" />
-    </>
-  );
-}
-
-// Dragon pixel art (10×11) — premium
-function DragonPixels({ legUp }: { legUp: boolean }) {
-  return (
-    <>
-      {/* Horns */}
-      <rect x={3} y={0} width={1} height={2} fill="#7c3aed" />
-      <rect x={6} y={0} width={1} height={2} fill="#7c3aed" />
-      {/* Head */}
-      <rect x={1} y={2} width={8} height={4} fill="#a78bfa" />
-      {/* Snout */}
-      <rect x={3} y={4} width={4} height={2} fill="#8b5cf6" />
-      {/* Eyes */}
-      <rect x={2} y={3} width={2} height={2} fill="#ffd700" />
-      <rect x={6} y={3} width={2} height={2} fill="#ffd700" />
-      <rect x={2} y={3} width={1} height={1} fill="white" />
-      <rect x={6} y={3} width={1} height={1} fill="white" />
-      {/* Wings */}
-      <rect x={0} y={6} width={2} height={2} fill="#7c3aed" />
-      <rect x={8} y={6} width={2} height={2} fill="#7c3aed" />
-      {/* Body */}
-      <rect x={2} y={6} width={6} height={4} fill="#a78bfa" />
-      {/* Tail */}
-      <rect x={8} y={8} width={2} height={1} fill="#7c3aed" />
-      {/* Legs */}
-      <rect x={2} y={legUp ? 9 : 10} width={2} height={1} fill="#8b5cf6" />
-      <rect x={6} y={legUp ? 10 : 9} width={2} height={1} fill="#8b5cf6" />
-    </>
-  );
-}
-
-// Rabbit pixel art (10×11)
-function RabbitPixels({ legUp }: { legUp: boolean }) {
-  return (
-    <>
-      {/* Ears (tall) */}
-      <rect x={2} y={0} width={2} height={4} fill="#f0e6d3" />
-      <rect x={6} y={0} width={2} height={4} fill="#f0e6d3" />
-      <rect x={3} y={0} width={1} height={3} fill="#f4a0a0" />
-      <rect x={6} y={0} width={1} height={3} fill="#f4a0a0" />
-      {/* Head */}
-      <rect x={1} y={3} width={8} height={5} fill="#f0e6d3" />
-      {/* Eyes */}
-      <rect x={2} y={4} width={2} height={2} fill="#e91e8c" />
-      <rect x={6} y={4} width={2} height={2} fill="#e91e8c" />
-      <rect x={2} y={4} width={1} height={1} fill="white" />
-      <rect x={6} y={4} width={1} height={1} fill="white" />
-      {/* Nose */}
-      <rect x={4} y={6} width={2} height={1} fill="#f4a0a0" />
-      {/* Body */}
-      <rect x={2} y={8} width={6} height={2} fill="#f0e6d3" />
-      {/* Fluffy tail */}
-      <rect x={8} y={8} width={2} height={2} fill="white" />
-      {/* Legs */}
-      <rect x={2} y={legUp ? 9 : 10} width={2} height={1} fill="#e0d0bc" />
-      <rect x={6} y={legUp ? 10 : 9} width={2} height={1} fill="#e0d0bc" />
-    </>
-  );
-}
-
-// ── Main Component ─────────────────────────────────────────────────────────
+const STEP_MS = 250;
 
 export default function PetCharacter({
   type,
   anim = "idle",
   facing = "right",
   size = ART_PX,
+  outline,
 }: PetCharacterProps) {
   const [walkFrame, setWalkFrame] = useState(0);
 
@@ -156,43 +37,26 @@ export default function PetCharacter({
     // See PixelCharacter: resetting the frame in the effect body was a
     // synchronous setState, so the resting frame is derived instead.
     if (anim !== "walk") return;
-    const id = setInterval(() => setWalkFrame((f) => (f + 1) % 2), 250);
+    const id = setInterval(() => setWalkFrame((f) => (f + 1) % 2), STEP_MS);
     return () => clearInterval(id);
   }, [anim]);
 
   const frame = anim === "walk" ? walkFrame : 0;
+  const art = PET_ART[type];
 
   let animClass = "";
   if (anim === "idle") animClass = "pixel-idle";
   if (anim === "jump") animClass = "pixel-jump";
   if (anim === "float") animClass = "pixel-float";
 
-  const legUp = frame === 0;
-
-  const PetPixels = {
-    cat: CatPixels,
-    dog: DogPixels,
-    dragon: DragonPixels,
-    rabbit: RabbitPixels,
-  }[type];
-
   return (
-    // 11 rows, not 10: the planted foot lives on row 10. Every pet shares the
-    // grid so they stay the same scale as each other.
-    <svg
-      viewBox="0 0 10 11"
-      width={10 * size}
-      height={11 * size}
+    <PixelSprite
+      map={art.frames[frame]}
+      palette={art.palette}
+      scale={size}
+      outline={outline}
       className={animClass}
-      style={{
-        // See PixelCharacter: image-rendering is a raster hint, inert on
-        // vector geometry. shapeRendering is the one that does the work.
-        shapeRendering: "crispEdges",
-        transform: facing === "left" ? "scaleX(-1)" : undefined,
-        display: "block",
-      }}
-    >
-      <PetPixels legUp={legUp} />
-    </svg>
+      style={{ transform: facing === "left" ? "scaleX(-1)" : undefined }}
+    />
   );
 }

--- a/client/src/components/PixelCharacter.tsx
+++ b/client/src/components/PixelCharacter.tsx
@@ -1,27 +1,28 @@
 "use client";
-import { useEffect, useState } from "react";
-import type { AvatarConfig, HairStyle, EyeStyle } from "@/lib/avatarData";
+import { useEffect, useMemo, useState } from "react";
+import { useReducedMotion } from "framer-motion";
+import type { AvatarConfig } from "@/lib/avatarData";
 import { ART_PX } from "@/lib/scene";
+import {
+  characterMap,
+  characterPalette,
+  WALK_POSES,
+  type CharacterPose,
+} from "@/lib/characterMaps";
+import PixelSprite from "./PixelSprite";
 
 // ─────────────────────────────────────────────────────────────────────────────
-// PixelCharacter — SVG-based 8-bit character renderer
+// PixelCharacter — the avatar.
 //
-// ViewBox: 0 0 16 24  (16 × 24 "pixels")
-// Displayed at: size * 16 × size * 24  (ART_PX → 48×72px)
+// The art lives in `lib/characterMaps.ts` as layered string maps; this file is
+// only the timing and the pose choice. It used to be ~90 `<rect>` elements with
+// their coordinates written into the JSX, which is why the character was the
+// one sprite in the app that couldn't be outlined or blinked without somebody
+// editing numbers by hand.
 //
 // `size` is one art pixel in CSS px. It defaults to ART_PX and every call site
 // passes ART_PX — a character rendering at a different pixel size to the scene
 // around it is the thing ART_PX exists to prevent, not a knob.
-//
-// Layout:
-//   y=0–3   Hair top
-//   y=3–10  Head / face  (skin)
-//   y=6–7   Eyes
-//   y=9     Blush marks
-//   y=11    Neck
-//   y=12–17 Body/outfit + Arms
-//   y=18–22 Legs
-//   y=23    Feet
 // ─────────────────────────────────────────────────────────────────────────────
 
 export type AnimState = "idle" | "walk" | "jump" | "sit" | "float";
@@ -30,142 +31,59 @@ interface PixelCharacterProps extends AvatarConfig {
   anim?: AnimState;
   facing?: "right" | "left";
   size?: number;
+  /**
+   * Draw a keyline around the silhouette. Off by default; on the Space world a
+   * dark-haired character genuinely disappears into `#04001A`.
+   */
+  outline?: string;
   className?: string;
 }
 
-// Darken a hex color by a ratio (0 = same, 1 = black)
-function darken(hex: string, ratio = 0.25): string {
-  const n = parseInt(hex.replace("#", ""), 16);
-  const r = Math.max(0, ((n >> 16) & 0xff) * (1 - ratio)) | 0;
-  const g = Math.max(0, ((n >> 8) & 0xff) * (1 - ratio)) | 0;
-  const b = Math.max(0, (n & 0xff) * (1 - ratio)) | 0;
-  return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
+const WALK_FRAME_MS = 180;
+
+// Real blinks are quick and irregular. A fixed interval reads as a tic.
+const BLINK_MIN_MS = 4000;
+const BLINK_MAX_MS = 6500;
+const BLINK_HOLD_MS = 130;
+
+/**
+ * True for the ~130 ms a blink lasts.
+ *
+ * Nothing in this sprite used to change its own pixels — `pixel-idle`
+ * translates the whole thing up three px and back — so a scene of people
+ * standing still read as a scene of dolls. A blink is the cheapest frame that
+ * fixes that, and it costs one row of the map.
+ */
+function useBlink(enabled: boolean): boolean {
+  const [blinking, setBlinking] = useState(false);
+
+  useEffect(() => {
+    // No synchronous setState on the disabled path: that is a cascading
+    // render, and it is why the walk frame is derived rather than reset here.
+    if (!enabled) return;
+    let hold: ReturnType<typeof setTimeout>;
+    let next: ReturnType<typeof setTimeout>;
+    const schedule = () => {
+      next = setTimeout(
+        () => {
+          setBlinking(true);
+          hold = setTimeout(() => {
+            setBlinking(false);
+            schedule();
+          }, BLINK_HOLD_MS);
+        },
+        BLINK_MIN_MS + Math.random() * (BLINK_MAX_MS - BLINK_MIN_MS),
+      );
+    };
+    schedule();
+    return () => {
+      clearTimeout(hold);
+      clearTimeout(next);
+    };
+  }, [enabled]);
+
+  return enabled && blinking;
 }
-
-// ── Hair Layers ───────────────────────────────────────────────────────────
-
-function HairBack({ style, color }: { style: HairStyle; color: string }) {
-  if (style === "long") {
-    // Side drapes behind the body
-    return (
-      <>
-        <rect x={1} y={4} width={2} height={9} fill={color} />
-        <rect x={13} y={4} width={2} height={9} fill={color} />
-      </>
-    );
-  }
-  return null;
-}
-
-function HairFront({ style, color }: { style: HairStyle; color: string }) {
-  const dark = darken(color, 0.15);
-  switch (style) {
-    case "bob":
-      return (
-        <>
-          <rect x={3} y={0} width={10} height={4} fill={color} />
-          <rect x={2} y={2} width={1} height={3} fill={color} />
-          <rect x={13} y={2} width={1} height={3} fill={color} />
-          {/* subtle shading line */}
-          <rect x={3} y={3} width={10} height={1} fill={dark} />
-        </>
-      );
-    case "mohawk":
-      return (
-        <>
-          <rect x={7} y={0} width={2} height={6} fill={color} />
-          <rect x={6} y={2} width={4} height={2} fill={color} />
-          <rect x={5} y={3} width={6} height={1} fill={dark} />
-        </>
-      );
-    case "long":
-      return (
-        <>
-          <rect x={3} y={0} width={10} height={4} fill={color} />
-          <rect x={2} y={2} width={1} height={3} fill={color} />
-          <rect x={13} y={2} width={1} height={3} fill={color} />
-          <rect x={3} y={3} width={10} height={1} fill={dark} />
-        </>
-      );
-    case "spiky":
-      return (
-        <>
-          {/* Base */}
-          <rect x={4} y={2} width={8} height={2} fill={color} />
-          {/* Spikes */}
-          <rect x={4} y={0} width={2} height={3} fill={color} />
-          <rect x={7} y={0} width={2} height={4} fill={color} />
-          <rect x={10} y={0} width={2} height={3} fill={color} />
-          <rect x={4} y={0} width={2} height={1} fill={dark} />
-          <rect x={7} y={0} width={2} height={1} fill={dark} />
-          <rect x={10} y={0} width={2} height={1} fill={dark} />
-        </>
-      );
-    case "bald":
-    default:
-      return null;
-  }
-}
-
-// ── Eye Layers ─────────────────────────────────────────────────────────────
-
-function Eyes({ style }: { style: EyeStyle }) {
-  switch (style) {
-    case "anime":
-      return (
-        <>
-          {/* Left eye */}
-          <rect x={4} y={5} width={3} height={3} fill="#1a1a2e" />
-          <rect x={4} y={5} width={1} height={1} fill="white" />
-          {/* Right eye */}
-          <rect x={9} y={5} width={3} height={3} fill="#1a1a2e" />
-          <rect x={9} y={5} width={1} height={1} fill="white" />
-        </>
-      );
-    case "sleepy":
-      return (
-        <>
-          {/* Left eye — half-closed */}
-          <rect x={4} y={7} width={3} height={1} fill="#1a1a2e" />
-          <rect x={4} y={6} width={3} height={1} fill="#1a1a2e" opacity={0.4} />
-          {/* Right eye */}
-          <rect x={9} y={7} width={3} height={1} fill="#1a1a2e" />
-          <rect x={9} y={6} width={3} height={1} fill="#1a1a2e" opacity={0.4} />
-        </>
-      );
-    case "normal":
-    default:
-      return (
-        <>
-          {/* Left eye */}
-          <rect x={4} y={6} width={2} height={2} fill="#1a1a2e" />
-          <rect x={4} y={6} width={1} height={1} fill="white" />
-          {/* Right eye */}
-          <rect x={10} y={6} width={2} height={2} fill="#1a1a2e" />
-          <rect x={10} y={6} width={1} height={1} fill="white" />
-        </>
-      );
-  }
-}
-
-// ── Walk Frame Leg Positions ───────────────────────────────────────────────
-// Returns { leftLegY, rightLegY, leftFootY, rightFootY }
-function getWalkLegPos(frame: number) {
-  switch (frame % 4) {
-    case 0:
-      return { leftLegY: 17, rightLegY: 19, leftFootY: 22, rightFootY: 23 };
-    case 1:
-      return { leftLegY: 18, rightLegY: 18, leftFootY: 23, rightFootY: 23 };
-    case 2:
-      return { leftLegY: 19, rightLegY: 17, leftFootY: 23, rightFootY: 22 };
-    case 3:
-      return { leftLegY: 18, rightLegY: 18, leftFootY: 23, rightFootY: 23 };
-    default:
-      return { leftLegY: 18, rightLegY: 18, leftFootY: 23, rightFootY: 23 };
-  }
-}
-
-// ── Main Component ─────────────────────────────────────────────────────────
 
 export default function PixelCharacter({
   skinColor,
@@ -176,8 +94,10 @@ export default function PixelCharacter({
   anim = "idle",
   facing = "right",
   size = ART_PX,
+  outline,
   className,
 }: PixelCharacterProps) {
+  const reducedMotion = useReducedMotion();
   const [walkFrame, setWalkFrame] = useState(0);
 
   useEffect(() => {
@@ -185,160 +105,51 @@ export default function PixelCharacter({
     // setWalkFrame(0) synchronously here, which is a cascading render — the
     // resting frame is derived below instead.
     if (anim !== "walk") return;
-    const id = setInterval(() => setWalkFrame((f) => (f + 1) % 4), 180);
+    const id = setInterval(
+      () => setWalkFrame((f) => (f + 1) % WALK_POSES.length),
+      WALK_FRAME_MS,
+    );
     return () => clearInterval(id);
   }, [anim]);
 
-  // Anything that isn't a walk renders the neutral stance.
-  const frame = anim === "walk" ? walkFrame : 0;
+  const blinking = useBlink(!reducedMotion);
 
-  const pantsColor = darken(outfitColor, 0.3);
-  const shoeColor = "#2a2a2a";
-  const blushColor = "#F4A0A0";
+  const pose: CharacterPose =
+    anim === "walk" ? WALK_POSES[walkFrame] : anim === "sit" ? "sit" : "stand";
 
-  const w = 16 * size;
-  const h = 24 * size;
+  const map = useMemo(
+    () => characterMap({ hairStyle, eyeStyle }, pose, blinking),
+    [hairStyle, eyeStyle, pose, blinking],
+  );
 
-  // Determine animation class
+  const palette = useMemo(
+    () =>
+      characterPalette({
+        skinColor,
+        hairStyle,
+        hairColor,
+        eyeStyle,
+        outfitColor,
+      }),
+    [skinColor, hairStyle, hairColor, eyeStyle, outfitColor],
+  );
+
   let animClass = "";
   if (anim === "idle") animClass = "pixel-idle";
   if (anim === "jump") animClass = "pixel-jump";
   if (anim === "float") animClass = "pixel-float";
   if (anim === "sit") animClass = "pixel-idle"; // gentle idle while sitting
 
-  const legPos =
-    anim === "walk"
-      ? getWalkLegPos(frame)
-      : { leftLegY: 18, rightLegY: 18, leftFootY: 23, rightFootY: 23 };
-
-  // Sit pose offsets — legs come forward, arms go down
-  const isSitting = anim === "sit";
-
   return (
-    <svg
-      viewBox="0 0 16 24"
-      width={w}
-      height={h}
+    <PixelSprite
+      map={map}
+      palette={palette}
+      scale={size}
+      outline={outline}
       className={`${animClass} ${className ?? ""}`}
-      style={{
-        // shapeRendering is the vector control; image-rendering only affects
-        // raster scaling and does nothing to <rect>s.
-        shapeRendering: "crispEdges",
-        transform: facing === "left" ? "scaleX(-1)" : undefined,
-        display: "block",
-      }}
-    >
-      {/* ── HAIR BACK (behind body for long hair) ── */}
-      <HairBack style={hairStyle} color={hairColor} />
-
-      {/* ── ARMS (sleeve cap + forearm) ── */}
-      {isSitting ? (
-        // Sitting: arms resting at sides
-        <>
-          {/* Left sleeve cap */}
-          <rect x={1} y={14} width={3} height={2} fill={outfitColor} />
-          {/* Left forearm (skin) */}
-          <rect x={1} y={16} width={3} height={2} fill={skinColor} />
-          {/* Right sleeve cap */}
-          <rect x={12} y={14} width={3} height={2} fill={outfitColor} />
-          {/* Right forearm (skin) */}
-          <rect x={12} y={16} width={3} height={2} fill={skinColor} />
-        </>
-      ) : (
-        <>
-          {/* Left arm */}
-          <g
-            transform={
-              anim === "walk" && frame % 4 < 2 ? "translate(0,1)" : ""
-            }
-          >
-            <rect x={1} y={12} width={3} height={2} fill={outfitColor} />
-            <rect x={1} y={14} width={3} height={3} fill={skinColor} />
-          </g>
-          {/* Right arm */}
-          <g
-            transform={
-              anim === "walk" && frame % 4 >= 2 ? "translate(0,1)" : ""
-            }
-          >
-            <rect x={12} y={12} width={3} height={2} fill={outfitColor} />
-            <rect x={12} y={14} width={3} height={3} fill={skinColor} />
-          </g>
-        </>
-      )}
-
-      {/* ── BODY/OUTFIT ── */}
-      <rect x={4} y={12} width={8} height={6} fill={outfitColor} />
-      {/* Collar detail */}
-      <rect
-        x={6}
-        y={12}
-        width={4}
-        height={1}
-        fill={darken(outfitColor, 0.15)}
-      />
-
-      {/* ── LEGS ── */}
-      {isSitting ? (
-        // Sitting legs: folded forward
-        <>
-          <rect x={3} y={20} width={4} height={3} fill={pantsColor} />
-          <rect x={9} y={20} width={4} height={3} fill={pantsColor} />
-          {/* Sitting feet */}
-          <rect x={3} y={23} width={4} height={1} fill={shoeColor} />
-          <rect x={9} y={23} width={4} height={1} fill={shoeColor} />
-        </>
-      ) : (
-        <>
-          <rect
-            x={4}
-            y={legPos.leftLegY}
-            width={3}
-            height={5}
-            fill={pantsColor}
-          />
-          <rect
-            x={9}
-            y={legPos.rightLegY}
-            width={3}
-            height={5}
-            fill={pantsColor}
-          />
-          {/* Feet */}
-          <rect
-            x={3}
-            y={legPos.leftFootY}
-            width={4}
-            height={1}
-            fill={shoeColor}
-          />
-          <rect
-            x={9}
-            y={legPos.rightFootY}
-            width={4}
-            height={1}
-            fill={shoeColor}
-          />
-        </>
-      )}
-
-      {/* ── NECK ── */}
-      <rect x={6} y={11} width={4} height={1} fill={skinColor} />
-
-      {/* ── HEAD/FACE ── */}
-      <rect x={3} y={3} width={10} height={8} fill={skinColor} />
-      {/* Subtle shading on chin */}
-      <rect x={3} y={10} width={10} height={1} fill={darken(skinColor, 0.08)} />
-
-      {/* ── EYES ── */}
-      <Eyes style={eyeStyle} />
-
-      {/* ── BLUSH ── */}
-      <rect x={3} y={8} width={2} height={1} fill={blushColor} opacity={0.6} />
-      <rect x={11} y={8} width={2} height={1} fill={blushColor} opacity={0.6} />
-
-      {/* ── HAIR FRONT ── */}
-      <HairFront style={hairStyle} color={hairColor} />
-    </svg>
+      // scaleX(-1) is a whole-sprite mirror on integer bounds, so it is one of
+      // the few transforms that doesn't resample the art.
+      style={{ transform: facing === "left" ? "scaleX(-1)" : undefined }}
+    />
   );
 }

--- a/client/src/lib/characterMaps.test.ts
+++ b/client/src/lib/characterMaps.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect } from "vitest";
+import {
+  characterMap,
+  characterPalette,
+  CHAR_W,
+  CHAR_H,
+  WALK_POSES,
+  type CharacterPose,
+} from "./characterMaps";
+import { PET_ART, PET_W, PET_H } from "./petMaps";
+import { keysUsed } from "./pixelMap";
+import {
+  DEFAULT_AVATAR,
+  SKIN_COLORS,
+  HAIR_COLORS,
+  OUTFIT_COLORS,
+} from "./avatarData";
+import type { AvatarConfig, EyeStyle, HairStyle } from "./avatarData";
+import { PET_OPTIONS } from "./types";
+
+const HAIR: HairStyle[] = ["bob", "long", "mohawk", "spiky", "bald"];
+const EYES: EyeStyle[] = ["normal", "anime", "sleepy"];
+const POSES: CharacterPose[] = ["stand", ...WALK_POSES, "sit"];
+
+const avatar = (over: Partial<AvatarConfig> = {}): AvatarConfig => ({
+  ...DEFAULT_AVATAR,
+  ...over,
+});
+
+/** Every combination the avatar creator can produce. */
+function* everyLook() {
+  for (const hairStyle of HAIR) {
+    for (const eyeStyle of EYES) {
+      for (const blinking of [false, true]) {
+        for (const pose of POSES) {
+          yield { hairStyle, eyeStyle, pose, blinking };
+        }
+      }
+    }
+  }
+}
+
+describe("character maps", () => {
+  it("fills the canvas exactly, in every look", () => {
+    for (const { hairStyle, eyeStyle, pose, blinking } of everyLook()) {
+      const map = characterMap({ hairStyle, eyeStyle }, pose, blinking);
+      const label = `${hairStyle}/${eyeStyle}/${pose}${blinking ? "/blink" : ""}`;
+      expect(map.length, label).toBe(CHAR_H);
+      for (const row of map) expect(row.length, label).toBe(CHAR_W);
+    }
+  });
+
+  it("only ever uses keys the palette can colour", () => {
+    // PixelSprite skips a character with no palette entry — silently, and it
+    // looks exactly like a hole in the sprite.
+    const palette = characterPalette(avatar());
+    for (const { hairStyle, eyeStyle, pose, blinking } of everyLook()) {
+      for (const key of keysUsed(characterMap({ hairStyle, eyeStyle }, pose, blinking))) {
+        expect(palette[key], `no palette entry for "${key}"`).toBeTruthy();
+      }
+    }
+  });
+
+  it("stands on the bottom row in every standing pose", () => {
+    // Not the sit pose: sitting feet are tucked, which is the point of it.
+    for (const pose of ["stand", ...WALK_POSES] as CharacterPose[]) {
+      const map = characterMap(DEFAULT_AVATAR, pose);
+      expect(map[CHAR_H - 1].includes("F"), pose).toBe(true);
+    }
+  });
+
+  it("draws a face symmetric about the head's centre line", () => {
+    // Shape, not colour: the catchlight sits on the same side of *both* eyes,
+    // because there is one light source. Folding W into E is what makes this a
+    // test of where the features are rather than of how they're lit.
+    for (const eyeStyle of EYES) {
+      const map = characterMap({ hairStyle: "bald", eyeStyle }, "stand");
+      for (let y = 3; y < 12; y++) {
+        const row = map[y].replaceAll("W", "E");
+        const mirrored = [...row].reverse().join("");
+        expect(mirrored, `row ${y} of ${eyeStyle} is not symmetric`).toBe(row);
+      }
+    }
+  });
+
+  it("centres the eyes on the head's axis", () => {
+    // Reported once as a defect — `anime` and `sleepy` supposedly centred on
+    // 7.5. They didn't, and nothing had ever checked. The head spans columns
+    // 3-12, so the axis is 8.
+    for (const eyeStyle of EYES) {
+      const map = characterMap({ hairStyle: "bald", eyeStyle }, "stand");
+      const columns = map.flatMap((row) =>
+        [...row].flatMap((cell, x) => (cell === "E" || cell === "W" ? [x] : [])),
+      );
+      expect(columns.length, eyeStyle).toBeGreaterThan(0);
+      const midpoint =
+        (Math.min(...columns) + Math.max(...columns) + 1) / 2;
+      expect(midpoint, `${eyeStyle} eyes are off-axis`).toBe(8);
+    }
+  });
+
+  it("closes the eyes on a blink, and changes nothing else", () => {
+    // The whole reason for the string maps: before this the sprite's own
+    // pixels never changed in any state, so a room of people reads as dolls.
+    for (const eyeStyle of EYES) {
+      const open = characterMap({ hairStyle: "bob", eyeStyle }, "stand", false);
+      const shut = characterMap({ hairStyle: "bob", eyeStyle }, "stand", true);
+      expect(open).not.toEqual(shut);
+      const differing = open
+        .map((row, y) => (row === shut[y] ? -1 : y))
+        .filter((y) => y >= 0);
+      // Eyes live in rows 5-7 depending on style; nothing outside may move.
+      for (const y of differing) expect(y).toBeGreaterThanOrEqual(5);
+      for (const y of differing) expect(y).toBeLessThanOrEqual(7);
+    }
+  });
+
+  it("moves something between every pair of walk frames", () => {
+    const frames = WALK_POSES.map((p) => characterMap(DEFAULT_AVATAR, p).join("\n"));
+    // Contact / passing / contact / passing: frames 1 and 3 are the same pose
+    // by design, but consecutive frames must differ or the walk is a still.
+    for (let i = 0; i < frames.length; i++) {
+      expect(frames[i]).not.toBe(frames[(i + 1) % frames.length]);
+    }
+  });
+
+  it("distinguishes long hair from bob by the drapes behind the head", () => {
+    // Reported once as "long is identical to bob". The fringes *are*
+    // identical; the side drapes are the difference.
+    const bob = characterMap({ hairStyle: "bob", eyeStyle: "normal" }, "stand");
+    const long = characterMap({ hairStyle: "long", eyeStyle: "normal" }, "stand");
+    expect(bob).not.toEqual(long);
+    expect(bob.slice(0, 4)).toEqual(long.slice(0, 4)); // same fringe
+  });
+});
+
+describe("character palette", () => {
+  it("gives every colour a distinct shadow", () => {
+    for (const skin of SKIN_COLORS) {
+      for (const hair of HAIR_COLORS) {
+        for (const outfit of OUTFIT_COLORS) {
+          const p = characterPalette(
+            avatar({
+              skinColor: skin.hex,
+              hairColor: hair.hex,
+              outfitColor: outfit.hex,
+            }),
+          );
+          expect(p.s, `skin ${skin.label}`).not.toBe(p.S);
+          expect(p.h, `hair ${hair.label}`).not.toBe(p.H);
+          expect(p.o, `outfit ${outfit.label}`).not.toBe(p.O);
+          expect(p.P, `trousers ${outfit.label}`).not.toBe(p.O);
+        }
+      }
+    }
+  });
+
+  it("does not render two of a sprite's own colours identically", () => {
+    // Two palette keys with the same value merge into one shape — that was a
+    // real bug once, in the coffee cup's handle.
+    const p = characterPalette(DEFAULT_AVATAR);
+    const values = Object.values(p).map((v) => v.toLowerCase());
+    expect(new Set(values).size).toBe(values.length);
+  });
+});
+
+describe("pet maps", () => {
+  const PETS = PET_OPTIONS.map((o) => o.type);
+
+  it("draws every pet on one grid, fully inside it", () => {
+    for (const type of PETS) {
+      for (const frame of PET_ART[type].frames) {
+        expect(frame.length, type).toBe(PET_H);
+        for (const row of frame) expect(row.length, type).toBe(PET_W);
+      }
+    }
+  });
+
+  it("colours every key each pet uses", () => {
+    for (const type of PETS) {
+      const { frames, palette } = PET_ART[type];
+      for (const frame of frames) {
+        for (const key of keysUsed(frame)) {
+          expect(palette[key], `${type} has no colour for "${key}"`).toBeTruthy();
+        }
+      }
+    }
+  });
+
+  it("keeps both feet on the ground in both frames", () => {
+    // The regression: the cat and the rabbit each drew a leg one row below
+    // their viewBox, so each walked on one leg, alternating which.
+    for (const type of PETS) {
+      for (const [i, frame] of PET_ART[type].frames.entries()) {
+        const feet = [...frame[PET_H - 1]].filter((c) => c !== ".").length;
+        expect(feet, `${type} frame ${i}`).toBeGreaterThanOrEqual(4);
+      }
+    }
+  });
+
+  it("actually steps between frames", () => {
+    for (const type of PETS) {
+      const [a, b] = PET_ART[type].frames;
+      expect(a.join("\n"), type).not.toBe(b.join("\n"));
+    }
+  });
+
+  it("gives each pet a different silhouette", () => {
+    // At nine pixels wide the outline is all there is to tell them apart.
+    const shapes = PETS.map((type) =>
+      PET_ART[type].frames[0]
+        .map((row) => [...row].map((c) => (c === "." ? "." : "#")).join(""))
+        .join("\n"),
+    );
+    expect(new Set(shapes).size).toBe(PETS.length);
+  });
+});

--- a/client/src/lib/characterMaps.ts
+++ b/client/src/lib/characterMaps.ts
@@ -1,0 +1,288 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Character maps — the avatar as layered string maps.
+//
+// This was ~90 hand-placed `<rect x= y= width= height=>` elements with the
+// coordinates inline in JSX. That shape works exactly once: it cannot be
+// palette-swapped, outlined, blinked, or given a second idle frame without
+// somebody editing numbers by hand and hoping. Everything below is a picture
+// you can read, which is the point — the eyes are where the eyes look.
+//
+// Canvas is 16 x 24, unchanged. The whole scene is anchored to it: GROUND, the
+// name tag, MEET_HALF_WIDTH in useCharacterPosition. Redrawing at a different
+// size is a separate change from redrawing.
+//
+// ── The key alphabet ────────────────────────────────────────────────────────
+// Every layer uses these, so compositing is "last non-transparent wins" and no
+// two layers can disagree about what a key means.
+//
+//   S skin          s skin in shadow      B cheek
+//   H hair          h hair in shadow
+//   O outfit        o outfit in shadow    P trousers      F shoes
+//   E eye           W eye highlight       e lowered lid
+// ─────────────────────────────────────────────────────────────────────────────
+
+import type { PixelMap, PixelPalette } from "@/components/PixelSprite";
+import { overlay, place } from "./pixelMap";
+import { shade, flush, blend } from "./palette";
+import type { AvatarConfig, EyeStyle, HairStyle } from "./avatarData";
+
+export const CHAR_W = 16;
+export const CHAR_H = 24;
+
+const at = (top: number, block: readonly string[]) =>
+  place(top, block, CHAR_H, CHAR_W);
+
+// ── Hair behind the head ────────────────────────────────────────────────────
+// Only 'long' has any. The side drapes are what actually distinguish it from
+// 'bob' — the two share a fringe, which is a reasonable design and was once
+// mistaken for a duplication bug.
+
+const HAIR_BACK: Record<HairStyle, PixelMap | null> = {
+  long: at(4, [
+    ".HH..........HH.",
+    ".HH..........HH.",
+    ".HH..........HH.",
+    ".HH..........HH.",
+    ".HH..........HH.",
+    ".HH..........HH.",
+    ".Hh..........hH.",
+    ".Hh..........hH.",
+    ".hh..........hh.",
+  ]),
+  bob: null,
+  mohawk: null,
+  spiky: null,
+  bald: null,
+};
+
+// ── Torso ───────────────────────────────────────────────────────────────────
+// Constant across every pose; arms and legs are the parts that move.
+
+const TORSO = at(12, [
+  "....OOooooOO....",
+  "....OOOOOOOO....",
+  "....OOOOOOOO....",
+  "....OOOOOOOO....",
+  "....OOOOOOOO....",
+  "....OOOOOOOo....",
+]);
+
+// ── Arms ────────────────────────────────────────────────────────────────────
+// A sleeve cap in outfit colour and a forearm in skin. The walk drops one arm
+// by a row and then the other, which is the whole arm swing — at 16 px wide
+// there is no room for an arm to travel further than one pixel without leaving
+// the body.
+
+const ARM_BLOCK = [
+  ".OOO........OOO.",
+  ".OOO........OOO.",
+  ".SSS........SSS.",
+  ".SSS........SSS.",
+  ".sss........sss.",
+];
+
+const armsAt = (leftTop: number, rightTop: number): PixelMap =>
+  overlay(
+    at(leftTop, ARM_BLOCK.map((row) => row.slice(0, 8) + "........")),
+    at(rightTop, ARM_BLOCK.map((row) => "........" + row.slice(8))),
+  );
+
+const ARMS = {
+  neutral: armsAt(12, 12),
+  leftDown: armsAt(13, 12),
+  rightDown: armsAt(12, 13),
+  /** Sitting: both arms drop to rest beside the hips. */
+  sit: armsAt(14, 14),
+} as const;
+
+// ── Legs ────────────────────────────────────────────────────────────────────
+
+const LEGS_TOGETHER = at(18, [
+  "....PPP..PPP....",
+  "....PPP..PPP....",
+  "....PPP..PPP....",
+  "....PPP..PPP....",
+  "....PPP..PPP....",
+  "...FFFF..FFFF...",
+]);
+
+// The stride. Splaying from the hip rather than the knee — the first version
+// stepped out two pixels a row and came out bow-legged, which at 16 px wide
+// reads as a stance rather than a step.
+const LEGS_APART = at(18, [
+  "....PPP..PPP....",
+  "....PPP..PPP....",
+  "...PPP....PPP...",
+  "...PPP....PPP...",
+  "..PPP......PPP..",
+  ".FFFF......FFFF.",
+]);
+
+// Hips on row 18, so there is no gap between the bottom of the torso and the
+// top of the legs. There was one at first: the torso ends at 17, and starting
+// the legs at 19 left the body floating a pixel above them.
+const LEGS_SIT = at(18, [
+  "...PPPPPPPPPP...",
+  "..PPPPP..PPPPP..",
+  "..PPPPP..PPPPP..",
+  "..PPPPP..PPPPP..",
+  "..PPPP....PPPP..",
+  "..FFFF....FFFF..",
+]);
+
+// ── Head ────────────────────────────────────────────────────────────────────
+// Neck, face, a shaded jaw, and cheeks. The cheeks are part of the face rather
+// than a translucent mark laid over it, so they are one flat colour derived
+// from the skin — see `flush` in palette.ts.
+
+const HEAD = at(3, [
+  "...SSSSSSSSSS...",
+  "...SSSSSSSSSS...",
+  "...SSSSSSSSSS...",
+  "...SSSSSSSSSS...",
+  "...SSSSSSSSSS...",
+  "...BBSSSSSSBB...",
+  "...SSSSSSSSSS...",
+  "...ssssssssss...",
+  "......SSSS......",
+]);
+
+// ── Eyes ────────────────────────────────────────────────────────────────────
+// Two frames each. Nothing in this sprite used to change its own pixels — the
+// idle animation translated the whole thing up three pixels — which is what
+// made scenes read as posed dolls rather than as people standing still.
+
+interface EyeFrames {
+  open: PixelMap;
+  shut: PixelMap;
+}
+
+const EYES: Record<EyeStyle, EyeFrames> = {
+  normal: {
+    open: at(6, ["....WE....WE....", "....EE....EE...."]),
+    shut: at(7, ["....EE....EE...."]),
+  },
+  anime: {
+    open: at(5, [
+      "....WEE..WEE....",
+      "....EEE..EEE....",
+      "....EEE..EEE....",
+    ]),
+    shut: at(7, ["....EEE..EEE...."]),
+  },
+  sleepy: {
+    // Already half-lidded, so the "open" frame carries the lowered lid and the
+    // blink just finishes the job.
+    open: at(6, ["....eee..eee....", "....EEE..EEE...."]),
+    shut: at(7, ["....EEE..EEE...."]),
+  },
+};
+
+// ── Hair in front ───────────────────────────────────────────────────────────
+
+const HAIR_FRONT: Record<HairStyle, PixelMap | null> = {
+  bob: at(0, [
+    "...HHHHHHHHHH...",
+    "...HHHHHHHHHH...",
+    "..HHHHHHHHHHHH..",
+    "..HhhhhhhhhhhH..",
+    "..H..........H..",
+  ]),
+  long: at(0, [
+    "...HHHHHHHHHH...",
+    "...HHHHHHHHHH...",
+    "..HHHHHHHHHHHH..",
+    "..HhhhhhhhhhhH..",
+    "..H..........H..",
+  ]),
+  mohawk: at(0, [
+    ".......HH.......",
+    ".......HH.......",
+    "......HHHH......",
+    ".....hHHHHh.....",
+    ".......HH.......",
+    ".......hh.......",
+  ]),
+  spiky: at(0, [
+    "....h..hh..h....",
+    "....H..HH..H....",
+    "....HH.HH.HH....",
+    "...HHHHHHHHHH...",
+    "...hhhhhhhhhh...",
+  ]),
+  bald: null,
+};
+
+// ── Poses ───────────────────────────────────────────────────────────────────
+
+export type CharacterPose =
+  | "stand"
+  | "walk0"
+  | "walk1"
+  | "walk2"
+  | "walk3"
+  | "sit";
+
+const POSES: Record<CharacterPose, { arms: PixelMap; legs: PixelMap }> = {
+  stand: { arms: ARMS.neutral, legs: LEGS_TOGETHER },
+  // Contact, passing, contact, passing — the arm that drops alternates so the
+  // cycle reads as a stride rather than a hop.
+  walk0: { arms: ARMS.leftDown, legs: LEGS_APART },
+  walk1: { arms: ARMS.neutral, legs: LEGS_TOGETHER },
+  walk2: { arms: ARMS.rightDown, legs: LEGS_APART },
+  walk3: { arms: ARMS.neutral, legs: LEGS_TOGETHER },
+  sit: { arms: ARMS.sit, legs: LEGS_SIT },
+};
+
+export const WALK_POSES: CharacterPose[] = ["walk0", "walk1", "walk2", "walk3"];
+
+/**
+ * One frame of a character, composited back to front.
+ *
+ * The order is load-bearing: hair behind the body, then limbs, then the torso
+ * over the sleeve caps, then the head over the neck, then eyes, then the
+ * fringe over the forehead.
+ */
+export function characterMap(
+  avatar: Pick<AvatarConfig, "hairStyle" | "eyeStyle">,
+  pose: CharacterPose,
+  blinking = false,
+): PixelMap {
+  const { arms, legs } = POSES[pose];
+  const eyes = EYES[avatar.eyeStyle];
+  return overlay(
+    HAIR_BACK[avatar.hairStyle],
+    arms,
+    legs,
+    TORSO,
+    HEAD,
+    blinking ? eyes.shut : eyes.open,
+    HAIR_FRONT[avatar.hairStyle],
+  );
+}
+
+/**
+ * The palette for one avatar.
+ *
+ * Every shadow is derived rather than picked, so a recoloured character stays
+ * lit the same way. The eye is not pure black: a black keyline on a dark hair
+ * colour loses the eye entirely, and the world's own shadow hue keeps it
+ * sitting in the same light as everything else.
+ */
+export function characterPalette(avatar: AvatarConfig): PixelPalette {
+  const { skinColor, hairColor, outfitColor } = avatar;
+  return {
+    S: skinColor,
+    s: shade(skinColor, 0.1),
+    B: flush(skinColor),
+    H: hairColor,
+    h: shade(hairColor, 0.13),
+    O: outfitColor,
+    o: shade(outfitColor, 0.13),
+    P: shade(outfitColor, 0.22),
+    F: "#2A2A33",
+    E: "#1A1A2E",
+    W: "#FFFFFF",
+    e: blend("#1A1A2E", skinColor, 0.55),
+  };
+}

--- a/client/src/lib/palette.test.ts
+++ b/client/src/lib/palette.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { shade, flush, hexToHsl, hslToHex } from "./palette";
+import { SKIN_COLORS, HAIR_COLORS, OUTFIT_COLORS } from "./avatarData";
+
+const lightness = (hex: string) => hexToHsl(hex)[2];
+const saturation = (hex: string) => hexToHsl(hex)[1];
+
+const SKINS = SKIN_COLORS.map((c) => c.hex);
+const ALL = [...SKINS, ...HAIR_COLORS, ...OUTFIT_COLORS].map((c) =>
+  typeof c === "string" ? c : c.hex,
+);
+
+describe("hexToHsl", () => {
+  it("round-trips through hslToHex", () => {
+    for (const hex of ALL) {
+      const [h, s, l] = hexToHsl(hex);
+      expect(hslToHex(h, s, l).toLowerCase()).toBe(hex.toLowerCase());
+    }
+  });
+
+  it("reports greys as unsaturated", () => {
+    expect(hexToHsl("#808080")[1]).toBe(0);
+    expect(hexToHsl("#000000")[2]).toBe(0);
+    expect(hexToHsl("#ffffff")[2]).toBe(1);
+  });
+});
+
+describe("shade", () => {
+  // The bug: `darken` was a per-channel RGB multiply, so the amount a colour
+  // moved depended on how bright it already was. On the two deepest skins the
+  // chin shadow shifted value by ~6/255 — drawn, paid for, invisible.
+  const previousDarken = (hex: string, ratio: number) => {
+    const n = parseInt(hex.replace("#", ""), 16);
+    const r = Math.max(0, ((n >> 16) & 0xff) * (1 - ratio)) | 0;
+    const g = Math.max(0, ((n >> 8) & 0xff) * (1 - ratio)) | 0;
+    const b = Math.max(0, (n & 0xff) * (1 - ratio)) | 0;
+    return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
+  };
+
+  it("darkens every skin tone by a visible and near-equal amount", () => {
+    const drops = SKINS.map((hex) => lightness(hex) - lightness(shade(hex)));
+    for (const drop of drops) expect(drop).toBeGreaterThan(0.08);
+    // Palest and deepest must move by comparable amounts. The old multiply
+    // spread these from 0.071 down to 0.016 — a 4.4x range.
+    expect(Math.max(...drops) / Math.min(...drops)).toBeLessThan(1.15);
+  });
+
+  it("moves the deepest skin far more than the multiply it replaced", () => {
+    const deepest = SKINS[SKINS.length - 1];
+    const now = lightness(deepest) - lightness(shade(deepest));
+    const before = lightness(deepest) - lightness(previousDarken(deepest, 0.08));
+    expect(before).toBeLessThan(0.02); // invisible, which was the bug
+    expect(now).toBeGreaterThan(before * 4);
+  });
+
+  it("never returns a colour lighter than its source", () => {
+    for (const hex of ALL) {
+      expect(lightness(shade(hex))).toBeLessThanOrEqual(lightness(hex));
+    }
+  });
+
+  it("does not turn pale colours vivid", () => {
+    // Holding HSL saturation while dropping lightness sent the palest skin to
+    // a pink; capping the chroma rise is what stops it.
+    for (const hex of ALL) {
+      expect(saturation(shade(hex))).toBeLessThan(saturation(hex) + 0.12);
+    }
+  });
+
+  it("still separates a near-black from its own shadow", () => {
+    // Blending toward a fixed dark tone failed here — black hair came back
+    // fractionally *lighter* than the colour it was shading.
+    const black = "#1A1A1A";
+    expect(lightness(black) - lightness(shade(black))).toBeGreaterThan(0.03);
+  });
+});
+
+describe("flush", () => {
+  it("warms every skin tone without bleaching it", () => {
+    for (const hex of SKINS) {
+      const [, s, l] = hexToHsl(hex);
+      const [, fs, fl] = hexToHsl(flush(hex));
+      expect(fs).toBeGreaterThan(s); // warmer
+      expect(Math.abs(fl - l)).toBeLessThan(0.08); // still that person's face
+    }
+  });
+
+  it("is not the same pink on every skin", () => {
+    // It used to be: a fixed #F4A0A0 at 0.6 opacity, which on the deepest skin
+    // read as two bright stripes rather than as a cheek.
+    expect(new Set(SKINS.map(flush)).size).toBe(SKINS.length);
+    for (const hex of SKINS) {
+      expect(flush(hex).toLowerCase()).not.toBe("#f4a0a0");
+    }
+  });
+});

--- a/client/src/lib/palette.ts
+++ b/client/src/lib/palette.ts
@@ -101,15 +101,6 @@ function parseHex(hex: string): [number, number, number] {
   return [(n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff];
 }
 
-/**
- * The one colour every shadow on a character mixes toward, and the one every
- * cheek mixes toward. Named constants rather than per-call arguments so a
- * sprite's shadows all agree — a face shaded toward one tone and a sleeve
- * toward another is what makes hand-picked shading look assembled.
- */
-const SHADOW_TONE = hslToHex(SHADOW_HUE, 0.34, 0.13);
-const CHEEK_TONE = hslToHex(6, 0.72, 0.6);
-
 /** Inverse of hslToHex. Hue in degrees, s and l in 0–1. */
 export function hexToHsl(hex: string): [number, number, number] {
   const [r255, g255, b255] = parseHex(hex);

--- a/client/src/lib/palette.ts
+++ b/client/src/lib/palette.ts
@@ -101,6 +101,100 @@ function parseHex(hex: string): [number, number, number] {
   return [(n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff];
 }
 
+/**
+ * The one colour every shadow on a character mixes toward, and the one every
+ * cheek mixes toward. Named constants rather than per-call arguments so a
+ * sprite's shadows all agree — a face shaded toward one tone and a sleeve
+ * toward another is what makes hand-picked shading look assembled.
+ */
+const SHADOW_TONE = hslToHex(SHADOW_HUE, 0.34, 0.13);
+const CHEEK_TONE = hslToHex(6, 0.72, 0.6);
+
+/** Inverse of hslToHex. Hue in degrees, s and l in 0–1. */
+export function hexToHsl(hex: string): [number, number, number] {
+  const [r255, g255, b255] = parseHex(hex);
+  const [r, g, b] = [r255 / 255, g255 / 255, b255 / 255];
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  const d = max - min;
+  if (d === 0) return [0, 0, l];
+  const s = d / (1 - Math.abs(2 * l - 1));
+  let h: number;
+  if (max === r) h = ((g - b) / d) % 6;
+  else if (max === g) h = (b - r) / d + 2;
+  else h = (r - g) / d + 4;
+  return [((h * 60) % 360 + 360) % 360, s, l];
+}
+
+/**
+ * The shaded side of a surface.
+ *
+ * Replaces a naive RGB multiply. Scaling channels by a ratio moves a *dark*
+ * colour almost not at all — `darken('#4A2518', 0.08)` shifted value by about
+ * 6/255, so the two deepest skin tones had a chin shadow nobody could see,
+ * while the same call on the palest skin was obvious. Subtracting lightness
+ * instead moves every colour by the same visible amount, and rotating toward
+ * the ambient shadow hue is what makes it read as a surface turning away from
+ * the light rather than as the same colour dimmed.
+ *
+ * Two things have to hold at once, and the obvious implementations each get
+ * one of them:
+ *
+ * - **Every colour must darken by a visible amount.** Blending toward a fixed
+ *   dark tone fails here, because a colour that is already dark barely moves —
+ *   black hair came out 0.006 *lighter* than its own shadow.
+ * - **Pale colours must not turn vivid.** Holding HSL `s` and dropping `l`
+ *   fails here: `s` means different things at different lightnesses, so a
+ *   peachy skin at l=0.85 shaded to l=0.75 came out pink.
+ *
+ * So: drop lightness by a fixed amount, and hold *chroma* rather than
+ * saturation while doing it — chroma is `(1 - |2l - 1|) · s`, so `s` has to be
+ * recomputed for the new lightness. Then rotate slightly toward the ambient
+ * shadow hue, which is what makes it read as a surface turning away from the
+ * light instead of the same colour dimmed.
+ *
+ * `drop` is in lightness units, not a ratio.
+ */
+export function shade(hex: string, drop = 0.1): string {
+  const [h, s, l] = hexToHsl(hex);
+  const lit = Math.max(0.04, l - drop);
+  const chroma = (1 - Math.abs(2 * l - 1)) * s;
+  const spread = 1 - Math.abs(2 * lit - 1);
+  // Chroma preservation asks for more and more saturation as lightness falls,
+  // and near the bottom it asks for impossible amounts — the deepest skin came
+  // back as a saturated near-black red. Cap the rise: hold chroma where that
+  // is achievable, and give up on it rather than produce a colour harsher than
+  // the one it is shading.
+  const sat = Math.min(s * 1.12, spread === 0 ? 0 : chroma / spread);
+  // Warm hues take the short way round to the ambient blue, i.e. through red —
+  // the same trap that turned the EMBER ramp pink. That is the right direction
+  // for skin and hair anyway (warm shadows go red-violet, not blue), so the
+  // pull stays small and the path is left alone.
+  return hslToHex(hueLerp(h, SHADOW_HUE, 0.1), clamp01(sat), lit);
+}
+
+/**
+ * Cheeks, on any skin.
+ *
+ * Was a fixed `#F4A0A0` at 0.6 opacity, which on the palest skin is a blush
+ * and on `#4A2518` is two bright pink stripes — the mark was being painted
+ * *over* the face instead of being the face flushing. Deriving it from the
+ * skin keeps the value where it was and moves only hue and saturation, so it
+ * reads as warmth at every tone. Opacity is gone with it: a flat colour is one
+ * fewer thing between the sprite and `crispEdges`.
+ */
+export function flush(skin: string): string {
+  const [h, s, l] = hexToHsl(skin);
+  return hslToHex(
+    hueLerp(h, 8, 0.4),
+    clamp01(s * 1.18 + 0.06),
+    // Warmth reads as a lift on deep skin and a deepening on pale skin, which
+    // is also how blood under skin actually behaves.
+    clamp01(l < 0.45 ? l + 0.05 : l - 0.04),
+  );
+}
+
 /** Mix two hexes; `t` 0 = `a`, 1 = `b`. */
 export function blend(a: string, b: string, t: number): string {
   const [ar, ag, ab] = parseHex(a);

--- a/client/src/lib/petMaps.ts
+++ b/client/src/lib/petMaps.ts
@@ -1,0 +1,124 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Pet maps — the companions as string maps.
+//
+// ── Why they got smaller ────────────────────────────────────────────────────
+// The pets were 10 x 11 cells. On ART_PX that is 30 x 33 px beside a 48 x 72
+// person, i.e. a cat 0.46x a human's height — a cat is about 0.25x. They only
+// ever looked right because they used to render at a *smaller pixel* than the
+// character did, which is the density mismatch PR #36 removed: the fix put them
+// on the same grid and the size problem became visible.
+//
+// So they are redrawn at 9 x 7, which is 27 x 21 px, or 0.29x a person. The
+// wrong fix is putting `size` back to 2 — that reintroduces two pixel grids in
+// one frame, and a scene with two pixel sizes reads as broken no matter how
+// well-proportioned the things in it are.
+//
+// ── What seven rows costs you ───────────────────────────────────────────────
+// Every pet is a head with a body under it, seen face-on. That is a choice, not
+// a limitation to apologise for: at this size the head is the only part with
+// room for anything readable, so it gets four of the seven rows and the body
+// gets two. The first attempt drew face-on heads with side-on tails, and the
+// tails read as detached sticks floating beside the animal — mixing two views
+// in nine pixels does not survive.
+//
+// Everything distinguishing therefore happens in the silhouette: cat ear
+// points, dog ears down the sides of the head, dragon horns and wings, rabbit
+// ears above it. Interior detail is two eyes and a nose.
+//
+// ── The key alphabet ────────────────────────────────────────────────────────
+//   C coat        c coat in shadow      M muzzle / marking
+//   E eye         N nose                W tail fluff
+// ─────────────────────────────────────────────────────────────────────────────
+
+import type { PixelMap, PixelPalette } from "@/components/PixelSprite";
+import { place } from "./pixelMap";
+import { shade } from "./palette";
+import type { PetType } from "./types";
+
+export const PET_W = 9;
+export const PET_H = 7;
+
+/**
+ * Both walk frames plant both feet on the bottom row.
+ *
+ * A pet that lifts a foot clean off the map is indistinguishable from one whose
+ * foot is being silently clipped — which is exactly what the cat and the rabbit
+ * shipped with, each walking on one leg. So the step is a change of *stance*,
+ * feet together and feet apart, and the bottom row is never empty.
+ */
+const FEET_TOGETHER = "..cc.cc..";
+const FEET_APART = ".cc...cc.";
+
+interface PetArt {
+  frames: [PixelMap, PixelMap];
+  palette: PixelPalette;
+}
+
+/** Six rows of body plus the two foot stances. */
+function pet(body: readonly string[], palette: PixelPalette): PetArt {
+  const frame = (feet: string) =>
+    place(0, [...body, feet], PET_H, PET_W);
+  return { frames: [frame(FEET_TOGETHER), frame(FEET_APART)], palette };
+}
+
+const coat = (base: string, rest: PixelPalette): PixelPalette => ({
+  C: base,
+  c: shade(base, 0.12),
+  ...rest,
+});
+
+export const PET_ART: Record<PetType, PetArt> = {
+  // Pointed ears at the head's corners, tail curling out to one side.
+  cat: pet(
+    [
+      ".C.....C.",
+      ".CCCCCCC.",
+      ".CECCCEC.",
+      ".CCCNCCC.",
+      "..CCCCCcc",
+      "..CCCCC.c",
+    ],
+    coat("#E2A65C", { E: "#2C3A4A", N: "#C4604A" }),
+  ),
+
+  // Ears down the sides rather than above — that plus the muzzle is the whole
+  // difference between this and the cat at nine pixels wide.
+  dog: pet(
+    [
+      "CC.....CC",
+      "cCCCCCCCc",
+      "cCECCCECc",
+      ".CCMMMCC.",
+      "..CCCCCc.",
+      "..CCCCC..",
+    ],
+    coat("#C99A63", { E: "#3B2411", M: "#EFD9B4", N: "#2A1808" }),
+  ),
+
+  // Horns up, wings out at the shoulders, gold eyes.
+  dragon: pet(
+    [
+      "..c...c..",
+      ".CCCCCCC.",
+      ".CECCCEC.",
+      ".CCCNCCC.",
+      "cCCCCCCCc",
+      "..CCCCC.c",
+    ],
+    coat("#A78BFA", { E: "#FFC93C", N: "#7C3AED" }),
+  ),
+
+  // Two rows of ear, which is most of what a rabbit is from the front, so it
+  // sits up and gets only one row of body.
+  rabbit: pet(
+    [
+      "...C.C...",
+      "...C.C...",
+      ".CCCCCCC.",
+      ".CECCCEC.",
+      ".CCCNCCC.",
+      "..CCCCCWW",
+    ],
+    coat("#EFE6D6", { E: "#8A5A6B", N: "#E39AA0", W: "#FFFFFF" }),
+  ),
+};

--- a/client/src/lib/pixelMap.test.ts
+++ b/client/src/lib/pixelMap.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { overlay, place, keysUsed, isClear } from "./pixelMap";
+
+describe("overlay", () => {
+  it("paints later layers over earlier ones", () => {
+    expect(overlay(["AAA"], [".B."])).toEqual(["ABA"]);
+  });
+
+  it("lets transparent cells through", () => {
+    // Both spellings of transparent, because the maps in this repo use each.
+    expect(overlay(["AAA"], ["...."], ["   "])).toEqual(["AAA."]);
+  });
+
+  it("sizes to the largest layer and pads the rest", () => {
+    expect(overlay(["AA"], ["...", "BBB"])).toEqual(["AA.", "BBB"]);
+  });
+
+  it("ignores absent layers", () => {
+    // Hair-back is null for four of the five styles; the call site shouldn't
+    // have to filter.
+    expect(overlay(null, ["AB"], undefined)).toEqual(["AB"]);
+    expect(overlay(null, undefined)).toEqual([]);
+  });
+
+  it("is not confused by a short row in the middle of a layer", () => {
+    expect(overlay(["AAAA", "AAAA"], ["BB", "..BB"])).toEqual([
+      "BBAA",
+      "AABB",
+    ]);
+  });
+});
+
+describe("place", () => {
+  it("puts a block at the requested row", () => {
+    expect(place(1, ["XX"], 3, 2)).toEqual(["..", "XX", ".."]);
+  });
+
+  it("refuses a block that runs off the bottom", () => {
+    // SVG clips out-of-bounds geometry without a word — that silence is how
+    // two pets shipped walking on one leg. A throw is the whole point.
+    expect(() => place(2, ["XX", "XX"], 3, 2)).toThrow(/does not fit/);
+  });
+
+  it("refuses a negative offset", () => {
+    expect(() => place(-1, ["XX"], 3, 2)).toThrow(/does not fit/);
+  });
+
+  it("refuses a row of the wrong width", () => {
+    // A short row is padded silently by PixelSprite, which is forgiving for a
+    // standalone sprite and wrong for a layer: the padding lands on top of
+    // whatever it was supposed to let through.
+    expect(() => place(0, ["XXX"], 2, 2)).toThrow(/expected 2/);
+    expect(() => place(0, ["X"], 2, 2)).toThrow(/expected 2/);
+  });
+});
+
+describe("keysUsed", () => {
+  it("lists the non-transparent keys", () => {
+    expect(keysUsed(["AB.", " CA"])).toEqual(new Set(["A", "B", "C"]));
+  });
+});
+
+describe("isClear", () => {
+  it("treats dot, space and absent as transparent", () => {
+    expect(isClear(".")).toBe(true);
+    expect(isClear(" ")).toBe(true);
+    expect(isClear(undefined)).toBe(true);
+    expect(isClear("A")).toBe(false);
+  });
+});

--- a/client/src/lib/pixelMap.ts
+++ b/client/src/lib/pixelMap.ts
@@ -1,0 +1,95 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Pixel maps — composition helpers.
+//
+// `PixelSprite` renders one map. A character is several: hair behind the body,
+// arms, torso, legs, head, eyes, hair in front. They have to composite in
+// z-order into a single map before rendering, because a character is one SVG —
+// stacking separate <svg> elements would put each layer's edges on its own
+// rounding, which is how pixel art picks up seams.
+//
+// Layers share one key alphabet (see characterMaps.ts), so compositing is just
+// "last non-transparent cell wins" and no palette merging is needed.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import type { PixelMap } from "@/components/PixelSprite";
+
+const TRANSPARENT = new Set([".", " "]);
+
+/** True when a cell should let whatever is behind it through. */
+export function isClear(cell: string | undefined): boolean {
+  return cell === undefined || TRANSPARENT.has(cell);
+}
+
+/**
+ * Composite layers back-to-front. Later layers paint over earlier ones.
+ *
+ * Ragged and short rows are tolerated the way `PixelSprite` tolerates them —
+ * a missing cell is transparent, not an error — and the result is sized to the
+ * largest layer.
+ */
+export function overlay(
+  ...layers: (PixelMap | null | undefined)[]
+): PixelMap {
+  const present = layers.filter((l): l is PixelMap => !!l && l.length > 0);
+  if (present.length === 0) return [];
+  const rows = present.reduce((m, l) => Math.max(m, l.length), 0);
+  const cols = present.reduce(
+    (m, l) => Math.max(m, l.reduce((n, r) => Math.max(n, r.length), 0)),
+    0,
+  );
+
+  const out: string[] = [];
+  for (let y = 0; y < rows; y++) {
+    let row = "";
+    for (let x = 0; x < cols; x++) {
+      let cell = ".";
+      for (const layer of present) {
+        const candidate = layer[y]?.[x];
+        if (!isClear(candidate)) cell = candidate!;
+      }
+      row += cell;
+    }
+    out.push(row);
+  }
+  return out;
+}
+
+/**
+ * Put a block of rows at row `top` of an otherwise empty canvas.
+ *
+ * Layers are written as just the rows they occupy — a legs layer is five rows,
+ * not five rows and nineteen lines of dots. Anything past the bottom of the
+ * canvas is a mistake worth hearing about rather than something SVG should
+ * quietly clip: that silent clip is what had two pets walking on one leg.
+ */
+export function place(
+  top: number,
+  block: readonly string[],
+  height: number,
+  width: number,
+): PixelMap {
+  if (top < 0 || top + block.length > height) {
+    throw new RangeError(
+      `block of ${block.length} rows at y=${top} does not fit in ${height} rows`,
+    );
+  }
+  const wrong = block.find((row) => row.length !== width);
+  if (wrong !== undefined) {
+    throw new RangeError(
+      `row "${wrong}" is ${wrong.length} cells, expected ${width}`,
+    );
+  }
+  const empty = ".".repeat(width);
+  return Array.from({ length: height }, (_, y) =>
+    y >= top && y < top + block.length ? block[y - top] : empty,
+  );
+}
+
+/** Every distinct non-transparent key used by a map. */
+export function keysUsed(map: PixelMap): Set<string> {
+  const keys = new Set<string>();
+  for (const row of map) {
+    for (const cell of row) if (!isClear(cell)) keys.add(cell);
+  }
+  return keys;
+}


### PR DESCRIPTION
Roadmap item 7b-char — the half deferred out of #37. The avatar and the pets
were the only sprites in the app still drawn as ~90 hand-placed
`<rect x= y= width= height=>` elements with the coordinates inline in the JSX,
which is why they were the two that never got the keyline, palette-swap or
blink frame everything else got in #33.

They're layered string maps now. **They also look different** — that part needs
your eye, not mine.

## The shading bug was real, and worse than reported

`darken()` scaled each RGB channel by a ratio, so how far a colour moved
depended on how bright it already was:

| skin | old Δlightness | new |
|---|---|---|
| Fair `#FDDBB4` | 0.071 | 0.098 |
| Tan `#B5714E` | 0.043 | 0.100 |
| Rich `#4A2518` | **0.016** | 0.100 |

0.016 is invisible. Two of the six skins had a chin shadow that was drawn,
rendered, and never seen — for the life of the feature.

Both obvious rewrites are also wrong, in opposite directions, and I wrote each
one before finding out:

- **Blend toward a fixed dark tone.** Darkens pale colours nicely, barely
  touches dark ones. Black hair came back 0.006 *lighter* than its own shadow.
- **Hold HSL saturation, drop lightness.** Darkens everything equally, turns
  pale colours vivid — `s` means different things at different lightnesses, so
  peachy skin shaded to pink.

What works is dropping lightness a fixed amount while holding *chroma*, with a
cap (chroma preservation asks for impossible saturation near black and returns
a colour harsher than the one it's shading). Both failure modes are regression
tests.

Blush got the same treatment: it was a fixed `#F4A0A0` at 0.6 opacity — a blush
on the palest skin and two bright pink stripes on `#4A2518`, because the mark
was painted *over* the face rather than being the face flushing.

## Pets are smaller

10×11 → 9×7 cells. At `ART_PX` that's 30×33 px → 27×21 beside a 48×72 person:
**0.46× a human → 0.29×**. A cat is about 0.25×.

Worth being clear about why they looked fine before: they were rendering at a
*smaller pixel* than the character. PR #36 put them on one grid, and that's
what made the size wrong — the fix exposed it. The tempting undo is `size={2}`,
which puts two pixel grids back in one frame.

My first attempt at 9×7 drew face-on heads with side-on tails, and the tails
rendered as detached sticks floating beside each animal. Mixing two views does
not survive nine pixels. They're face-on now, and everything distinguishing
happens in the silhouette — cat ear points, dog ears down the sides, dragon
horns and wings, rabbit ears above.

## The avatar blinks

Every 4–6.5 s, jittered (a fixed interval reads as a tic), 130 ms, off under
`prefers-reduced-motion`. This is what the string maps were for: nothing in
this sprite ever changed its own pixels — `pixel-idle` translates the whole
thing up three px and back — so a scene of people standing still read as a
scene of dolls.

The 2-frame idle from the roadmap is **not** in here. A second body frame on
top of `pixel-idle` looked busy in the static dump, and that's a call worth
making after watching it move rather than before.

## Fixed while redrawing

- Sitting had a one-pixel gap between the bottom of the torso and the top of
  the legs — the body floated.
- The first walk splayed two pixels a row from the knee and came out
  bow-legged. It swings from the hip now.
- Two unused constants from the abandoned shading approach shipped in the first
  commit and are removed in a later one. They were warnings, not errors, so CI
  would have gone green — I committed on a lint run I hadn't read, and the
  commit says so.

## A/B

- **`shade`** — "moves the deepest skin far more than the multiply it replaced"
  pins the old behaviour at 0.016 and requires 4×. The pale-colour and
  near-black tests are each a regression test for one of the two wrong
  implementations above.
- **Pet size** — `draws characters and their pets on the same pixel grid` fails
  against the previous commit with ``no sprite with viewBox "0 0 9 7"``. That
  test also stops hardcoding the grids and reads them off the art; hardcoding
  is what had it restating whatever the code did.
- The height-ratio test next to it is a **guard** and is labelled as one — it
  reads the constants the art declares, so it holds regardless.
- `characterMaps.test.ts` and `pixelMap.test.ts` are new-surface coverage,
  not A/B. Two of them do settle old arguments though: the eye-centring and
  "long hair == bob" claims in the roadmap's corrections section are now
  enforced rather than argued from line numbers.

## Not verified

**Nothing here has been looked at in a browser.** I rendered every avatar
combination and every pet to static HTML and rasterised it to check the
drawings — that's how the detached tails, the sit gap and the bow legs were
caught — but a still frame can't show:

- whether the blink cadence feels right or twitchy
- whether the walk reads as a stride at real size and speed
- whether the pets are now *too* small next to their owner

The last one is the judgment call I'd most like a second opinion on. Outlines
are one prop away (`outline="#12101a"`) and deliberately **not** turned on —
that's the rest of item 4 and it's a visual decision.

## Commits

6, rebase-merge as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)