### PR TITLE
Pixel-ify the chrome, and add a real README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,86 @@
+# Duodoro
+
+A real-time focus timer for long-distance couples and friends.
+
+Live: [duodoro.live](https://duodoro.live)
+
+Sign in with Google or Discord, draw a pixel-art avatar, and run a
+synchronised pomodoro (or open-ended flow) with someone in the same session.
+You walk toward each other during focus, meet in the middle, and take the
+break in whichever world the clock is on.
+
+## How long this has been going
+
+The git history starts on **26 February 2026** (`Initial commit of existing
+project`). As of August 2026 that is a little under six months of recorded
+work.
+
+## What it is today
+
+- **Two people, one timer.** The Socket.IO server owns the phase clock. The
+  client never trusts its own `Date.now()` for the countdown.
+- **Worlds rotate.** There is no picker. New sessions land in whichever of
+  the eight worlds the UTC clock is on (hourly, on the :30). A session keeps
+  the world it started in.
+- **Pets grow with focus.** Premium unlocks a companion. Size is derived from
+  completed focus time (young at the start, grown after 3 hours, full after
+  15), not stored as its own column.
+- **Premium is currently free** in exchange for the OAuth-confirmed email.
+  Pets are the gated feature; there is no world unlock, because nobody picks
+  a world.
+- Friends, invites, sticky-note tasks, and session stats sit on top.
+
+## Stack
+
+Two npm packages, plus Supabase:
+
+| | |
+|---|---|
+| `client/` | Next.js 16, React 19, Tailwind 4. Deploys to Vercel. |
+| `server/` | Express + Socket.IO (plain Node, CommonJS). Deploys to Render. |
+| `supabase/migrations/` | Numbered SQL, applied by hand in the SQL editor. |
+
+Auth and persistence (profiles, friends, tasks, completed session history)
+are Supabase. Live session state is in-memory on the server and dies with
+the process.
+
+## Local development
+
+You need both processes.
+
+**Server** (`server/`):
+
+```bash
+cp .env.example .env   # then fill in, or leave Supabase blank for dev mode
+npm install
+npm start              # port 3001
+```
+
+Without `SUPABASE_URL` / `SUPABASE_SERVICE_KEY` the server skips JWT
+verification and persistence. That is fine for local timer work; it is not
+how production runs.
+
+**Client** (`client/`):
+
+```bash
+# .env.local
+# NEXT_PUBLIC_SOCKET_URL=http://localhost:3001
+# NEXT_PUBLIC_SUPABASE_URL=...
+# NEXT_PUBLIC_SUPABASE_ANON_KEY=...
+npm install
+npm run dev            # http://localhost:3000
+```
+
+Tests: `npm run test:run` inside `client/` or `server/`. Lint and `tsc`
+live in `client/`.
+
+`docker-compose.yml` is a leftover local/self-hosted setup (no nginx). The
+live site is Vercel + Render, not that file.
+
+## Deploy
+
+Push to `main` deploys both halves. There is no deploy workflow in this
+repo — each host watches the repo itself.
+
+CI (`.github/workflows/ci.yml`) runs server tests, then client typecheck,
+lint, tests, and `next build`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,8 +5,8 @@ that does the work, not afterwards. Ordered by value; each line names the real
 files. Was `ROADMAP.local.md` and gitignored until PR #38 — it is tracked now,
 so the file:line references land in diffs and want keeping honest.
 
-Last updated: 2026-08-19. PRs #35–#43 merged.
-Item 8 is on `feat/emoji-purge`.
+Last updated: 2026-08-19. PRs #35–#44 merged.
+Item 9 is on `feat/pixel-chrome`.
 Migrations 016–020 are applied to Supabase. **020 verified in production**
 2026-08-15: RLS on, one SELECT-only policy, zero client write grants, EXECUTE
 limited to authenticated/service_role, SECURITY DEFINER with a pinned
@@ -82,10 +82,15 @@ the live database.
       on the tagline is gone; the duo mark is charcoal/paper instead of
       Tailwind emerald; the install splash uses `#171411` instead of gray-900.
       Copy and colours live in `client/src/lib/site.ts`.
-- [x] **8. Emoji purge** — this PR. `PetPicker` draws `PetCharacter`; friend
+- [x] **8. Emoji purge** — PR #44. `PetPicker` draws `PetCharacter`; friend
       rows and session history use `WorldThumb` (`WorldThumbnail` in a chip);
       PremiumModal opens on a cat instead of 🐾. The emoji fields on
       `PET_OPTIONS` and `WORLDS` went with them. **Not verified in a browser.**
+- [x] **9. Pixel-ify the chrome** — this PR. Timer is Pixelify (`font-display`),
+      HUD card is a chunky square (`border-b-4`, no blur), icons use square
+      caps, waiting slot is a person-sized square, close buttons are
+      `CloseIcon`. Root `README.md` covers what the product is and that git
+      starts 2026-02-26. **Not verified in a browser.**
 
 ## ⚠️ Corrections to this file
 
@@ -393,23 +398,27 @@ yet those replacements were unused:
   the fiction; this was the last one.
 
 The `emoji` field on `WORLDS` and `PET_OPTIONS` had no remaining callers and
-came off. Close buttons still use ✕; that's chrome, item 9.
+came off. Close buttons still used ✕; that moved to item 9.
 
 **Not verified in a browser.**
 
 ---
 
-## 9. Pixel-ify the chrome  ·  after 3
+## 9. Pixel-ify the chrome  ·  SHIPPED — this PR
 
-The app loads the pixel typeface Pixelify Sans (`app/layout.tsx:17`) and then
-renders **the timer — the largest element in the product — in Geist Mono**
-(`SessionHUD.tsx:144`). Elsewhere: `rounded-2xl backdrop-blur shadow-xl`
-(`SessionHUD.tsx:133`), `rounded-full` status dots, Feather-style stroke icons
-with `strokeLinecap: "round"` (`Icons.tsx:8-16`), and a waiting slot that is a
-dashed **circle** with a text "?" (`GameWorld.tsx:313-322`). Soft-SaaS chrome
-wrapped around a game.
+~~The timer — the largest element in the product — was Geist Mono
+(`SessionHUD.tsx`) while Pixelify Sans was already loaded.~~ `hud-timer` is
+`font-display`. The HUD card dropped `rounded-2xl backdrop-blur shadow-xl`
+for a square `border-2 border-b-4`. Status dots and `Button` sizes lost their
+pills. Icons use `strokeLinecap: "square"` / `miter` instead of Feather
+rounds. The waiting slot is a person-sized square (`CHAR_W × CHAR_H` at
+`ART_PX`), not a dashed circle with "?". Close controls use `CloseIcon`.
 
-`Button.tsx:29-33` already gestures at the right idiom with `border-b-4`.
+A root `README.md` now describes the current product (rotating worlds, email
+premium, growing pets) and that git starts on 26 February 2026. The
+create-next-app stub in `client/README.md` is a pointer to it.
+
+**Not verified in a browser.**
 
 ---
 

--- a/client/README.md
+++ b/client/README.md
@@ -1,36 +1,4 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# client
 
-## Getting Started
-
-First, run the development server:
-
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
-```
-
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
-
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+The Next.js app. See the [repo README](../README.md) for what Duodoro is,
+how long it has been in progress, and how to run this package locally.

--- a/client/src/components/Button.tsx
+++ b/client/src/components/Button.tsx
@@ -27,9 +27,9 @@ const VARIANT_CLASSES: Record<Variant, string> = {
 };
 
 const SIZE_CLASSES: Record<Size, string> = {
-  sm: "px-4 py-2 text-sm rounded-xl",
-  md: "px-6 py-3 text-base rounded-2xl",
-  lg: "px-8 py-4 text-xl rounded-2xl",
+  sm: "px-4 py-2 text-sm rounded-none",
+  md: "px-6 py-3 text-base rounded-none",
+  lg: "px-8 py-4 text-xl rounded-none",
 };
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {

--- a/client/src/components/FriendsPanel.tsx
+++ b/client/src/components/FriendsPanel.tsx
@@ -7,6 +7,7 @@ import { formatTag } from "@/lib/format";
 import { useFriendsList } from "@/hooks/useFriendsList";
 import { useFriendSearch } from "@/hooks/useFriendSearch";
 import WorldThumb from "./WorldThumb";
+import { CheckIcon, CloseIcon } from "./Icons";
 
 interface Props {
   open: boolean;
@@ -103,15 +104,17 @@ function RequestRow({
       <div className="flex gap-1.5">
         <button
           onClick={() => onAccept(friendshipId)}
+          aria-label="Accept"
           className="text-xs bg-go hover:brightness-105 text-white font-bold px-2.5 py-1 rounded-lg transition-all"
         >
-          ✓
+          <CheckIcon className="w-3.5 h-3.5" />
         </button>
         <button
           onClick={() => onDecline(friendshipId)}
+          aria-label="Decline"
           className="text-xs bg-line hover:bg-faint text-ink font-bold px-2.5 py-1 rounded-lg transition-colors"
         >
-          ✕
+          <CloseIcon className="w-3.5 h-3.5" />
         </button>
       </div>
     </div>
@@ -163,9 +166,10 @@ export default function FriendsPanel({
                 </h2>
                 <button
                   onClick={onClose}
+                  aria-label="Close"
                   className="text-faint hover:text-ink transition-colors"
                 >
-                  ✕
+                  <CloseIcon />
                 </button>
               </div>
 
@@ -203,7 +207,7 @@ export default function FriendsPanel({
                     aria-label="Dismiss error"
                     className="font-bold hover:opacity-70"
                   >
-                    ✕
+                    <CloseIcon className="w-3.5 h-3.5" />
                   </button>
                 </div>
               )}

--- a/client/src/components/GameWorld.test.tsx
+++ b/client/src/components/GameWorld.test.tsx
@@ -254,3 +254,28 @@ describe("contact shadows", () => {
     }
   });
 });
+
+describe("waiting slot", () => {
+  it("is a square the size of a person, not a dashed circle", () => {
+    // A/B — against the previous commit this is a w-12 h-12 rounded-full
+    // dashed ring with a "?" in the middle.
+    const { container } = render(
+      <GameWorld
+        worldId="forest"
+        phase="waiting"
+        focusProgress={0}
+        returningProgress={0}
+        me={me}
+        partner={null}
+      />,
+    );
+    expect(container.textContent).toMatch(/WAITING/);
+    expect(container.innerHTML).not.toMatch(/rounded-full/);
+    const frame = Array.from(container.querySelectorAll("div")).find(
+      (el) => el.textContent === "?" && el.children.length === 0,
+    );
+    expect(frame).toBeTruthy();
+    expect(frame!.style.width).toBe(`${CHAR_W * ART_PX}px`);
+    expect(frame!.style.height).toBe(`${CHAR_H * ART_PX}px`);
+  });
+});

--- a/client/src/components/GameWorld.tsx
+++ b/client/src/components/GameWorld.tsx
@@ -24,6 +24,7 @@ import { WorldDecor, CUP, CUP_PALETTE } from "./WorldDecorations";
 import ContactShadow from "./ContactShadow";
 import type { PixelMap, PixelPalette } from "./PixelSprite";
 import { ART_PX, GROUND } from "@/lib/scene";
+import { CHAR_W, CHAR_H } from "@/lib/characterMaps";
 
 export type GamePhase =
   | "waiting"
@@ -388,10 +389,13 @@ export default function GameWorld({
           className="absolute right-4 flex flex-col items-center opacity-40"
           style={{ bottom: GROUND }}
         >
-          <div className="w-12 h-12 rounded-full border-2 border-dashed border-white/50 flex items-center justify-center text-white text-lg">
+          <div
+            className="border-2 border-white/50 flex items-center justify-center font-display text-white text-xl leading-none"
+            style={{ width: CHAR_W * ART_PX, height: CHAR_H * ART_PX }}
+          >
             ?
           </div>
-          <div className="text-[10px] text-center mt-1 font-bold text-white font-mono">
+          <div className="text-[10px] text-center mt-1 font-bold text-white font-display">
             WAITING
           </div>
         </div>

--- a/client/src/components/Icons.tsx
+++ b/client/src/components/Icons.tsx
@@ -11,8 +11,8 @@ function base(className?: string) {
     fill: "none",
     stroke: "currentColor",
     strokeWidth: 2,
-    strokeLinecap: "round" as const,
-    strokeLinejoin: "round" as const,
+    strokeLinecap: "square" as const,
+    strokeLinejoin: "miter" as const,
     className: className ?? "w-4 h-4",
   };
 }
@@ -115,7 +115,7 @@ export function CloseIcon({ className }: IconProps) {
 export function LockIcon({ className }: IconProps) {
   return (
     <svg {...base(className)}>
-      <rect x="5" y="11" width="14" height="10" rx="2" />
+      <rect x="5" y="11" width="14" height="10" />
       <path d="M8 11V8a4 4 0 0 1 8 0v3" />
     </svg>
   );

--- a/client/src/components/PetPicker.test.tsx
+++ b/client/src/components/PetPicker.test.tsx
@@ -14,8 +14,8 @@ describe("PetPicker", () => {
         onPremiumClick={vi.fn()}
       />,
     );
-    expect(locked.textContent).not.toMatch(/🐱|🐶|🐉|🐰|🔒/);
-    expect(locked.querySelectorAll("svg").length).toBe(PET_OPTIONS.length);
+    expect(locked.textContent).not.toMatch(/🐱|🐶|🐉|🐰|🔒|✕/);
+    expect(locked.querySelectorAll("svg").length).toBe(PET_OPTIONS.length + 1);
 
     const { container: open } = render(
       <PetPicker
@@ -25,9 +25,9 @@ describe("PetPicker", () => {
         onPremiumClick={vi.fn()}
       />,
     );
-    expect(open.textContent).not.toMatch(/🐱|🐶|🐉|🐰|🔒/);
+    expect(open.textContent).not.toMatch(/🐱|🐶|🐉|🐰|🔒|✕/);
     expect(screen.getByTitle("Cat")).toBeInTheDocument();
-    // Grown pet sprites, one per option, plus nothing else using emoji.
-    expect(open.querySelectorAll("svg").length).toBe(PET_OPTIONS.length);
+    // Grown pet sprites, one per option, plus CloseIcon for "no pet".
+    expect(open.querySelectorAll("svg").length).toBe(PET_OPTIONS.length + 1);
   });
 });

--- a/client/src/components/PetPicker.tsx
+++ b/client/src/components/PetPicker.tsx
@@ -2,7 +2,7 @@
 import type { PetType } from "@/lib/types";
 import { PET_OPTIONS } from "@/lib/types";
 import PetCharacter from "./PetCharacter";
-import { LockIcon } from "./Icons";
+import { CloseIcon, LockIcon } from "./Icons";
 
 export default function PetPicker({
   selected,
@@ -20,20 +20,21 @@ export default function PetPicker({
       <span className="text-faint text-xs font-medium uppercase tracking-wide">Pet:</span>
       <button
         onClick={() => (isPremium ? onSelect(null) : onPremiumClick())}
-        className={`w-7 h-7 rounded-full border text-xs flex items-center justify-center transition-all ${
+        className={`w-7 h-7 border flex items-center justify-center transition-all ${
           selected === null
             ? "border-faint bg-raise text-ink"
             : "border-line bg-surface text-faint hover:border-faint"
         }`}
         title="No pet"
+        aria-label="No pet"
       >
-        {"✕"}
+        <CloseIcon className="w-3.5 h-3.5" />
       </button>
       {PET_OPTIONS.map(({ type, label }) => (
         <button
           key={type}
           onClick={() => (isPremium ? onSelect(type) : onPremiumClick())}
-          className={`w-7 h-7 rounded-full border flex items-end justify-center overflow-hidden transition-all ${
+          className={`w-7 h-7 border flex items-end justify-center overflow-hidden transition-all ${
             selected === type
               ? "border-accent bg-accent/15"
               : "border-line bg-surface hover:border-faint"

--- a/client/src/components/PremiumModal.tsx
+++ b/client/src/components/PremiumModal.tsx
@@ -5,6 +5,7 @@ import { getSupabase } from "@/lib/supabase";
 import { PREMIUM_IS_FREE } from "@/lib/billing";
 import Button from "./Button";
 import PetCharacter from "./PetCharacter";
+import { CloseIcon } from "./Icons";
 
 interface Props {
   open: boolean;
@@ -105,9 +106,9 @@ export default function PremiumModal({
               <button
                 onClick={onClose}
                 aria-label="Close"
-                className="absolute top-2 right-2 sm:top-4 sm:right-4 w-10 h-10 sm:w-auto sm:h-auto flex items-center justify-center text-faint hover:text-ink transition-colors text-xl"
+                className="absolute top-2 right-2 sm:top-4 sm:right-4 w-10 h-10 sm:w-auto sm:h-auto flex items-center justify-center text-faint hover:text-ink transition-colors"
               >
-                ✕
+                <CloseIcon className="w-5 h-5" />
               </button>
 
               <div className="text-center mb-6">

--- a/client/src/components/SessionHUD.tsx
+++ b/client/src/components/SessionHUD.tsx
@@ -133,7 +133,7 @@ export default function SessionHUD({
     // controls ("end session" / "leave session") can scroll clear of the home
     // indicator instead of sitting under it.
     <div className="flex-1 flex items-start justify-center px-6 pt-4 pb-[calc(1rem+env(safe-area-inset-bottom))] overflow-y-auto">
-      <div className="hud-card bg-surface/85 backdrop-blur border border-line rounded-2xl px-6 sm:px-8 py-5 flex flex-col items-center gap-3 shadow-xl mb-4">
+      <div className="hud-card bg-surface border-2 border-line border-b-4 px-6 sm:px-8 py-5 flex flex-col items-center gap-3 mb-4">
         <div className="font-display text-lg tracking-wide text-ink">
           {phaseLabel[phase](playerCount)}
         </div>
@@ -144,7 +144,7 @@ export default function SessionHUD({
         )}
 
         {showTimer && (
-          <div className="hud-timer text-5xl sm:text-6xl font-mono font-bold tabular-nums flex flex-col items-center">
+          <div className="hud-timer text-5xl sm:text-6xl font-display font-bold tabular-nums tracking-wide flex flex-col items-center">
             {phase === "focus" && serverMode === "flow" && (
               <span className="text-xs text-calm mb-1 tracking-widest font-bold uppercase">
                 Flow elapsed
@@ -160,10 +160,10 @@ export default function SessionHUD({
 
         {!sessionStarted && phase === "waiting" && (
           <div className="w-full max-w-xs space-y-4 mt-1">
-            <div className="flex bg-raise rounded-lg p-1 border border-line">
+            <div className="flex bg-raise p-1 border-2 border-line">
               <button
                 onClick={() => onTimerModeChange("pomodoro")}
-                className={`flex-1 py-2 sm:py-1 text-xs font-bold rounded-md transition-colors ${
+                className={`flex-1 py-2 sm:py-1 text-xs font-bold transition-colors ${
                   timerMode === "pomodoro"
                     ? "bg-accent text-white"
                     : "text-muted hover:text-ink"
@@ -173,7 +173,7 @@ export default function SessionHUD({
               </button>
               <button
                 onClick={() => onTimerModeChange("flow")}
-                className={`flex-1 py-2 sm:py-1 text-xs font-bold rounded-md transition-colors ${
+                className={`flex-1 py-2 sm:py-1 text-xs font-bold transition-colors ${
                   timerMode === "flow"
                     ? "bg-calm text-white"
                     : "text-muted hover:text-ink"
@@ -224,7 +224,7 @@ export default function SessionHUD({
         {/* Player indicators */}
         <div className="flex items-center gap-2">
           <div
-            className={`w-2 h-2 rounded-full ${playerCount >= 1 ? "bg-go" : "bg-faint"}`}
+            className={`w-2 h-2 ${playerCount >= 1 ? "bg-go" : "bg-faint"}`}
           />
           <span className="text-muted text-xs font-medium uppercase tracking-wide">
             You
@@ -232,7 +232,7 @@ export default function SessionHUD({
           {playerCount >= 2 && (
             <>
               <div className="w-8 h-px bg-line" />
-              <div className="w-2 h-2 rounded-full bg-go" />
+              <div className="w-2 h-2 bg-go" />
               <span className="text-muted text-xs font-medium uppercase tracking-wide">
                 Partner
               </span>
@@ -241,7 +241,7 @@ export default function SessionHUD({
           {playerCount < 2 && phase === "waiting" && (
             <>
               <div className="w-8 h-px bg-line" />
-              <div className="w-2 h-2 rounded-full bg-faint" />
+              <div className="w-2 h-2 bg-faint" />
               <span className="text-faint text-xs font-medium uppercase tracking-wide">
                 Waiting...
               </span>

--- a/client/src/components/SessionTopBar.tsx
+++ b/client/src/components/SessionTopBar.tsx
@@ -19,7 +19,7 @@ function SessionStatusDot({ phase }: { phase: GamePhase }) {
         : "bg-gold";
   return (
     <div
-      className={`w-2 h-2 rounded-full ${color} ${phase !== "waiting" ? "animate-pulse" : ""}`}
+      className={`w-2 h-2 ${color} ${phase !== "waiting" ? "animate-pulse" : ""}`}
     />
   );
 }

--- a/client/src/components/StatsPanel.tsx
+++ b/client/src/components/StatsPanel.tsx
@@ -5,6 +5,7 @@ import { useStats } from "@/lib/useStats";
 import StatsErrorState from "./StatsErrorState";
 import type { DuoStats, SessionWithPartner } from "@/lib/types";
 import WorldThumb from "./WorldThumb";
+import { CloseIcon } from "./Icons";
 
 interface Props {
   open: boolean;
@@ -150,9 +151,10 @@ export default function StatsPanel({
                 </h2>
                 <button
                   onClick={onClose}
+                  aria-label="Close"
                   className="text-faint hover:text-ink transition-colors"
                 >
-                  ✕
+                  <CloseIcon />
                 </button>
               </div>
 

--- a/client/src/components/StatsScreen.tsx
+++ b/client/src/components/StatsScreen.tsx
@@ -5,6 +5,7 @@ import { useStats } from "@/lib/useStats";
 import StatsErrorState from "./StatsErrorState";
 import type { DailyFocus } from "@/lib/types";
 import WorldThumb from "./WorldThumb";
+import { CloseIcon } from "./Icons";
 
 interface Props {
   open: boolean;
@@ -143,9 +144,10 @@ export default function StatsScreen({ open, onClose, userId }: Props) {
             </h1>
             <button
               onClick={onClose}
-              className="text-faint hover:text-ink transition-colors text-lg"
+              aria-label="Close"
+              className="text-faint hover:text-ink transition-colors"
             >
-              ✕
+              <CloseIcon className="w-5 h-5" />
             </button>
           </div>
 

--- a/client/src/components/StickyNote.tsx
+++ b/client/src/components/StickyNote.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useStickyNotes } from "@/hooks/useStickyNotes";
 import type { Task } from "@/lib/types";
+import { CloseIcon } from "./Icons";
 
 interface Props {
   open: boolean;
@@ -46,9 +47,9 @@ function TaskRow({
   onDelete,
 }: {
   task: Task;
-  /** Deletion stays owner-only in the database (migration 017), so the ✕ is
-   *  only drawn for notes where it can actually succeed. Ticking is open to
-   *  both partners, so the checkbox is always live. */
+  /** Deletion stays owner-only in the database (migration 017), so the close
+   *  control is only drawn for notes where it can actually succeed. Ticking is
+   *  open to both partners, so the checkbox is always live. */
   isOwn: boolean;
   nameFor: (userId: string) => string;
   onToggle: (id: string, done: boolean) => void;
@@ -99,7 +100,7 @@ function TaskRow({
           aria-label="Delete note"
           className="text-amber-400 hover:text-red-600 transition-colors opacity-0 group-hover:opacity-100 text-xs mt-0.5 flex-shrink-0"
         >
-          ✕
+          <CloseIcon className="w-3.5 h-3.5" />
         </button>
       )}
     </motion.div>
@@ -260,7 +261,7 @@ export default function StickyNote({
                           disabled={completedCount === 0}
                           className="w-full text-left text-xs font-mono text-gray-600 hover:text-red-500 py-1 disabled:opacity-30 transition-colors"
                         >
-                          ✕ Clear completed ({completedCount})
+                          Clear completed ({completedCount})
                         </button>
                       </div>
                     )}
@@ -268,10 +269,11 @@ export default function StickyNote({
                   {/* Close */}
                   <button
                     onClick={onClose}
-                    className="w-7 h-7 flex items-center justify-center rounded-lg text-base transition-opacity hover:opacity-60"
+                    aria-label="Close"
+                    className="w-7 h-7 flex items-center justify-center rounded-none text-base transition-opacity hover:opacity-60"
                     style={{ color: color.accent }}
                   >
-                    ✕
+                    <CloseIcon className="w-4 h-4" />
                   </button>
                 </div>
               </div>
@@ -356,7 +358,7 @@ export default function StickyNote({
                     aria-label="Dismiss error"
                     className="font-bold hover:opacity-70"
                   >
-                    ✕
+                    <CloseIcon className="w-3.5 h-3.5" />
                   </button>
                 </div>
               )}

--- a/client/src/components/TaskSection.tsx
+++ b/client/src/components/TaskSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { motion, AnimatePresence } from "framer-motion";
 import type { Task } from "@/lib/types";
+import { CloseIcon } from "./Icons";
 
 interface Props {
   tasks: Task[];
@@ -43,7 +44,7 @@ export default function TaskSection({
               aria-label="Dismiss error"
               className="font-bold hover:opacity-70"
             >
-              ✕
+              <CloseIcon className="w-3.5 h-3.5" />
             </button>
           )}
         </div>
@@ -89,9 +90,10 @@ export default function TaskSection({
               </p>
               <button
                 onClick={() => deleteTask(task.id)}
+                aria-label="Delete task"
                 className="text-faint hover:text-danger text-xs opacity-0 group-hover:opacity-100 transition-all"
               >
-                {"✕"}
+                <CloseIcon className="w-3.5 h-3.5" />
               </button>
             </motion.div>
           ))}
@@ -115,9 +117,10 @@ export default function TaskSection({
               </p>
               <button
                 onClick={() => deleteTask(task.id)}
+                aria-label="Delete task"
                 className="text-faint hover:text-danger text-xs opacity-0 group-hover:opacity-100 transition-all"
               >
-                {"✕"}
+                <CloseIcon className="w-3.5 h-3.5" />
               </button>
             </motion.div>
           ))}

--- a/client/src/components/pixelChrome.test.ts
+++ b/client/src/components/pixelChrome.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+// Soft-SaaS chrome around a pixel-art game: Geist Mono on the timer, a
+// frosted HUD card, Feather round-caps, pill buttons. These read the source
+// because a render() of SessionHUD needs a socket session and still wouldn't
+// tell you whether the class list was rounded-2xl.
+
+const here = (...parts: string[]) =>
+  readFileSync(path.join(__dirname, ...parts), "utf8");
+
+const HUD = here("SessionHUD.tsx");
+const ICONS = here("Icons.tsx");
+const BUTTON = here("Button.tsx");
+const WORLD = here("GameWorld.tsx");
+
+describe("pixel chrome", () => {
+  it("sets the timer in Pixelify, not Geist Mono", () => {
+    // A/B — hud-timer used to be font-mono.
+    const timer = HUD.match(/hud-timer[^\n]+/)?.[0] ?? "";
+    expect(timer).toMatch(/font-display/);
+    expect(timer).not.toMatch(/font-mono/);
+  });
+
+  it("does not glass the HUD card", () => {
+    // A/B — hud-card used to be rounded-2xl backdrop-blur shadow-xl.
+    const card = HUD.match(/className="hud-card[^"]+"/)?.[0] ?? "";
+    expect(card).toContain("hud-card");
+    expect(card).not.toMatch(/backdrop-blur/);
+    expect(card).not.toMatch(/rounded-2xl/);
+    expect(card).not.toMatch(/shadow-xl/);
+  });
+
+  it("draws square-cap icons, not Feather rounds", () => {
+    // A/B — strokeLinecap/Linejoin were "round".
+    expect(ICONS).toMatch(/strokeLinecap: "square"/);
+    expect(ICONS).toMatch(/strokeLinejoin: "miter"/);
+    expect(ICONS).not.toMatch(/strokeLinecap: "round"/);
+  });
+
+  it("keeps buttons square to match the border-b-4 press", () => {
+    expect(BUTTON).not.toMatch(/rounded-xl/);
+    expect(BUTTON).not.toMatch(/rounded-2xl/);
+  });
+
+  it("does not draw the waiting slot as a dashed circle", () => {
+    expect(WORLD).not.toMatch(/rounded-full border-2 border-dashed/);
+  });
+});


### PR DESCRIPTION
## Summary
- Timer, HUD card, buttons, icons, and the empty partner slot now match the pixel typeface instead of sitting in Soft-SaaS chrome (Geist Mono, frosted `rounded-2xl`, Feather round-caps, dashed circle with "?").
- Close controls use `CloseIcon` instead of a text ✕ (leftover from item 8).
- Root `README.md` describes the current product (rotating worlds, email-unlock premium, growing pets) and that git starts 26 February 2026 — a little under six months as of August 2026. The create-next-app stub in `client/README.md` is a pointer to it.

Item 9. Six commits. No Supabase.

## Test plan
- [x] Client tests (253) and lint — green locally
- [x] A/B: `pixelChrome.test.ts` / waiting-slot test fail against `main` (hud-timer was `font-mono`, card was `backdrop-blur rounded-2xl shadow-xl`, icons were `strokeLinecap: "round"`, waiting slot was `rounded-full border-dashed`)
- [ ] Look at a session HUD in the browser — timer in Pixelify, square card, square waiting slot, close icons
- [ ] Landscape phone (`max-height: 520px`) still doesn't bury the scene under the HUD
- [ ] Skim the root README on GitHub after merge

Nothing here has been browser-tested by the agent.


Made with [Cursor](https://cursor.com)