### PR TITLE
Pets level up and grow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,9 +70,9 @@ Security conventions in the socket layer (preserve these when adding events):
 - Mutating events check the socket is actually a player in the session; create/join/invite are rate-limited per socket.
 - Knowing a session id is not permission to use it: `join_session` requires an existing slot, an invite, or friendship with someone already in the session, and `send_invite` is friends-only. Server-side ids are read from `socketToSession`, never taken from the payload.
 
-Pets are part of session state, not just local UI: `set_pet` updates the player's slot server-side (sanitized against `VALID_PETS`) and relays `pet_changed` to the other player, so both sides see the same companion.
+Pets are part of session state, not just local UI: `set_pet` updates the player's slot server-side (sanitized against `VALID_PETS`) and relays `pet_changed` to the other player, so both sides see the same companion. `petStage` is derived from total completed focus (`server/petLevel.js` / `client/src/lib/petLevel.ts`, same two-copy pin as the rotation) and a client-sent stage is ignored. Growth is more cells at `ART_PX`, never a scale multiplier.
 
-Note: `server/session.js` holds the pure session-state helpers (`createSessionState`, `addPlayer`, `removePlayer`, `setPlayerPet`, `findPlayerByUserId`, `markPlayerDisconnected`, `sessionParticipantIds`, `buildSyncPayload`); `index.js` imports them and `session.test.js` covers them. Put new pure session logic there, not inline in `index.js`.
+Note: `server/session.js` holds the pure session-state helpers (`createSessionState`, `addPlayer`, `removePlayer`, `setPlayerPet`, `creditFocus`, `findPlayerByUserId`, `markPlayerDisconnected`, `sessionParticipantIds`, `buildSyncPayload`); `index.js` imports them and `session.test.js` covers them. Put new pure session logic there, not inline in `index.js`.
 
 ### Client structure
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,9 +5,8 @@ that does the work, not afterwards. Ordered by value; each line names the real
 files. Was `ROADMAP.local.md` and gitignored until PR #38 — it is tracked now,
 so the file:line references land in diffs and want keeping honest.
 
-Last updated: 2026-08-15. PRs #35–#40 merged.
-Item 4 is on `art/character-outline-shadow` — contact shadows shipped,
-character outlines tried and reverted. Reviewed on localhost 2026-08-15.
+Last updated: 2026-08-18. PRs #35–#41 merged.
+Item 12 is on `feat/pet-levels`. Not verified in a browser.
 Migrations 016–020 are applied to Supabase. **020 verified in production**
 2026-08-15: RLS on, one SELECT-only policy, zero client write grants, EXECUTE
 limited to authenticated/service_role, SECURITY DEFINER with a pinned
@@ -64,17 +63,20 @@ the live database.
       down to what exists. Stripe seam is `client/src/lib/billing.ts`.
       **Migration 020 must be applied before the deploy**, or the button
       raises `function claim_premium does not exist`.
-- [x] **4. Contact shadow** — branch `art/character-outline-shadow`.
-      `PixelSprite` has had an outline pass and `Grounded` a contact shadow
-      since #37; what was missing is that `GameWorld` draws the characters
-      itself and passed neither, so the two things the scene is about were the
-      only two hovering. Shadow extracted to `components/ContactShadow.tsx` so
-      the scenery and the characters share one recipe.
+- [x] **4. Contact shadow** — PR #41. `PixelSprite` has had an outline pass
+      and `Grounded` a contact shadow since #37; what was missing is that
+      `GameWorld` draws the characters itself and passed neither, so the two
+      things the scene is about were the only two hovering. Shadow extracted
+      to `components/ContactShadow.tsx` so the scenery and the characters
+      share one recipe.
       **Outlines were tried on the characters and taken back off** at the
       owner's call, 2026-08-15 — see below.
-- [ ] **12. Pets level up and grow** — owner's idea, 2026-08-13. Written up
-      below. Mostly drawing: growth has to be maps with more cells, never a
-      bigger `size`. Levels want deriving from focus history, not storing.
+- [x] **12. Pets level up and grow** — this PR. Derived from completed focus
+      (`server/petLevel.js` + `client/src/lib/petLevel.ts`, 3h / 15h), same
+      two-copy pin as the rotation. Growth is more cells at `ART_PX`: young
+      7×5, grown 9×7 (today's art), full 11×9. Stage travels in the slot as
+      `petStage`; a client-sent value is ignored. Per user, not per pet.
+      Premium stays the pet gate. **Not verified in a browser.**
 
 ## ⚠️ Corrections to this file
 
@@ -483,7 +485,7 @@ by eye — the countdown ticking on home, and that a session left open across a
 
 ---
 
-## 12. Pets level up and grow  ·  owner's idea, 2026-08-13, not started
+## 12. Pets level up and grow  ·  SHIPPED — this PR
 
 The owner's call after previewing #39: pets earn levels and get **bigger** as
 they level. A companion that visibly changes because of hours you actually put
@@ -515,26 +517,28 @@ Total focus minutes already exist in `sessions`/`session_participants`, and
 new column, cannot drift, and is automatically right for existing users on the
 day it ships — everyone's back catalogue counts.
 
-Open questions worth settling before drawing anything:
+**What actually shipped, settling the open questions:**
 
-- **Per user or per pet type?** Per user is one number and reuses the stats
-  that exist. Per pet type means a real table and makes switching pets cost
-  progress, which is either the point or a punishment depending on taste.
-- **Does your partner see your pet's level?** They see the pet already
-  (`pet_changed` relays the type). If growth is only local, two people in the
-  same room see different animals, which is the same class of bug the world
-  rotation exists to prevent. So the level has to travel with the pet in
-  session state, which means the server derives it too — and the server has the
-  service key and the same rows, so that is cheap.
-- **What are the thresholds?** Wants to be slow enough to mean something and
-  fast enough that a new user sees one change. First growth inside a week of
-  ordinary use is a reasonable target.
-- **Does it interact with premium?** Pets are the one thing actually gated
-  today (`PetPicker.tsx:20,34`), so levelling is currently a premium-only
-  feature by accident. Worth deciding deliberately — see item 2.
+- **Per user, not per pet type.** One number, the `sum(actual_focus)` that
+  already exists. Switching cat → dog keeps the size.
+- **Partner sees the same animal.** `petStage` travels in the slot;
+  `buildSyncPayload` / `player_joined` / `pet_changed` carry it.
+  `focusSeconds` stays off the wire. A client-sent stage is ignored, same
+  shape as `world`.
+- **Thresholds:** young → grown at **3 hours** (10800 s), grown → full at
+  **15 hours** (54000 s). First change is inside a week of two 25-minute
+  sessions a day. Both packages pin the same table of seconds.
+- **Premium stays the pet gate.** Levelling is not a second lock.
+- A completed focus credits the in-memory total so a pet can grow in the
+  room it earned it, rather than on the next join.
+- Grown maps in `lib/petMaps.ts` are the #39 art, unchanged. Young and full
+  are the same silhouettes with less or more room. `size` stays `ART_PX`.
+- A missing `petStage` (older server) renders as grown, so a client-first
+  deploy does not shrink every pet to young.
 
-Prerequisite: none. #39 put both sprites on string maps, so adding sizes is
-adding maps to `lib/petMaps.ts` and a selector, not touching a component.
+**Not verified:** nothing here has been looked at in a browser. The young
+and full silhouettes need an owner's eye — geometry tests catch clipping and
+grid size, not whether a 5-row cat still reads as a cat.
 
 ---
 

--- a/client/src/components/DuoTimer.tsx
+++ b/client/src/components/DuoTimer.tsx
@@ -366,6 +366,8 @@ export default function DuoTimer() {
           partner={game.partner}
           myPet={game.myPet}
           partnerPet={game.partnerPet}
+          myPetStage={game.myPetStage}
+          partnerPetStage={game.partnerPetStage}
           partnerDisconnected={game.partnerDisconnected}
           myName={profile?.display_name ?? profile?.username}
           partnerName={game.partnerName}

--- a/client/src/components/GameWorld.test.tsx
+++ b/client/src/components/GameWorld.test.tsx
@@ -4,7 +4,8 @@ import GameWorld, { type GamePhase } from "./GameWorld";
 import { DEFAULT_AVATAR, type WorldId } from "@/lib/avatarData";
 import { ART_PX, GROUND } from "@/lib/scene";
 import { CHAR_W, CHAR_H } from "@/lib/characterMaps";
-import { PET_W, PET_H } from "@/lib/petMaps";
+import { PET_W, PET_H, PET_STAGE_SIZE } from "@/lib/petMaps";
+import { PET_STAGES, type PetStage } from "@/lib/petLevel";
 
 // The scene used to place characters with `calc(41.7% + 8px)` on `left` and
 // spin the break-phase controller ±10°. Both put sprite edges between device
@@ -21,6 +22,7 @@ function renderScene(
   returning = 0,
   pets = false,
   worldId: WorldId = "forest",
+  petStage: PetStage | null = "grown",
 ) {
   return render(
     <GameWorld
@@ -32,6 +34,8 @@ function renderScene(
       partner={partner}
       myPet={pets ? "cat" : null}
       partnerPet={pets ? "dog" : null}
+      myPetStage={pets ? petStage : null}
+      partnerPetStage={pets ? petStage : null}
       myName="ME"
       partnerName="THEM"
     />,
@@ -181,13 +185,29 @@ describe("one art pixel", () => {
     expect(ratio).toBeGreaterThan(0.2);
   });
 
-  it("pins the ratio so a bounding-box change has to notice", () => {
+  it("pins the grown ratio so a bounding-box change has to notice", () => {
     // A one-cell border costs a 7-row pet proportionally far more than a
     // 24-row person: turning outlines on moved this from 0.292 to 0.346, about
     // a third of the shrink #39 gave the pets, as a side effect of a change
     // about keylines. The outlines came back off, so it is 0.292 again — and
     // pinned, because the next thing to touch either box will move it too.
     expect((PET_H / CHAR_H).toFixed(3)).toBe("0.292");
+  });
+
+  it("grows by adding cells, never by scaling pixels, and stops short of half a person", () => {
+    expect((PET_STAGE_SIZE.young.h / CHAR_H).toFixed(3)).toBe("0.208");
+    expect((PET_STAGE_SIZE.full.h / CHAR_H).toFixed(3)).toBe("0.375");
+    for (const stage of PET_STAGES) {
+      const { container } = renderScene("waiting", 0, 0, true, "forest", stage);
+      const { w, h } = PET_STAGE_SIZE[stage];
+      expect(density(container, w, h)).toBe(ART_PX);
+      const petPx = Number(findSprite(container, w, h).getAttribute("height"));
+      const personPx = Number(
+        findSprite(container, CHAR_W, CHAR_H).getAttribute("height"),
+      );
+      expect(petPx / personPx).toBeLessThan(0.38);
+      expect(petPx / personPx).toBeGreaterThan(0.2);
+    }
   });
 });
 

--- a/client/src/components/GameWorld.tsx
+++ b/client/src/components/GameWorld.tsx
@@ -5,6 +5,7 @@ import PixelCharacter from "./PixelCharacter";
 import PetCharacter from "./PetCharacter";
 import { getWorld, type WorldId, type AvatarConfig } from "@/lib/avatarData";
 import type { PetType } from "@/lib/types";
+import type { PetStage } from "@/lib/petLevel";
 import {
   useCharacterPosition,
   useSceneWidth,
@@ -48,6 +49,8 @@ interface Props {
   partner: PlayerInfo | null;
   myPet?: PetType | null;
   partnerPet?: PetType | null;
+  myPetStage?: PetStage | null;
+  partnerPetStage?: PetStage | null;
   myName?: string;
   partnerName?: string;
   /** Partner's socket dropped; server is holding their spot */
@@ -129,7 +132,13 @@ function Standing({
 // box — the avatar is 16 cells wide and the pets 9, but a shadow is cast by
 // what touches the ground, so it tracks the feet rather than the shoulders.
 const CHARACTER_SHADOW = 10;
-const PET_SHADOW = 6;
+
+/** Footprints track the feet, not the bounding box, and the box grows. */
+function petShadow(stage: PetStage | null | undefined): number {
+  if (stage === "young") return 4;
+  if (stage === "full") return 8;
+  return 6;
+}
 
 function BreakOverlay({ worldId }: { worldId: WorldId }) {
   const prop = BREAK_PROP[worldId] ?? BREAK_PROP.forest;
@@ -153,6 +162,8 @@ export default function GameWorld({
   partner,
   myPet,
   partnerPet,
+  myPetStage,
+  partnerPetStage,
   myName,
   partnerName,
   partnerDisconnected,
@@ -279,9 +290,10 @@ export default function GameWorld({
       >
         <div className="flex items-end gap-1">
           {myPet && (
-            <Standing shadow={PET_SHADOW}>
+            <Standing shadow={petShadow(myPetStage)}>
               <PetCharacter
                 type={myPet}
+                stage={myPetStage}
                 anim={myAnim}
                 facing="right"
                 size={ART_PX}
@@ -323,9 +335,10 @@ export default function GameWorld({
               />
             </Standing>
             {partnerPet && (
-              <Standing shadow={PET_SHADOW}>
+              <Standing shadow={petShadow(partnerPetStage)}>
                 <PetCharacter
                   type={partnerPet}
+                  stage={partnerPetStage}
                   anim={partnerDisconnected ? "idle" : partnerAnim}
                   facing="left"
                   size={ART_PX}

--- a/client/src/components/PetCharacter.test.tsx
+++ b/client/src/components/PetCharacter.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, act } from "@testing-library/react";
 import PetCharacter from "./PetCharacter";
 import { PET_OPTIONS } from "@/lib/types";
+import { PET_STAGES } from "@/lib/petLevel";
 
 // A rect drawn outside the viewBox is silently clipped — it costs nothing at
 // runtime and produces no warning, so the cat and rabbit shipped with their
@@ -32,43 +33,65 @@ describe("pet sprite geometry", () => {
   // different pair of leg rows — so both frames have to be checked. frame 0 is
   // legUp, frame 1 is its opposite.
   for (const frame of [0, 1]) {
-    for (const type of PETS) {
-      it(`${type} draws entirely inside its viewBox (walk frame ${frame})`, () => {
-        vi.useFakeTimers();
-        const { container } = render(
-          <PetCharacter type={type} size={2} anim="walk" />,
-        );
-        if (frame === 1) {
-          act(() => void vi.advanceTimersByTime(250));
-        }
-        const { minX, minY, width, height, rects } = spriteGeometry(container);
-        expect(rects.length).toBeGreaterThan(0);
-        for (const r of rects) {
-          expect(r.x).toBeGreaterThanOrEqual(minX);
-          expect(r.y).toBeGreaterThanOrEqual(minY);
-          expect(r.x + r.w).toBeLessThanOrEqual(minX + width);
-          expect(r.y + r.h).toBeLessThanOrEqual(minY + height);
-        }
-      });
+    for (const stage of PET_STAGES) {
+      for (const type of PETS) {
+        it(`${type} ${stage} draws entirely inside its viewBox (walk frame ${frame})`, () => {
+          vi.useFakeTimers();
+          const { container } = render(
+            <PetCharacter type={type} stage={stage} size={2} anim="walk" />,
+          );
+          if (frame === 1) {
+            act(() => void vi.advanceTimersByTime(250));
+          }
+          const { minX, minY, width, height, rects } = spriteGeometry(container);
+          expect(rects.length).toBeGreaterThan(0);
+          for (const r of rects) {
+            expect(r.x).toBeGreaterThanOrEqual(minX);
+            expect(r.y).toBeGreaterThanOrEqual(minY);
+            expect(r.x + r.w).toBeLessThanOrEqual(minX + width);
+            expect(r.y + r.h).toBeLessThanOrEqual(minY + height);
+          }
+        });
+      }
     }
   }
 
   // The specific regression: two legs drawn, two legs visible.
-  for (const type of PETS) {
-    it(`${type} has a foot on its bottom row so it stands on the ground`, () => {
-      const { container } = render(<PetCharacter type={type} size={2} />);
-      const { minY, height, rects } = spriteGeometry(container);
-      const bottom = minY + height;
-      expect(rects.some((r) => r.y + r.h === bottom)).toBe(true);
-    });
+  for (const stage of PET_STAGES) {
+    for (const type of PETS) {
+      it(`${type} ${stage} has a foot on its bottom row so it stands on the ground`, () => {
+        const { container } = render(
+          <PetCharacter type={type} stage={stage} size={2} />,
+        );
+        const { minY, height, rects } = spriteGeometry(container);
+        const bottom = minY + height;
+        expect(rects.some((r) => r.y + r.h === bottom)).toBe(true);
+      });
+    }
   }
 
-  it("renders every pet on the same grid, so they share one scale", () => {
-    const boxes = PETS.map((type) => {
-      const { container } = render(<PetCharacter type={type} size={2} />);
-      const { width, height } = spriteGeometry(container);
-      return `${width}x${height}`;
-    });
-    expect(new Set(boxes).size).toBe(1);
+  it("renders every pet of a given stage on the same grid", () => {
+    for (const stage of PET_STAGES) {
+      const boxes = PETS.map((type) => {
+        const { container } = render(
+          <PetCharacter type={type} stage={stage} size={2} />,
+        );
+        const { width, height } = spriteGeometry(container);
+        return `${width}x${height}`;
+      });
+      expect(new Set(boxes).size, stage).toBe(1);
+    }
+  });
+
+  it("defaults a missing stage to grown, so an older server does not shrink pets", () => {
+    const grown = spriteGeometry(
+      render(<PetCharacter type="cat" stage="grown" size={2} />).container,
+    );
+    const missing = spriteGeometry(
+      render(<PetCharacter type="cat" size={2} />).container,
+    );
+    expect(`${missing.width}x${missing.height}`).toBe(
+      `${grown.width}x${grown.height}`,
+    );
   });
 });

--- a/client/src/components/PetCharacter.tsx
+++ b/client/src/components/PetCharacter.tsx
@@ -4,6 +4,7 @@ import type { AnimState } from "./PixelCharacter";
 import type { PetType } from "@/lib/types";
 import { ART_PX } from "@/lib/scene";
 import { PET_ART } from "@/lib/petMaps";
+import type { PetStage } from "@/lib/petLevel";
 import PixelSprite from "./PixelSprite";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -16,6 +17,9 @@ import PixelSprite from "./PixelSprite";
 
 interface PetCharacterProps {
   type: PetType;
+  /** Missing on an older server; grown is today's art, so a client-first
+   *  deploy does not shrink every pet to young. */
+  stage?: PetStage | null;
   anim?: AnimState;
   facing?: "right" | "left";
   size?: number;
@@ -26,6 +30,7 @@ const STEP_MS = 250;
 
 export default function PetCharacter({
   type,
+  stage = "grown",
   anim = "idle",
   facing = "right",
   size = ART_PX,
@@ -42,7 +47,7 @@ export default function PetCharacter({
   }, [anim]);
 
   const frame = anim === "walk" ? walkFrame : 0;
-  const art = PET_ART[type];
+  const art = PET_ART[type][stage ?? "grown"];
 
   let animClass = "";
   if (anim === "idle") animClass = "pixel-idle";

--- a/client/src/hooks/useGameSession.test.tsx
+++ b/client/src/hooks/useGameSession.test.tsx
@@ -223,3 +223,73 @@ describe("useGameSession connection lifecycle", () => {
     await waitFor(() => expect(fakeSocket.connectCalls).toBeGreaterThan(before));
   });
 });
+
+describe("useGameSession pet stage", () => {
+  beforeEach(() => {
+    fakeSocket = createFakeSocket();
+    sessionStorage.clear();
+  });
+
+  const sync = (players: Record<string, unknown>) => ({
+    mode: "pomodoro" as const,
+    phase: "waiting" as const,
+    focusDuration: 1500,
+    breakDuration: 300,
+    phaseStartTime: null,
+    world: "forest",
+    players,
+    playerCount: Object.keys(players).length,
+    sessionId: "sess-1",
+  });
+
+  it("takes own petStage from sync_state", async () => {
+    const { result } = renderHook(() => useGameSession(null));
+    await waitFor(() => expect(fakeSocket.listenerCount("connect")).toBeGreaterThan(0));
+    act(() => fakeSocket.connect());
+    act(() =>
+      fakeSocket.fire(
+        "sync_state",
+        sync({
+          "sock-1": {
+            avatar: {},
+            displayName: "Me",
+            pet: "cat",
+            petStage: "full",
+          },
+        }),
+      ),
+    );
+    await waitFor(() => expect(result.current.myPetStage).toBe("full"));
+  });
+
+  it("updates own stage when the server emits pet_changed for this socket", async () => {
+    const { result } = renderHook(() => useGameSession(null));
+    await waitFor(() => expect(fakeSocket.listenerCount("connect")).toBeGreaterThan(0));
+    act(() => fakeSocket.connect());
+    act(() =>
+      fakeSocket.fire("pet_changed", {
+        playerId: "sock-1",
+        pet: "cat",
+        petStage: "grown",
+      }),
+    );
+    await waitFor(() => expect(result.current.myPetStage).toBe("grown"));
+  });
+
+  it("reads the partner's stage off their slot", async () => {
+    const { result } = renderHook(() => useGameSession(null));
+    await waitFor(() => expect(fakeSocket.listenerCount("connect")).toBeGreaterThan(0));
+    act(() => fakeSocket.connect());
+    act(() =>
+      fakeSocket.fire(
+        "sync_state",
+        sync({
+          "sock-1": { avatar: {}, displayName: "Me", pet: "cat", petStage: "young" },
+          "sock-2": { avatar: {}, displayName: "Them", pet: "dog", petStage: "full" },
+        }),
+      ),
+    );
+    await waitFor(() => expect(result.current.partnerPet).toBe("dog"));
+    expect(result.current.partnerPetStage).toBe("full");
+  });
+});

--- a/client/src/hooks/useGameSession.ts
+++ b/client/src/hooks/useGameSession.ts
@@ -4,6 +4,7 @@ import { io, Socket } from "socket.io-client";
 import type { GamePhase } from "@/components/GameWorld";
 import type { AvatarConfig, WorldId } from "@/lib/avatarData";
 import type { Profile, PetType } from "@/lib/types";
+import type { PetStage } from "@/lib/petLevel";
 import type {
   PlayerData,
   SyncPayload,
@@ -33,6 +34,7 @@ export function useGameSession(profile: Profile | null) {
   // number.
   const [myWorld, setMyWorld] = useState<WorldId>("forest");
   const [myPet, setMyPetState] = useState<PetType | null>(null);
+  const [myPetStage, setMyPetStage] = useState<PetStage | null>(null);
   // Ref mirrors so the socket handlers — registered once with [] deps — read
   // current values instead of whatever was captured at mount. Without this, an
   // invite sent before a session exists is relayed by the session_created
@@ -218,6 +220,12 @@ export function useGameSession(profile: Profile | null) {
         setPlayers(data.players || {});
         if (data.world) setMyWorld(data.world as WorldId);
         if (data.sessionId) setSessionId(data.sessionId);
+        // Own stage comes from the slot, not a local guess: useStats is stale
+        // during a session, and a client-sent stage is ignored by the server.
+        const self = socket.id ? data.players?.[socket.id] : undefined;
+        if (self) {
+          setMyPetStage(self.pet ? (self.petStage ?? "grown") : null);
+        }
         // Mirror the phase in both directions. Only ever setting this to true
         // left the *other* player stuck after someone pressed end-session:
         // phase went back to "waiting" but sessionStarted stayed true, which
@@ -242,27 +250,54 @@ export function useGameSession(profile: Profile | null) {
           avatar,
           displayName,
           pet,
+          petStage,
         }: {
           playerId: string;
           avatar: AvatarConfig;
           displayName?: string;
           pet?: PetType | null;
+          petStage?: PetStage | null;
         }) => {
           setPlayers((prev) => ({
             ...prev,
-            [playerId]: { avatar, displayName, pet: pet ?? null },
+            [playerId]: {
+              avatar,
+              displayName,
+              pet: pet ?? null,
+              petStage: pet ? (petStage ?? "grown") : null,
+            },
           }));
         },
       );
 
       socket.on(
         "pet_changed",
-        ({ playerId, pet }: { playerId: string; pet: PetType | null }) => {
+        ({
+          playerId,
+          pet,
+          petStage,
+        }: {
+          playerId: string;
+          pet: PetType | null;
+          petStage?: PetStage | null;
+        }) => {
           setPlayers((prev) =>
             prev[playerId]
-              ? { ...prev, [playerId]: { ...prev[playerId], pet } }
+              ? {
+                  ...prev,
+                  [playerId]: {
+                    ...prev[playerId],
+                    pet,
+                    petStage: pet ? (petStage ?? "grown") : null,
+                  },
+                }
               : prev,
           );
+          // The server emits to the whole room, including the picker, so the
+          // originator sees the derived size rather than guessing from stats.
+          if (playerId === socket.id) {
+            setMyPetStage(pet ? (petStage ?? "grown") : null);
+          }
         },
       );
 
@@ -441,6 +476,7 @@ export function useGameSession(profile: Profile | null) {
   const partnerName = partnerEntry?.[1].displayName;
   const partnerUserId = partnerEntry?.[1].userId ?? null;
   const partnerPet = partnerEntry?.[1].pet ?? null;
+  const partnerPetStage = partnerEntry?.[1].petStage ?? null;
   const partnerDisconnected = partnerEntry?.[1].disconnected ?? false;
 
   const playerCount = Object.keys(players).length;
@@ -569,6 +605,7 @@ export function useGameSession(profile: Profile | null) {
     // and a setter here is a way to put the client back in charge of it.
     myWorld,
     myPet,
+    myPetStage,
     setMyPet,
     // Session config
     timerMode,
@@ -595,6 +632,7 @@ export function useGameSession(profile: Profile | null) {
     partnerName,
     partnerUserId,
     partnerPet,
+    partnerPetStage,
     partnerDisconnected,
     playerCount,
     // Session actions

--- a/client/src/lib/characterMaps.test.ts
+++ b/client/src/lib/characterMaps.test.ts
@@ -7,7 +7,8 @@ import {
   WALK_POSES,
   type CharacterPose,
 } from "./characterMaps";
-import { PET_ART, PET_W, PET_H } from "./petMaps";
+import { PET_ART, PET_STAGE_SIZE } from "./petMaps";
+import { PET_STAGES } from "./petLevel";
 import { keysUsed } from "./pixelMap";
 import {
   DEFAULT_AVATAR,
@@ -167,21 +168,31 @@ describe("character palette", () => {
 describe("pet maps", () => {
   const PETS = PET_OPTIONS.map((o) => o.type);
 
-  it("draws every pet on one grid, fully inside it", () => {
+  it("draws every pet on its stage's grid, fully inside it", () => {
     for (const type of PETS) {
-      for (const frame of PET_ART[type].frames) {
-        expect(frame.length, type).toBe(PET_H);
-        for (const row of frame) expect(row.length, type).toBe(PET_W);
+      for (const stage of PET_STAGES) {
+        const { w, h } = PET_STAGE_SIZE[stage];
+        for (const frame of PET_ART[type][stage].frames) {
+          expect(frame.length, `${type} ${stage}`).toBe(h);
+          for (const row of frame) {
+            expect(row.length, `${type} ${stage}`).toBe(w);
+          }
+        }
       }
     }
   });
 
   it("colours every key each pet uses", () => {
     for (const type of PETS) {
-      const { frames, palette } = PET_ART[type];
-      for (const frame of frames) {
-        for (const key of keysUsed(frame)) {
-          expect(palette[key], `${type} has no colour for "${key}"`).toBeTruthy();
+      for (const stage of PET_STAGES) {
+        const { frames, palette } = PET_ART[type][stage];
+        for (const frame of frames) {
+          for (const key of keysUsed(frame)) {
+            expect(
+              palette[key],
+              `${type} ${stage} has no colour for "${key}"`,
+            ).toBeTruthy();
+          }
         }
       }
     }
@@ -191,27 +202,34 @@ describe("pet maps", () => {
     // The regression: the cat and the rabbit each drew a leg one row below
     // their viewBox, so each walked on one leg, alternating which.
     for (const type of PETS) {
-      for (const [i, frame] of PET_ART[type].frames.entries()) {
-        const feet = [...frame[PET_H - 1]].filter((c) => c !== ".").length;
-        expect(feet, `${type} frame ${i}`).toBeGreaterThanOrEqual(4);
+      for (const stage of PET_STAGES) {
+        const h = PET_STAGE_SIZE[stage].h;
+        for (const [i, frame] of PET_ART[type][stage].frames.entries()) {
+          const feet = [...frame[h - 1]].filter((c) => c !== ".").length;
+          expect(feet, `${type} ${stage} frame ${i}`).toBeGreaterThanOrEqual(4);
+        }
       }
     }
   });
 
   it("actually steps between frames", () => {
     for (const type of PETS) {
-      const [a, b] = PET_ART[type].frames;
-      expect(a.join("\n"), type).not.toBe(b.join("\n"));
+      for (const stage of PET_STAGES) {
+        const [a, b] = PET_ART[type][stage].frames;
+        expect(a.join("\n"), `${type} ${stage}`).not.toBe(b.join("\n"));
+      }
     }
   });
 
-  it("gives each pet a different silhouette", () => {
-    // At nine pixels wide the outline is all there is to tell them apart.
-    const shapes = PETS.map((type) =>
-      PET_ART[type].frames[0]
-        .map((row) => [...row].map((c) => (c === "." ? "." : "#")).join(""))
-        .join("\n"),
-    );
-    expect(new Set(shapes).size).toBe(PETS.length);
+  it("gives each pet a different silhouette at every stage", () => {
+    // At these sizes the outline is all there is to tell them apart.
+    for (const stage of PET_STAGES) {
+      const shapes = PETS.map((type) =>
+        PET_ART[type][stage].frames[0]
+          .map((row) => [...row].map((c) => (c === "." ? "." : "#")).join(""))
+          .join("\n"),
+      );
+      expect(new Set(shapes).size, stage).toBe(PETS.length);
+    }
   });
 });

--- a/client/src/lib/petLevel.test.ts
+++ b/client/src/lib/petLevel.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { PET_STAGES, petStageAt, isPetStage } from "./petLevel";
+
+/**
+ * The cross-package pin.
+ *
+ * Byte-identical to the table in `server/petLevel.test.js`. These are
+ * recorded outputs, not independently-derived expectations — the properties
+ * below are what check the design. What this table is for is *agreement*:
+ * edit one implementation's thresholds and the other package's suite fails.
+ * Two people looking at two different animals is invisible from inside
+ * either half alone.
+ */
+const PINNED: [number, string][] = [
+  [0, "young"],
+  [1, "young"],
+  [10799, "young"],
+  [10800, "grown"],
+  [53999, "grown"],
+  [54000, "full"],
+  [360000, "full"],
+];
+
+describe("petStageAt", () => {
+  it("matches the pinned schedule shared with the server", () => {
+    for (const [seconds, stage] of PINNED) {
+      expect(`${seconds} -> ${petStageAt(seconds)}`).toBe(
+        `${seconds} -> ${stage}`,
+      );
+    }
+  });
+
+  it("treats missing and junk totals as young, not full", () => {
+    for (const junk of [undefined, null, NaN, -1, "-5", "", "full"]) {
+      expect(petStageAt(junk), String(junk)).toBe("young");
+    }
+  });
+
+  it("only ever returns a real stage", () => {
+    for (const s of [-1, 0, 10799, 10800, 53999, 54000, 1e12]) {
+      expect(PET_STAGES).toContain(petStageAt(s));
+    }
+  });
+
+  it("is monotonic: more focus never shrinks the pet", () => {
+    let prev = 0;
+    const rank = { young: 0, grown: 1, full: 2 };
+    for (let s = 0; s <= 20 * 3600; s += 600) {
+      const next = rank[petStageAt(s)];
+      expect(next).toBeGreaterThanOrEqual(prev);
+      prev = next;
+    }
+  });
+});
+
+describe("isPetStage", () => {
+  it("accepts the three stages and nothing else", () => {
+    for (const stage of PET_STAGES) expect(isPetStage(stage)).toBe(true);
+    expect(isPetStage("baby")).toBe(false);
+    expect(isPetStage("grown ")).toBe(false);
+    expect(isPetStage(null)).toBe(false);
+    expect(isPetStage(2)).toBe(false);
+  });
+});

--- a/client/src/lib/petLevel.ts
+++ b/client/src/lib/petLevel.ts
@@ -1,0 +1,67 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Pet growth — derived from total completed focus, never stored.
+//
+// A companion that gets bigger because of hours you actually put in is the
+// first thing in the product that rewards returning. Growth is a *map with
+// more cells* at the same ART_PX, never a scale multiplier — a 9×7 cat at
+// size={4} is the same cat with bigger pixels, not a bigger cat.
+//
+// **Derived, not stored**, same instinct as the world rotation and for the
+// same reason: a stored counter is a thing to migrate, resync and reconcile,
+// and it can disagree with the history it is supposed to summarise. Total
+// completed focus seconds already live in `sessions` / `session_participants`.
+// `level = f(totalFocusSeconds)` needs no new column, cannot drift, and is
+// automatically right for existing users the day it ships.
+//
+// **This file is duplicated at `server/petLevel.js`.** `client/` and `server/`
+// are independent npm packages and cannot import each other. Both copies are
+// pinned to the same table of (seconds → stage) in their tests, so editing
+// one and not the other fails the other package's suite rather than silently
+// showing two people two different animals.
+//
+// The server is still the authority in a session. This copy exists so the
+// client can reason about its own pet before `sync_state` lands, and so the
+// tests have something to pin. A client-sent stage is ignored.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const PET_STAGES = ["young", "grown", "full"] as const;
+export type PetStage = (typeof PET_STAGES)[number];
+
+/**
+ * Seconds of completed focus before the pet grows from young → grown.
+ *
+ * Three hours is about seven ordinary pomodoros — inside a week of two
+ * 25-minute sessions a day, which is the "ordinary use" the thresholds
+ * were aimed at.
+ */
+export const GROWN_AT_SECONDS = 3 * 60 * 60;
+
+/**
+ * Seconds of completed focus before the pet grows from grown → full.
+ *
+ * Fifteen hours is a few weeks at that same pace. Stop there: a companion
+ * taller than about 0.38× its owner stops reading as a pet.
+ */
+export const FULL_AT_SECONDS = 15 * 60 * 60;
+
+/** True when `value` is one of the three stages. */
+export function isPetStage(value: unknown): value is PetStage {
+  return (
+    typeof value === "string" &&
+    (PET_STAGES as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Stage for a total of completed focus seconds.
+ *
+ * Junk input (NaN, negative, missing) is young — that's 0 hours, not a
+ * reason to skip to full. The server is what stops a client from sending
+ * `'full'` and getting it.
+ */
+export function petStageAt(focusSeconds: unknown): PetStage {
+  const s = Number(focusSeconds);
+  if (!Number.isFinite(s) || s < GROWN_AT_SECONDS) return "young";
+  if (s < FULL_AT_SECONDS) return "grown";
+  return "full";
+}

--- a/client/src/lib/petMaps.ts
+++ b/client/src/lib/petMaps.ts
@@ -1,29 +1,24 @@
 // ─────────────────────────────────────────────────────────────────────────────
-// Pet maps — the companions as string maps.
+// Pet maps — the companions as string maps, in three sizes.
 //
-// ── Why they got smaller ────────────────────────────────────────────────────
-// The pets were 10 x 11 cells. On ART_PX that is 30 x 33 px beside a 48 x 72
-// person, i.e. a cat 0.46x a human's height — a cat is about 0.25x. They only
-// ever looked right because they used to render at a *smaller pixel* than the
-// character did, which is the density mismatch PR #36 removed: the fix put them
-// on the same grid and the size problem became visible.
+// Growth is more cells at the same ART_PX, never a scale multiplier. A 9×7
+// cat at size={4} is the same cat with bigger pixels, not a bigger cat. The
+// three stages:
 //
-// So they are redrawn at 9 x 7, which is 27 x 21 px, or 0.29x a person. The
-// wrong fix is putting `size` back to 2 — that reintroduces two pixel grids in
-// one frame, and a scene with two pixel sizes reads as broken no matter how
-// well-proportioned the things in it are.
+//   young  7×5   21×15 px   0.21× a person
+//   grown  9×7   27×21 px   0.29× a person   ← today's art, unchanged
+//   full   11×9  33×27 px   0.38× a person
 //
-// ── What seven rows costs you ───────────────────────────────────────────────
-// Every pet is a head with a body under it, seen face-on. That is a choice, not
-// a limitation to apologise for: at this size the head is the only part with
-// room for anything readable, so it gets four of the seven rows and the body
-// gets two. The first attempt drew face-on heads with side-on tails, and the
-// tails read as detached sticks floating beside the animal — mixing two views
-// in nine pixels does not survive.
+// Stop at 0.38×: a companion taller than half its owner stops reading as a
+// pet. The grown maps are the ones that shipped in #39; young and full are
+// the same silhouettes with less or more room for the same tells (cat ears
+// at the corners, dog ears down the sides, dragon horns and wings, rabbit
+// ears above).
 //
-// Everything distinguishing therefore happens in the silhouette: cat ear
-// points, dog ears down the sides of the head, dragon horns and wings, rabbit
-// ears above it. Interior detail is two eyes and a nose.
+// ── What seven (or five, or nine) rows costs you ────────────────────────────
+// Every pet is a head with a body under it, seen face-on. That is a choice:
+// at this size the head is the only part with room for anything readable.
+// Everything distinguishing therefore happens in the silhouette.
 //
 // ── The key alphabet ────────────────────────────────────────────────────────
 //   C coat        c coat in shadow      M muzzle / marking
@@ -33,10 +28,20 @@
 import type { PixelMap, PixelPalette } from "@/components/PixelSprite";
 import { place } from "./pixelMap";
 import { shade } from "./palette";
+import type { PetStage } from "./petLevel";
 import type { PetType } from "./types";
 
-export const PET_W = 9;
-export const PET_H = 7;
+export type { PetStage };
+
+export const PET_STAGE_SIZE: Record<PetStage, { w: number; h: number }> = {
+  young: { w: 7, h: 5 },
+  grown: { w: 9, h: 7 },
+  full: { w: 11, h: 9 },
+};
+
+/** Grown size, the one the rest of the scene was drawn against. */
+export const PET_W = PET_STAGE_SIZE.grown.w;
+export const PET_H = PET_STAGE_SIZE.grown.h;
 
 /**
  * Both walk frames plant both feet on the bottom row.
@@ -46,19 +51,27 @@ export const PET_H = 7;
  * shipped with, each walking on one leg. So the step is a change of *stance*,
  * feet together and feet apart, and the bottom row is never empty.
  */
-const FEET_TOGETHER = "..cc.cc..";
-const FEET_APART = ".cc...cc.";
+const FEET: Record<PetStage, { together: string; apart: string }> = {
+  young: { together: ".cc.cc.", apart: "cc...cc" },
+  grown: { together: "..cc.cc..", apart: ".cc...cc." },
+  full: { together: "...cc.cc...", apart: "..cc...cc.." },
+};
 
 interface PetArt {
   frames: [PixelMap, PixelMap];
   palette: PixelPalette;
 }
 
-/** Six rows of body plus the two foot stances. */
-function pet(body: readonly string[], palette: PixelPalette): PetArt {
-  const frame = (feet: string) =>
-    place(0, [...body, feet], PET_H, PET_W);
-  return { frames: [frame(FEET_TOGETHER), frame(FEET_APART)], palette };
+/** Body rows plus the two foot stances, sized to the stage. */
+function pet(
+  stage: PetStage,
+  body: readonly string[],
+  palette: PixelPalette,
+): PetArt {
+  const { w, h } = PET_STAGE_SIZE[stage];
+  const feet = FEET[stage];
+  const frame = (feetRow: string) => place(0, [...body, feetRow], h, w);
+  return { frames: [frame(feet.together), frame(feet.apart)], palette };
 }
 
 const coat = (base: string, rest: PixelPalette): PixelPalette => ({
@@ -67,58 +80,152 @@ const coat = (base: string, rest: PixelPalette): PixelPalette => ({
   ...rest,
 });
 
-export const PET_ART: Record<PetType, PetArt> = {
-  // Pointed ears at the head's corners, tail curling out to one side.
-  cat: pet(
-    [
-      ".C.....C.",
-      ".CCCCCCC.",
-      ".CECCCEC.",
-      ".CCCNCCC.",
-      "..CCCCCcc",
-      "..CCCCC.c",
-    ],
-    coat("#E2A65C", { E: "#2C3A4A", N: "#C4604A" }),
-  ),
+const CAT = coat("#E2A65C", { E: "#2C3A4A", N: "#C4604A" });
+const DOG = coat("#C99A63", { E: "#3B2411", M: "#EFD9B4", N: "#2A1808" });
+const DRAGON = coat("#A78BFA", { E: "#FFC93C", N: "#7C3AED" });
+const RABBIT = coat("#EFE6D6", { E: "#8A5A6B", N: "#E39AA0", W: "#FFFFFF" });
+
+export const PET_ART: Record<PetType, Record<PetStage, PetArt>> = {
+  cat: {
+    // Pointed ears at the head's corners, tail curling out to one side.
+    young: pet(
+      "young",
+      [".C...C.", ".CCCCC.", ".CENCE.", ".CCCCCc"],
+      CAT,
+    ),
+    grown: pet(
+      "grown",
+      [
+        ".C.....C.",
+        ".CCCCCCC.",
+        ".CECCCEC.",
+        ".CCCNCCC.",
+        "..CCCCCcc",
+        "..CCCCC.c",
+      ],
+      CAT,
+    ),
+    full: pet(
+      "full",
+      [
+        ".C.......C.",
+        ".CCCCCCCCC.",
+        ".CCECCCECC.",
+        ".CCCCCCCCC.",
+        ".CCCCNCCCC.",
+        "...CCCCCcc.",
+        "...CCCCCc.c",
+        "...CCCCC..c",
+      ],
+      CAT,
+    ),
+  },
 
   // Ears down the sides rather than above — that plus the muzzle is the whole
-  // difference between this and the cat at nine pixels wide.
-  dog: pet(
-    [
-      "CC.....CC",
-      "cCCCCCCCc",
-      "cCECCCECc",
-      ".CCMMMCC.",
-      "..CCCCCc.",
-      "..CCCCC..",
-    ],
-    coat("#C99A63", { E: "#3B2411", M: "#EFD9B4", N: "#2A1808" }),
-  ),
+  // difference between this and the cat at these sizes.
+  dog: {
+    young: pet(
+      "young",
+      ["CC...CC", "cCECECc", ".CCMMC.", ".CCCCC."],
+      DOG,
+    ),
+    grown: pet(
+      "grown",
+      [
+        "CC.....CC",
+        "cCCCCCCCc",
+        "cCECCCECc",
+        ".CCMMMCC.",
+        "..CCCCCc.",
+        "..CCCCC..",
+      ],
+      DOG,
+    ),
+    full: pet(
+      "full",
+      [
+        "CC.......CC",
+        "cCCCCCCCCCc",
+        "cCCECCCECCc",
+        ".CCMMMMMCC.",
+        ".CCCCCCCCC.",
+        "..CCCCCCCc.",
+        "..CCCCCC...",
+        "..CCCCC....",
+      ],
+      DOG,
+    ),
+  },
 
   // Horns up, wings out at the shoulders, gold eyes.
-  dragon: pet(
-    [
-      "..c...c..",
-      ".CCCCCCC.",
-      ".CECCCEC.",
-      ".CCCNCCC.",
-      "cCCCCCCCc",
-      "..CCCCC.c",
-    ],
-    coat("#A78BFA", { E: "#FFC93C", N: "#7C3AED" }),
-  ),
+  dragon: {
+    young: pet(
+      "young",
+      [".c...c.", ".CCCCC.", ".CENCE.", "cCCCCCc"],
+      DRAGON,
+    ),
+    grown: pet(
+      "grown",
+      [
+        "..c...c..",
+        ".CCCCCCC.",
+        ".CECCCEC.",
+        ".CCCNCCC.",
+        "cCCCCCCCc",
+        "..CCCCC.c",
+      ],
+      DRAGON,
+    ),
+    full: pet(
+      "full",
+      [
+        "..c.....c..",
+        ".CCCCCCCCC.",
+        ".CCECCCECC.",
+        ".CCCCCCCCC.",
+        ".CCCCNCCCC.",
+        "cCCCCCCCCCc",
+        "..CCCCCcc.c",
+        "..CCCCC...c",
+      ],
+      DRAGON,
+    ),
+  },
 
-  // Two rows of ear, which is most of what a rabbit is from the front, so it
-  // sits up and gets only one row of body.
-  rabbit: pet(
-    [
-      "...C.C...",
-      "...C.C...",
-      ".CCCCCCC.",
-      ".CECCCEC.",
-      ".CCCNCCC.",
-      "..CCCCCWW",
-    ],
-    coat("#EFE6D6", { E: "#8A5A6B", N: "#E39AA0", W: "#FFFFFF" }),
-  ),
+  // Two rows of ear, which is most of what a rabbit is from the front. Full
+  // gets a third so the ears scale with the rest of it; young keeps two and
+  // drops the body, same sit-up as grown.
+  rabbit: {
+    young: pet(
+      "young",
+      ["..C.C..", "..C.C..", ".CENCE.", ".CCCWW."],
+      RABBIT,
+    ),
+    grown: pet(
+      "grown",
+      [
+        "...C.C...",
+        "...C.C...",
+        ".CCCCCCC.",
+        ".CECCCEC.",
+        ".CCCNCCC.",
+        "..CCCCCWW",
+      ],
+      RABBIT,
+    ),
+    full: pet(
+      "full",
+      [
+        "...C...C...",
+        "...C...C...",
+        "...C...C...",
+        ".CCCCCCCCC.",
+        ".CCECCCECC.",
+        ".CCCCNCCCC.",
+        "..CCCCCCC..",
+        "..CCCCCWWW.",
+      ],
+      RABBIT,
+    ),
+  },
 };

--- a/client/src/lib/sessionTypes.ts
+++ b/client/src/lib/sessionTypes.ts
@@ -1,6 +1,7 @@
 import type { GamePhase } from "@/components/GameWorld";
 import type { AvatarConfig } from "./avatarData";
 import type { PetType } from "./types";
+import type { PetStage } from "./petLevel";
 
 export type AppStep = "loading" | "landing" | "avatar" | "home" | "game";
 
@@ -12,6 +13,9 @@ export interface PlayerData {
    *  task's owner_id to a name without a second round trip. */
   userId?: string | null;
   pet?: PetType | null;
+  /** Server-derived growth stage. Missing on an older server; treat as grown
+   *  so a client-first deploy does not shrink every pet to young. */
+  petStage?: PetStage | null;
   /** True while the player's socket dropped and the server is holding their
    *  spot during the reconnect grace window. */
   disconnected?: boolean;

--- a/client/src/lib/types.ts
+++ b/client/src/lib/types.ts
@@ -42,6 +42,8 @@ export type Task = {
   completed_by: string | null;
 };
 
+export type { PetStage } from "./petLevel";
+
 export type PetType = "cat" | "dog" | "dragon" | "rabbit";
 
 export const PET_OPTIONS: { type: PetType; label: string; emoji: string }[] = [

--- a/server/createSession.test.js
+++ b/server/createSession.test.js
@@ -126,3 +126,63 @@ describe("create_session assigns the rotating world", () => {
     expect(ROTATION_WORLDS).toContain(world);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pet stage is the server's to decide, same shape as the world.
+//
+// Dev mode has no Supabase, so totalFocusSeconds is 0 and a pet is young.
+// Run against the previous commit and `petStage` is missing from the slot,
+// so these fail — that's the A/B.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function createAndSlot(payload, sub) {
+  return new Promise((resolve, reject) => {
+    const socket = connect(url, {
+      auth: { token: fakeToken(sub) },
+      transports: ["websocket"],
+    });
+    const timer = setTimeout(() => {
+      socket.close();
+      reject(new Error("no sync_state"));
+    }, 10_000);
+    socket.on("connect_error", (err) => {
+      clearTimeout(timer);
+      socket.close();
+      reject(err);
+    });
+    socket.on("sync_state", (state) => {
+      clearTimeout(timer);
+      const me = state.players[socket.id];
+      socket.close();
+      resolve(me);
+    });
+    socket.on("connect", () => {
+      socket.emit("create_session", { avatar: AVATAR, displayName: "Tester", ...payload });
+    });
+  });
+}
+
+describe("create_session assigns pet stage from focus, not the payload", () => {
+  it("ignores a petStage sent by the client", async () => {
+    const me = await createAndSlot(
+      { pet: "cat", petStage: "full" },
+      "55555555-5555-4555-8555-555555555555",
+    );
+    expect(me.pet).toBe("cat");
+    expect(me.petStage).toBe("young");
+  });
+
+  it("does not put focusSeconds on the wire", async () => {
+    const me = await createAndSlot(
+      { pet: "dog" },
+      "66666666-6666-4666-8666-666666666666",
+    );
+    expect(me).not.toHaveProperty("focusSeconds");
+  });
+
+  it("leaves stage empty when there is no pet", async () => {
+    const me = await createAndSlot({}, "77777777-7777-4777-8777-777777777777");
+    expect(me.pet).toBe(null);
+    expect(me.petStage).toBe(null);
+  });
+});

--- a/server/index.js
+++ b/server/index.js
@@ -10,6 +10,7 @@ const {
   addPlayer,
   removePlayer,
   setPlayerPet,
+  creditFocus,
   inviteUser,
   isInvited,
   findPlayerByUserId,
@@ -19,6 +20,7 @@ const {
   buildSyncPayload,
 } = require('./session');
 const { worldAt } = require('./rotation');
+const { petStageAt, GROWN_AT_SECONDS } = require('./petLevel');
 require('dotenv').config();
 
 const supabase = (process.env.SUPABASE_URL && process.env.SUPABASE_SERVICE_KEY)
@@ -65,6 +67,40 @@ function sanitizePet(pet) {
   return VALID_PETS.includes(pet) ? pet : null;
 }
 
+// Completed focus seconds for one user, the input to petStageAt(). Service
+// role bypasses RLS; the filter is the user id. A failed read returns null
+// so the caller can keep the current look (grown) rather than shrinking
+// everyone to young — a zero and a failure must not render the same way.
+async function totalFocusSeconds(userId) {
+  if (!supabase || !userId) return 0;
+  const { data, error } = await supabase
+    .from('session_participants')
+    .select('sessions!inner(actual_focus, completed)')
+    .eq('user_id', userId)
+    .eq('sessions.completed', true);
+  if (error) {
+    console.error('Failed to load focus total:', error.message);
+    return null;
+  }
+  return (data ?? []).reduce((sum, row) => {
+    const focus = row.sessions?.actual_focus;
+    return sum + (typeof focus === 'number' ? focus : 0);
+  }, 0);
+}
+
+function stageForTotal(seconds) {
+  // A failed fetch is not 0 hours. Leave the pet at today's size rather
+  // than pretending the user is new.
+  if (seconds === null) return 'grown';
+  return petStageAt(seconds);
+}
+
+// Keep the cached total consistent with stageForTotal: a failed fetch
+// must not later recompute as young when the user picks a different pet.
+function cachedFocus(seconds) {
+  return seconds === null ? GROWN_AT_SECONDS : seconds;
+}
+
 function sanitizeAvatar(avatar) {
   if (!avatar || typeof avatar !== 'object') return null;
   const { skinColor, hairStyle, hairColor, eyeStyle, outfitColor } = avatar;
@@ -104,7 +140,7 @@ io.use(async (socket, next) => {
 // sessions[sessionId] = {
 //   phase, focusDuration, breakDuration, phaseStartTime, phaseTimer,
 //   world, hostId (socketId),
-//   players: { [socketId]: { avatar, displayName, userId, pet } }
+//   players: { [socketId]: { avatar, displayName, userId, pet, petStage } }
 // }
 const sessions = {};
 const socketToSession = {};
@@ -257,6 +293,14 @@ async function recordSession(sessionId, session, completed, participantIds) {
       console.error(`[${sessionId}] Failed to record participants:`, pError.message);
     } else {
       console.log(`[${sessionId}] Session recorded: ${actualFocus}s, ${completed ? 'completed' : 'stopped early'}, ${userIds.length} participants`);
+      // Only completed rows feed get_focus_stats, so only those grow the pet.
+      // Credit the in-memory total rather than re-querying: the row was just
+      // written, and a replica lag would otherwise delay the growth by a round.
+      if (completed && sessions[sessionId]) {
+        for (const update of creditFocus(session, userIds, actualFocus)) {
+          io.to(sessionId).emit('pet_changed', update);
+        }
+      }
     }
   } catch (err) {
     console.error(`[${sessionId}] Session recording error:`, err);
@@ -494,7 +538,7 @@ io.on('connection', (socket) => {
   // field in the payload is ignored rather than rejected, so an older client
   // still gets a session instead of an error. There is nothing left to validate
   // here because there is nothing left to trust.
-  socket.on('create_session', ({ avatar, displayName, pet }) => {
+  socket.on('create_session', async ({ avatar, displayName, pet }) => {
     if (!rateLimits.createSession(socket.id)) {
       socket.emit('session_error', { message: 'Too many requests, slow down' });
       return;
@@ -512,6 +556,8 @@ io.on('connection', (socket) => {
     if (prevSession) leaveSession(socket, prevSession);
 
     const userId = socket.userId || null;
+    const safePet = sanitizePet(pet);
+    const focusSeconds = await totalFocusSeconds(userId);
 
     const session = createSessionState(safeWorld, socket.id);
     const sessionId = session.id;
@@ -523,7 +569,12 @@ io.on('connection', (socket) => {
       avatar: safeAvatar,
       displayName: safeName,
       userId,
-      pet: sanitizePet(pet),
+      pet: safePet,
+      // petStage in the payload is ignored the same way world is — the server
+      // derives it from this user's completed focus, so two people never see
+      // different animals in one room.
+      petStage: safePet ? stageForTotal(focusSeconds) : null,
+      focusSeconds: cachedFocus(focusSeconds),
     });
 
     if (userId) setPresence(userId, sessionId, safeWorld);
@@ -590,6 +641,8 @@ io.on('connection', (socket) => {
     }
 
     const safePet = sanitizePet(pet);
+    const focusSeconds = await totalFocusSeconds(userId);
+    const petStage = safePet ? stageForTotal(focusSeconds) : null;
     socket.join(sessionId);
     socketToSession[socket.id] = sessionId;
     const playerCount = addPlayer(session, socket.id, {
@@ -597,6 +650,8 @@ io.on('connection', (socket) => {
       displayName: safeName,
       userId,
       pet: safePet,
+      petStage,
+      focusSeconds: cachedFocus(focusSeconds),
     });
 
     if (userId) setPresence(userId, sessionId, session.world);
@@ -607,6 +662,7 @@ io.on('connection', (socket) => {
       avatar: safeAvatar,
       displayName: safeName,
       pet: safePet,
+      petStage,
     });
 
     socket.emit('sync_state', buildSyncPayload(session));
@@ -708,14 +764,22 @@ io.on('connection', (socket) => {
   });
 
   // set_pet: { sessionId, pet }
-  // Change your pet mid-session; relayed to the other player.
+  // Change your pet mid-session; relayed to the other player. Stage is
+  // derived here, never taken from the payload, and emitted to the whole
+  // room (including the sender) so the picker sees the server's size.
   socket.on('set_pet', ({ sessionId, pet }) => {
     const session = getSession(sessionId);
     if (!session) return;
-    if (!session.players[socket.id]) return; // Only participants
+    const player = session.players[socket.id];
+    if (!player) return; // Only participants
     const safePet = sanitizePet(pet);
-    setPlayerPet(session, socket.id, safePet);
-    socket.to(sessionId).emit('pet_changed', { playerId: socket.id, pet: safePet });
+    const petStage = safePet ? petStageAt(player.focusSeconds || 0) : null;
+    setPlayerPet(session, socket.id, safePet, petStage);
+    io.to(sessionId).emit('pet_changed', {
+      playerId: socket.id,
+      pet: safePet,
+      petStage,
+    });
   });
 
   // leave_session: no payload needed — the server knows which session this

--- a/server/petLevel.js
+++ b/server/petLevel.js
@@ -1,0 +1,70 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Pet growth — derived from total completed focus, never stored.
+//
+// A companion that gets bigger because of hours you actually put in is the
+// first thing in the product that rewards returning. Growth is a *map with
+// more cells* at the same ART_PX, never a scale multiplier — a 9×7 cat at
+// size={4} is the same cat with bigger pixels, not a bigger cat.
+//
+// **Derived, not stored**, same instinct as the world rotation and for the
+// same reason: a stored counter is a thing to migrate, resync and reconcile,
+// and it can disagree with the history it is supposed to summarise. Total
+// completed focus seconds already live in `sessions` / `session_participants`.
+// `level = f(totalFocusSeconds)` needs no new column, cannot drift, and is
+// automatically right for existing users the day it ships.
+//
+// **This file is duplicated at `client/src/lib/petLevel.ts`.** `client/` and
+// `server/` are independent npm packages and cannot import each other. Both
+// copies are pinned to the same table of (seconds → stage) in their tests,
+// so editing one and not the other fails the other package's suite rather
+// than silently showing two people two different animals.
+//
+// The server is the authority. A client-sent stage is ignored; this is the
+// function that actually decides.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const PET_STAGES = ["young", "grown", "full"];
+
+/**
+ * Seconds of completed focus before the pet grows from young → grown.
+ *
+ * Three hours is about seven ordinary pomodoros — inside a week of two
+ * 25-minute sessions a day, which is the "ordinary use" the thresholds
+ * were aimed at.
+ */
+const GROWN_AT_SECONDS = 3 * 60 * 60;
+
+/**
+ * Seconds of completed focus before the pet grows from grown → full.
+ *
+ * Fifteen hours is a few weeks at that same pace. Stop there: a companion
+ * taller than about 0.38× its owner stops reading as a pet.
+ */
+const FULL_AT_SECONDS = 15 * 60 * 60;
+
+/** True when `value` is one of the three stages. */
+function isPetStage(value) {
+  return typeof value === "string" && PET_STAGES.includes(value);
+}
+
+/**
+ * Stage for a total of completed focus seconds.
+ *
+ * Junk input (NaN, negative, missing) is young — that's 0 hours, not a
+ * reason to skip to full. The server is what stops a client from sending
+ * `'full'` and getting it.
+ */
+function petStageAt(focusSeconds) {
+  const s = Number(focusSeconds);
+  if (!Number.isFinite(s) || s < GROWN_AT_SECONDS) return "young";
+  if (s < FULL_AT_SECONDS) return "grown";
+  return "full";
+}
+
+module.exports = {
+  PET_STAGES,
+  GROWN_AT_SECONDS,
+  FULL_AT_SECONDS,
+  isPetStage,
+  petStageAt,
+};

--- a/server/petLevel.test.js
+++ b/server/petLevel.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { PET_STAGES, petStageAt, isPetStage } from "./petLevel.js";
+
+/**
+ * The cross-package pin.
+ *
+ * Byte-identical to the table in `client/src/lib/petLevel.test.ts`. These are
+ * recorded outputs, not independently-derived expectations — the properties
+ * below are what check the design. What this table is for is *agreement*:
+ * edit one implementation's thresholds and the other package's suite fails.
+ * Two people looking at two different animals is invisible from inside
+ * either half alone.
+ */
+const PINNED = [
+  [0, "young"],
+  [1, "young"],
+  [10799, "young"],
+  [10800, "grown"],
+  [53999, "grown"],
+  [54000, "full"],
+  [360000, "full"],
+];
+
+describe("petStageAt", () => {
+  it("matches the pinned schedule shared with the client", () => {
+    for (const [seconds, stage] of PINNED) {
+      expect(`${seconds} -> ${petStageAt(seconds)}`).toBe(
+        `${seconds} -> ${stage}`,
+      );
+    }
+  });
+
+  it("treats missing and junk totals as young, not full", () => {
+    for (const junk of [undefined, null, NaN, -1, "-5", "", "full"]) {
+      expect(petStageAt(junk), String(junk)).toBe("young");
+    }
+  });
+
+  it("only ever returns a real stage", () => {
+    for (const s of [-1, 0, 10799, 10800, 53999, 54000, 1e12]) {
+      expect(PET_STAGES).toContain(petStageAt(s));
+    }
+  });
+
+  it("is monotonic: more focus never shrinks the pet", () => {
+    let prev = 0;
+    const rank = { young: 0, grown: 1, full: 2 };
+    for (let s = 0; s <= 20 * 3600; s += 600) {
+      const next = rank[petStageAt(s)];
+      expect(next).toBeGreaterThanOrEqual(prev);
+      prev = next;
+    }
+  });
+});
+
+describe("isPetStage", () => {
+  it("accepts the three stages and nothing else", () => {
+    for (const stage of PET_STAGES) expect(isPetStage(stage)).toBe(true);
+    expect(isPetStage("baby")).toBe(false);
+    expect(isPetStage("grown ")).toBe(false);
+    expect(isPetStage(null)).toBe(false);
+    expect(isPetStage(2)).toBe(false);
+  });
+});

--- a/server/session.js
+++ b/server/session.js
@@ -1,4 +1,5 @@
 const { randomUUID } = require("crypto");
+const { petStageAt } = require("./petLevel");
 
 function createSessionState(world, hostSocketId) {
   return {
@@ -28,12 +29,21 @@ function isInvited(session, userId) {
   return Boolean(userId) && session.invitedUserIds.has(userId);
 }
 
-function addPlayer(session, socketId, { avatar, displayName, userId, pet }) {
+function addPlayer(session, socketId, { avatar, displayName, userId, pet, petStage, focusSeconds }) {
+  const safePet = pet || null;
   session.players[socketId] = {
     avatar,
     displayName: displayName || "Player",
     userId: userId || null,
-    pet: pet || null,
+    pet: safePet,
+    // Stage is the server's. Callers pass what petStageAt() returned for this
+    // user's completed-focus total; a missing value is young (0 hours), never
+    // full. Cleared when there is no pet so a later pick doesn't inherit a
+    // stale size from a previous animal.
+    petStage: safePet ? petStage || "young" : null,
+    // Private cache of the total that produced petStage. Stripped from
+    // buildSyncPayload — the partner sees the animal, not the hours.
+    focusSeconds: Number.isFinite(focusSeconds) ? focusSeconds : 0,
     disconnected: false,
   };
   return Object.keys(session.players).length;
@@ -54,11 +64,38 @@ function markPlayerDisconnected(session, socketId, disconnected) {
   return true;
 }
 
-function setPlayerPet(session, socketId, pet) {
+function setPlayerPet(session, socketId, pet, petStage) {
   const player = session.players[socketId];
   if (!player) return false;
   player.pet = pet || null;
+  player.petStage = player.pet ? petStage || "young" : null;
   return true;
+}
+
+/**
+ * Add completed-focus seconds to the named users and grow any pet that
+ * crossed a threshold.
+ *
+ * Returns the slots whose *visible* stage changed, so the caller can emit
+ * pet_changed. Accumulating on someone with no pet still counts — they
+ * should not have to re-fetch to see the right size when they pick one
+ * later in the same session.
+ */
+function creditFocus(session, userIds, extraSeconds) {
+  const extra = Number(extraSeconds);
+  if (!Number.isFinite(extra) || extra <= 0) return [];
+  const idSet = new Set(userIds);
+  const changed = [];
+  for (const [socketId, player] of Object.entries(session.players)) {
+    if (!player.userId || !idSet.has(player.userId)) continue;
+    player.focusSeconds = (player.focusSeconds || 0) + extra;
+    if (!player.pet) continue;
+    const next = petStageAt(player.focusSeconds);
+    if (next === player.petStage) continue;
+    player.petStage = next;
+    changed.push({ playerId: socketId, pet: player.pet, petStage: next });
+  }
+  return changed;
 }
 
 function removePlayer(session, socketId) {
@@ -89,7 +126,16 @@ function findUserSessions(sessions, userId) {
     .map(([sessionId]) => sessionId);
 }
 
+function publicPlayer(player) {
+  const { focusSeconds: _focusSeconds, ...rest } = player;
+  return rest;
+}
+
 function buildSyncPayload(session) {
+  const players = {};
+  for (const [id, player] of Object.entries(session.players)) {
+    players[id] = publicPlayer(player);
+  }
   return {
     mode: session.mode,
     phase: session.phase,
@@ -97,7 +143,7 @@ function buildSyncPayload(session) {
     breakDuration: session.breakDuration,
     phaseStartTime: session.phaseStartTime,
     world: session.world,
-    players: session.players,
+    players,
     playerCount: Object.keys(session.players).length,
     sessionId: session.id,
   };
@@ -108,6 +154,7 @@ module.exports = {
   addPlayer,
   removePlayer,
   setPlayerPet,
+  creditFocus,
   inviteUser,
   isInvited,
   findPlayerByUserId,

--- a/server/session.test.js
+++ b/server/session.test.js
@@ -4,6 +4,7 @@ import {
   addPlayer,
   removePlayer,
   setPlayerPet,
+  creditFocus,
   findPlayerByUserId,
   markPlayerDisconnected,
   inviteUser,
@@ -209,21 +210,118 @@ describe("setPlayerPet", () => {
     addPlayer(s, "p1", { avatar: {}, displayName: "A", userId: "u1", pet: "cat" });
     addPlayer(s, "p2", { avatar: {}, displayName: "B", userId: "u2" });
     expect(s.players["p1"].pet).toBe("cat");
+    expect(s.players["p1"].petStage).toBe("young");
     expect(s.players["p2"].pet).toBe(null);
+    expect(s.players["p2"].petStage).toBe(null);
+  });
+
+  it("keeps a caller-supplied stage rather than inventing one", () => {
+    const s = createSessionState("forest", "host");
+    addPlayer(s, "p1", {
+      avatar: {},
+      displayName: "A",
+      userId: "u1",
+      pet: "cat",
+      petStage: "full",
+      focusSeconds: 20 * 3600,
+    });
+    expect(s.players["p1"].petStage).toBe("full");
+    expect(s.players["p1"].focusSeconds).toBe(20 * 3600);
   });
 
   it("updates an existing player's pet", () => {
     const s = createSessionState("forest", "host");
     addPlayer(s, "p1", { avatar: {}, displayName: "A", userId: "u1" });
-    expect(setPlayerPet(s, "p1", "dragon")).toBe(true);
+    expect(setPlayerPet(s, "p1", "dragon", "grown")).toBe(true);
     expect(s.players["p1"].pet).toBe("dragon");
+    expect(s.players["p1"].petStage).toBe("grown");
     expect(setPlayerPet(s, "p1", null)).toBe(true);
     expect(s.players["p1"].pet).toBe(null);
+    expect(s.players["p1"].petStage).toBe(null);
   });
 
   it("returns false for a socket that is not a player", () => {
     const s = createSessionState("forest", "host");
     expect(setPlayerPet(s, "ghost", "cat")).toBe(false);
+  });
+
+  it("does not put focusSeconds on the wire", () => {
+    const s = createSessionState("forest", "host");
+    addPlayer(s, "p1", {
+      avatar: {},
+      displayName: "A",
+      userId: "u1",
+      pet: "cat",
+      focusSeconds: 10800,
+    });
+    const payload = buildSyncPayload(s);
+    expect(payload.players["p1"].pet).toBe("cat");
+    expect(payload.players["p1"].petStage).toBe("young");
+    expect(payload.players["p1"]).not.toHaveProperty("focusSeconds");
+  });
+});
+
+describe("creditFocus", () => {
+  it("grows a pet that crosses a threshold and leaves the rest", () => {
+    const s = createSessionState("forest", "host");
+    addPlayer(s, "p1", {
+      avatar: {},
+      displayName: "A",
+      userId: "u1",
+      pet: "cat",
+      petStage: "young",
+      focusSeconds: 10700,
+    });
+    addPlayer(s, "p2", {
+      avatar: {},
+      displayName: "B",
+      userId: "u2",
+      pet: "dog",
+      petStage: "young",
+      focusSeconds: 0,
+    });
+
+    const changed = creditFocus(s, ["u1", "u2"], 200);
+    expect(changed).toEqual([{ playerId: "p1", pet: "cat", petStage: "grown" }]);
+    expect(s.players["p1"].petStage).toBe("grown");
+    expect(s.players["p1"].focusSeconds).toBe(10900);
+    expect(s.players["p2"].petStage).toBe("young");
+    expect(s.players["p2"].focusSeconds).toBe(200);
+  });
+
+  it("still accumulates for a player with no pet", () => {
+    const s = createSessionState("forest", "host");
+    addPlayer(s, "p1", { avatar: {}, displayName: "A", userId: "u1" });
+    expect(creditFocus(s, ["u1"], 10800)).toEqual([]);
+    expect(s.players["p1"].focusSeconds).toBe(10800);
+    expect(s.players["p1"].petStage).toBe(null);
+  });
+
+  it("ignores users who are not in the credit list", () => {
+    const s = createSessionState("forest", "host");
+    addPlayer(s, "p1", {
+      avatar: {},
+      displayName: "A",
+      userId: "u1",
+      pet: "cat",
+      focusSeconds: 10700,
+    });
+    expect(creditFocus(s, ["u9"], 200)).toEqual([]);
+    expect(s.players["p1"].focusSeconds).toBe(10700);
+  });
+
+  it("does not shrink or re-emit a pet that is already there", () => {
+    const s = createSessionState("forest", "host");
+    addPlayer(s, "p1", {
+      avatar: {},
+      displayName: "A",
+      userId: "u1",
+      pet: "cat",
+      petStage: "full",
+      focusSeconds: 54000,
+    });
+    expect(creditFocus(s, ["u1"], 3600)).toEqual([]);
+    expect(s.players["p1"].petStage).toBe("full");
   });
 });
 


### PR DESCRIPTION
## Summary
- Pets grow by **more cells at the same `ART_PX`**, never a scale multiplier: young 7×5, grown 9×7 (today’s art, unchanged), full 11×9. Stops at 0.38× a person.
- Stage is **derived from total completed focus**, not stored — same two-copy pin as the world rotation (`server/petLevel.js` + `client/src/lib/petLevel.ts`). Thresholds: 3h → grown, 15h → full.
- `petStage` travels in the session slot so both people see the same animal. A client-sent stage is ignored. Hours stay off the wire. A completed focus can grow the pet in the room it was earned in.
- Per user, not per pet. Premium stays the pet gate. Item 12 ticked in this PR.

## Test plan
- [ ] Client `npm run test:run` and `npm run lint`; server `npm run test:run` (A/B: `createSession.test.js` “ignores a client-sent petStage” and the GameWorld ratio pins fail against the previous commit)
- [ ] New account, pick a pet in a session: it should be **young** (dev mode with no Supabase is always young)
- [ ] Partner in the same session sees the same size
- [ ] Switching cat → dog keeps the size
- [ ] Eye the young and full silhouettes for all four pets — geometry tests catch clipping and grid size, not whether a 5-row cat still reads as a cat
- [ ] (Harder) an account with ≥3h / ≥15h of completed focus should join as grown / full

**Not verified in a browser.** Nothing in this PR has been looked at on localhost.


Made with [Cursor](https://cursor.com)