### PR TITLE
Emoji purge: use the sprites that already existed

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,8 +5,8 @@ that does the work, not afterwards. Ordered by value; each line names the real
 files. Was `ROADMAP.local.md` and gitignored until PR #38 — it is tracked now,
 so the file:line references land in diffs and want keeping honest.
 
-Last updated: 2026-08-19. PRs #35–#42 merged.
-Item 10 is on `feat/launch-surface`.
+Last updated: 2026-08-19. PRs #35–#43 merged.
+Item 8 is on `feat/emoji-purge`.
 Migrations 016–020 are applied to Supabase. **020 verified in production**
 2026-08-15: RLS on, one SELECT-only policy, zero client write grants, EXECUTE
 limited to authenticated/service_role, SECURITY DEFINER with a pinned
@@ -77,11 +77,15 @@ the live database.
       7×5, grown 9×7 (today's art), full 11×9. Stage travels in the slot as
       `petStage`; a client-sent value is ignored. Per user, not per pet.
       Premium stays the pet gate. **Not verified in a browser.**
-- [x] **10. Launch surface** — this PR. `metadataBase` is `https://duodoro.live`,
+- [x] **10. Launch surface** — PR #43. `metadataBase` is `https://duodoro.live`,
       so the generated OG/Twitter image is an absolute URL; the extra period
       on the tagline is gone; the duo mark is charcoal/paper instead of
       Tailwind emerald; the install splash uses `#171411` instead of gray-900.
       Copy and colours live in `client/src/lib/site.ts`.
+- [x] **8. Emoji purge** — this PR. `PetPicker` draws `PetCharacter`; friend
+      rows and session history use `WorldThumb` (`WorldThumbnail` in a chip);
+      PremiumModal opens on a cat instead of 🐾. The emoji fields on
+      `PET_OPTIONS` and `WORLDS` went with them. **Not verified in a browser.**
 
 ## ⚠️ Corrections to this file
 
@@ -374,18 +378,24 @@ a per-world outline is the cheapest way back.
 
 ---
 
-## 8. Emoji purge  ·  ~20 lines, disproportionately visible
+## 8. Emoji purge  ·  SHIPPED — this PR
 
 `lib/uiSprites.ts:3` says sprites exist for "anywhere an emoji would break the
 pixel-art look" and `Icons.tsx:1` says the set "replaces emoji in UI chrome" —
-yet:
+yet those replacements were unused:
 
-- `PetPicker.tsx:40` renders 🐱🐶🐉🐰/🔒 while `PetCharacter` can draw the pets
-- `FriendsPanel.tsx:56` and `FriendsOnlineSection.tsx:59` render world emoji
-  while `WorldThumbnail` (`WorldDecorations.tsx:787`) exists
-- `PremiumModal.tsx:12-16,72` is all emoji
+- ~~`PetPicker.tsx` 🐱🐶🐉🐰/🔒~~ — `PetCharacter` at grown, `LockIcon` when
+  gated.
+- ~~`FriendsPanel` / `FriendsOnlineSection` world emoji~~ — `WorldThumb`, a
+  sized `WorldThumbnail`. Same swap in `StatsPanel` / `StatsScreen`, which
+  had a three-world emoji table and fell back to 🌍 for grocery/library/cafe.
+- ~~`PremiumModal` 🐾~~ — a cat. The old feature-list emoji died in #40 with
+  the fiction; this was the last one.
 
-The replacements already exist and are simply unused in these spots.
+The `emoji` field on `WORLDS` and `PET_OPTIONS` had no remaining callers and
+came off. Close buttons still use ✕; that's chrome, item 9.
+
+**Not verified in a browser.**
 
 ---
 
@@ -403,7 +413,7 @@ wrapped around a game.
 
 ---
 
-## 10. Launch surface  ·  SHIPPED — this PR
+## 10. Launch surface  ·  SHIPPED — PR #43
 
 - ~~no `openGraph.images` and no `metadataBase` → every shared link renders a
   blank card~~ — `metadataBase` is `https://duodoro.live`; `app/opengraph-image.tsx`

--- a/client/src/components/FriendsOnlineSection.tsx
+++ b/client/src/components/FriendsOnlineSection.tsx
@@ -1,11 +1,11 @@
 "use client";
 import { WORLDS } from "@/lib/avatarData";
 import type { Profile } from "@/lib/types";
+import WorldThumb from "./WorldThumb";
 
-const WORLD_LABEL: Record<string, { emoji: string; label: string }> =
-  Object.fromEntries(
-    WORLDS.map((w) => [w.id, { emoji: w.emoji, label: w.label }]),
-  );
+const WORLD_LABEL: Record<string, string> = Object.fromEntries(
+  WORLDS.map((w) => [w.id, w.label]),
+);
 
 interface Props {
   onlineFriends: Profile[];
@@ -38,7 +38,7 @@ export default function FriendsOnlineSection({
       <div className="space-y-1">
         {onlineFriends.slice(0, 5).map((f) => {
           const inSession = !!f.current_session_id;
-          const worldInfo = f.current_world_id
+          const worldLabel = f.current_world_id
             ? WORLD_LABEL[f.current_world_id]
             : null;
           const name = f.display_name ?? f.username;
@@ -54,9 +54,10 @@ export default function FriendsOnlineSection({
                 <p className="text-sm font-semibold text-ink truncate">
                   {name}
                 </p>
-                {inSession && worldInfo ? (
-                  <p className="text-[10px] text-go truncate">
-                    {worldInfo.emoji} In {worldInfo.label}
+                {inSession && worldLabel && f.current_world_id ? (
+                  <p className="text-[10px] text-go truncate flex items-center gap-1.5">
+                    <WorldThumb worldId={f.current_world_id} />
+                    In {worldLabel}
                   </p>
                 ) : (
                   <p className="text-[10px] text-faint">Online</p>

--- a/client/src/components/FriendsPanel.tsx
+++ b/client/src/components/FriendsPanel.tsx
@@ -6,6 +6,7 @@ import type { Profile } from "@/lib/types";
 import { formatTag } from "@/lib/format";
 import { useFriendsList } from "@/hooks/useFriendsList";
 import { useFriendSearch } from "@/hooks/useFriendSearch";
+import WorldThumb from "./WorldThumb";
 
 interface Props {
   open: boolean;
@@ -17,10 +18,9 @@ interface Props {
 
 type Tab = "friends" | "requests" | "find";
 
-const WORLD_LABEL: Record<string, { emoji: string; label: string }> =
-  Object.fromEntries(
-    WORLDS.map((w) => [w.id, { emoji: w.emoji, label: w.label }]),
-  );
+const WORLD_LABEL: Record<string, string> = Object.fromEntries(
+  WORLDS.map((w) => [w.id, w.label]),
+);
 
 function StatusDot({ inSession }: { inSession: boolean }) {
   return (
@@ -41,7 +41,7 @@ function FriendRow({
   onInvite: () => void;
 }) {
   const inSession = !!friend.current_session_id;
-  const worldInfo = friend.current_world_id
+  const worldLabel = friend.current_world_id
     ? WORLD_LABEL[friend.current_world_id]
     : null;
   const name = friend.display_name ?? friend.username;
@@ -51,9 +51,10 @@ function FriendRow({
       <StatusDot inSession={inSession} />
       <div className="flex-1 min-w-0">
         <p className="text-sm font-bold text-ink truncate">{name}</p>
-        {inSession && worldInfo ? (
-          <p className="text-xs text-go truncate">
-            {worldInfo.emoji} In {worldInfo.label}
+        {inSession && worldLabel && friend.current_world_id ? (
+          <p className="text-xs text-go truncate flex items-center gap-1.5">
+            <WorldThumb worldId={friend.current_world_id} />
+            In {worldLabel}
           </p>
         ) : (
           <p className="text-xs text-faint font-mono truncate">

--- a/client/src/components/Icons.tsx
+++ b/client/src/components/Icons.tsx
@@ -112,6 +112,15 @@ export function CloseIcon({ className }: IconProps) {
   );
 }
 
+export function LockIcon({ className }: IconProps) {
+  return (
+    <svg {...base(className)}>
+      <rect x="5" y="11" width="14" height="10" rx="2" />
+      <path d="M8 11V8a4 4 0 0 1 8 0v3" />
+    </svg>
+  );
+}
+
 export function PlusIcon({ className }: IconProps) {
   return (
     <svg {...base(className)}>

--- a/client/src/components/PetPicker.test.tsx
+++ b/client/src/components/PetPicker.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import PetPicker from "./PetPicker";
+import { PET_OPTIONS } from "@/lib/types";
+
+describe("PetPicker", () => {
+  it("draws the pets instead of emoji, and a lock instead of 🔒", () => {
+    // A/B — against the previous commit this contains 🐱🐶🐉🐰 and 🔒.
+    const { container: locked } = render(
+      <PetPicker
+        selected={null}
+        onSelect={vi.fn()}
+        isPremium={false}
+        onPremiumClick={vi.fn()}
+      />,
+    );
+    expect(locked.textContent).not.toMatch(/🐱|🐶|🐉|🐰|🔒/);
+    expect(locked.querySelectorAll("svg").length).toBe(PET_OPTIONS.length);
+
+    const { container: open } = render(
+      <PetPicker
+        selected="cat"
+        onSelect={vi.fn()}
+        isPremium
+        onPremiumClick={vi.fn()}
+      />,
+    );
+    expect(open.textContent).not.toMatch(/🐱|🐶|🐉|🐰|🔒/);
+    expect(screen.getByTitle("Cat")).toBeInTheDocument();
+    // Grown pet sprites, one per option, plus nothing else using emoji.
+    expect(open.querySelectorAll("svg").length).toBe(PET_OPTIONS.length);
+  });
+});

--- a/client/src/components/PetPicker.tsx
+++ b/client/src/components/PetPicker.tsx
@@ -1,5 +1,8 @@
+"use client";
 import type { PetType } from "@/lib/types";
 import { PET_OPTIONS } from "@/lib/types";
+import PetCharacter from "./PetCharacter";
+import { LockIcon } from "./Icons";
 
 export default function PetPicker({
   selected,
@@ -26,18 +29,24 @@ export default function PetPicker({
       >
         {"✕"}
       </button>
-      {PET_OPTIONS.map(({ type, emoji, label }) => (
+      {PET_OPTIONS.map(({ type, label }) => (
         <button
           key={type}
           onClick={() => (isPremium ? onSelect(type) : onPremiumClick())}
-          className={`w-7 h-7 rounded-full border text-sm flex items-center justify-center transition-all ${
+          className={`w-7 h-7 rounded-full border flex items-end justify-center overflow-hidden transition-all ${
             selected === type
               ? "border-accent bg-accent/15"
               : "border-line bg-surface hover:border-faint"
           } ${!isPremium ? "opacity-50" : ""}`}
           title={isPremium ? label : `${label} (Premium)`}
         >
-          {isPremium ? emoji : "🔒"}
+          {isPremium ? (
+            <PetCharacter type={type} stage="grown" size={2} />
+          ) : (
+            <span className="flex items-center justify-center w-full h-full">
+              <LockIcon className="w-3.5 h-3.5" />
+            </span>
+          )}
         </button>
       ))}
     </div>

--- a/client/src/components/PremiumModal.test.tsx
+++ b/client/src/components/PremiumModal.test.tsx
@@ -121,4 +121,11 @@ describe("PremiumModal", () => {
     expect(container.textContent).not.toMatch(/\$|\/mo|subscri|payment|card/i);
     expect(container.textContent).toMatch(/free/i);
   });
+
+  it("draws a companion instead of a paw-print emoji", () => {
+    // A/B — the previous commit opened with 🐾.
+    const { container } = open();
+    expect(container.textContent).not.toMatch(/🐾/);
+    expect(container.querySelector("svg")).toBeTruthy();
+  });
 });

--- a/client/src/components/PremiumModal.tsx
+++ b/client/src/components/PremiumModal.tsx
@@ -4,6 +4,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { getSupabase } from "@/lib/supabase";
 import { PREMIUM_IS_FREE } from "@/lib/billing";
 import Button from "./Button";
+import PetCharacter from "./PetCharacter";
 
 interface Props {
   open: boolean;
@@ -110,7 +111,9 @@ export default function PremiumModal({
               </button>
 
               <div className="text-center mb-6">
-                <div className="text-5xl mb-3">🐾</div>
+                <div className="flex justify-center mb-3">
+                  <PetCharacter type="cat" stage="grown" />
+                </div>
                 <h2 className="font-display text-2xl text-ink">
                   Duodoro Premium
                 </h2>

--- a/client/src/components/StatsPanel.tsx
+++ b/client/src/components/StatsPanel.tsx
@@ -4,6 +4,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { useStats } from "@/lib/useStats";
 import StatsErrorState from "./StatsErrorState";
 import type { DuoStats, SessionWithPartner } from "@/lib/types";
+import WorldThumb from "./WorldThumb";
 
 interface Props {
   open: boolean;
@@ -33,12 +34,6 @@ function formatDate(iso: string): string {
   if (days < 7) return `${days}d ago`;
   return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
 }
-
-const WORLD_EMOJI: Record<string, string> = {
-  forest: "🌲",
-  space: "🚀",
-  beach: "🏖️",
-};
 
 // ── Stat Card ───────────────────────────────────────────────────────────────
 
@@ -81,7 +76,7 @@ function PartnerRow({ duo, rank }: { duo: DuoStats; rank: number }) {
 function SessionRow({ session }: { session: SessionWithPartner }) {
   return (
     <div className="flex items-center gap-2 py-2 px-3 rounded-xl bg-raise">
-      <span className="text-sm">{WORLD_EMOJI[session.world] ?? "🌍"}</span>
+      <WorldThumb worldId={session.world} />
       <div className="flex-1 min-w-0">
         <p className="text-xs font-bold text-ink truncate">
           {formatDuration(session.actual_focus)} focus

--- a/client/src/components/StatsScreen.tsx
+++ b/client/src/components/StatsScreen.tsx
@@ -4,6 +4,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { useStats } from "@/lib/useStats";
 import StatsErrorState from "./StatsErrorState";
 import type { DailyFocus } from "@/lib/types";
+import WorldThumb from "./WorldThumb";
 
 interface Props {
   open: boolean;
@@ -28,12 +29,6 @@ function formatDate(iso: string): string {
     minute: "2-digit",
   });
 }
-
-const WORLD_EMOJI: Record<string, string> = {
-  forest: "🌲",
-  space: "🚀",
-  beach: "🏖️",
-};
 
 // ── Weekly Bar Chart ────────────────────────────────────────────────────────
 
@@ -255,9 +250,7 @@ export default function StatsScreen({ open, onClose, userId }: Props) {
                           key={s.id}
                           className="flex items-center gap-3 bg-surface border border-line rounded-xl px-4 py-2.5"
                         >
-                          <span className="text-base">
-                            {WORLD_EMOJI[s.world] ?? "🌍"}
-                          </span>
+                          <WorldThumb worldId={s.world} />
                           <div className="flex-1 min-w-0">
                             <p className="text-sm font-bold text-ink">
                               {formatDuration(s.actual_focus)}

--- a/client/src/components/WorldThumb.test.tsx
+++ b/client/src/components/WorldThumb.test.tsx
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import WorldThumb from "./WorldThumb";
+import { WORLDS } from "@/lib/avatarData";
+
+describe("WorldThumb", () => {
+  it("renders a sprite for every world, and nothing for an unknown id", () => {
+    for (const world of WORLDS) {
+      const { container } = render(<WorldThumb worldId={world.id} />);
+      expect(container.querySelector("svg"), world.id).toBeTruthy();
+    }
+    const { container } = render(<WorldThumb worldId="lofi" />);
+    expect(container.querySelector("svg")).toBeNull();
+  });
+});

--- a/client/src/components/WorldThumb.tsx
+++ b/client/src/components/WorldThumb.tsx
@@ -1,0 +1,31 @@
+"use client";
+import { WORLDS, type WorldId } from "@/lib/avatarData";
+import { WorldThumbnail } from "./WorldDecorations";
+
+export function isWorldId(id: string): id is WorldId {
+  return WORLDS.some((w) => w.id === id);
+}
+
+/**
+ * Inline world chip for lists that used to print an emoji.
+ *
+ * `WorldThumbnail` already draws the sky + signature sprite; this just gives
+ * it a box small enough to sit in a friend row or a history line.
+ */
+export default function WorldThumb({
+  worldId,
+  className = "w-8 h-5",
+}: {
+  worldId: string;
+  className?: string;
+}) {
+  if (!isWorldId(worldId)) return null;
+  return (
+    <span
+      className={`relative inline-block overflow-hidden rounded-sm border border-line shrink-0 ${className}`}
+      aria-hidden="true"
+    >
+      <WorldThumbnail worldId={worldId} />
+    </span>
+  );
+}

--- a/client/src/lib/avatarData.ts
+++ b/client/src/lib/avatarData.ts
@@ -74,7 +74,6 @@ export const DEFAULT_AVATAR: AvatarConfig = {
 export type WorldConfig = {
   id: WorldId;
   label: string;
-  emoji: string;
   skyGradient: string;
   groundColor: string;
   groundPatternColor: string;
@@ -84,7 +83,6 @@ export const WORLDS: WorldConfig[] = [
   {
     id: 'forest',
     label: 'Forest',
-    emoji: '🌲',
     skyGradient: 'linear-gradient(180deg, #7EC8E3 0%, #AEE5D8 100%)',
     groundColor: '#4a7c59',
     groundPatternColor: '#3d6849',
@@ -92,7 +90,6 @@ export const WORLDS: WorldConfig[] = [
   {
     id: 'space',
     label: 'Space',
-    emoji: '🚀',
     // Standing on the moon, so the ground is regolith rather than purple.
     skyGradient: 'linear-gradient(180deg, #04001A 0%, #130840 100%)',
     groundColor: '#6d727c',
@@ -101,7 +98,6 @@ export const WORLDS: WorldConfig[] = [
   {
     id: 'beach',
     label: 'Beach',
-    emoji: '🏖️',
     skyGradient: 'linear-gradient(180deg, #FF8C42 0%, #FFD166 100%)',
     groundColor: '#C9A84C',
     groundPatternColor: '#B89238',
@@ -109,7 +105,6 @@ export const WORLDS: WorldConfig[] = [
   {
     id: 'city',
     label: 'City',
-    emoji: '🏙️',
     skyGradient: 'linear-gradient(180deg, #1a1a2e 0%, #16213e 100%)',
     groundColor: '#3a3a4a',
     groundPatternColor: '#2d2d3d',
@@ -117,7 +112,6 @@ export const WORLDS: WorldConfig[] = [
   {
     id: 'mountain',
     label: 'Mountain',
-    emoji: '🏔️',
     // Winter: the ground is snow over rock, not the alpine meadow it was.
     skyGradient: 'linear-gradient(180deg, #87CEEB 0%, #E0F0FF 100%)',
     groundColor: '#dbe4ea',
@@ -126,7 +120,6 @@ export const WORLDS: WorldConfig[] = [
   {
     id: 'library',
     label: 'Library',
-    emoji: '📚',
     skyGradient: 'linear-gradient(180deg, #3e2723 0%, #5d4037 100%)',
     groundColor: '#6d4c41',
     groundPatternColor: '#5d3f35',
@@ -134,7 +127,6 @@ export const WORLDS: WorldConfig[] = [
   {
     id: 'cafe',
     label: 'Café',
-    emoji: '☕',
     skyGradient: 'linear-gradient(180deg, #f5e6d3 0%, #e8d5b7 100%)',
     groundColor: '#8d6e63',
     groundPatternColor: '#795548',
@@ -142,7 +134,6 @@ export const WORLDS: WorldConfig[] = [
   {
     id: 'grocery',
     label: 'Grocery',
-    emoji: '🛒',
     // An interior: the "sky" is a lit ceiling, the ground is vinyl tile.
     skyGradient: 'linear-gradient(180deg, #f2f4f0 0%, #dfe4dd 55%, #cdd4cc 100%)',
     groundColor: '#c8ccc6',

--- a/client/src/lib/types.ts
+++ b/client/src/lib/types.ts
@@ -46,11 +46,11 @@ export type { PetStage } from "./petLevel";
 
 export type PetType = "cat" | "dog" | "dragon" | "rabbit";
 
-export const PET_OPTIONS: { type: PetType; label: string; emoji: string }[] = [
-  { type: "cat",    label: "Cat",    emoji: "🐱" },
-  { type: "dog",    label: "Dog",    emoji: "🐶" },
-  { type: "dragon", label: "Dragon", emoji: "🐉" },
-  { type: "rabbit", label: "Rabbit", emoji: "🐰" },
+export const PET_OPTIONS: { type: PetType; label: string }[] = [
+  { type: "cat",    label: "Cat" },
+  { type: "dog",    label: "Dog" },
+  { type: "dragon", label: "Dragon" },
+  { type: "rabbit", label: "Rabbit" },
 ];
 
 // ── Session Stats ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Pet picker draws `PetCharacter` instead of 🐱🐶🐉🐰; locked slots get `LockIcon` instead of 🔒.
- Friend rows and session history use `WorldThumb` (`WorldThumbnail` in a chip). Stats only had emoji for three of eight worlds, so grocery and the interiors were falling through to 🌍.
- Premium modal opens on a cat instead of 🐾. `WORLDS.emoji` and `PET_OPTIONS.emoji` had no callers left and came off.

## Test plan
- [ ] Client `npm run test:run` — `PetPicker.test.tsx` and the PremiumModal paw test fail against the previous commit (they contain 🐱/🔒/🐾)
- [ ] In a session, the pet picker shows the four animals, not emoji; a non-premium account shows locks
- [ ] A friend in a session shows a tiny world chip, not 🌲
- [ ] Stats history for grocery/library/cafe is a thumbnail, not 🌍
- [ ] Premium modal hero is a cat

**Not verified in a browser.** Close buttons still use ✕; that's chrome for item 9.


Made with [Cursor](https://cursor.com)